### PR TITLE
Stop using warnings.warn when fedmsgs fail

### DIFF
--- a/anitya/__init__.py
+++ b/anitya/__init__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import logging
-import warnings
 
 import anitya.lib.plugins
 import anitya.lib.exceptions
@@ -35,7 +34,7 @@ def fedmsg_publish(*args, **kwargs):  # pragma: no cover
         import fedmsg
         fedmsg.publish(*args, **kwargs)
     except Exception as err:
-        warnings.warn(str(err))
+        _log.error(str(err))
 
 
 # Ordering is handled differently based on Python version


### PR DESCRIPTION
This switches the exception block that handles fedmsg failures to use
the logger rather than the warnings module. It logs at the error level
as it's a general, unexpected exception.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>