### PR TITLE
Add a fedmsg consumer that handles libraries.io messages

### DIFF
--- a/anitya/config.py
+++ b/anitya/config.py
@@ -89,6 +89,7 @@ DEFAULTS = dict(
     SOCIAL_AUTH_LOGIN_URL='/login/',
     SOCIAL_AUTH_LOGIN_REDIRECT_URL='/',
     SOCIAL_AUTH_LOGIN_ERROR_URL='/login-error/',
+    CREATE_LIBRARIESIO_PROJECTS=False,
 )
 
 # Start with a basic logging configuration, which will be replaced by any user-

--- a/anitya/lib/ecosystems/__init__.py
+++ b/anitya/lib/ecosystems/__init__.py
@@ -21,8 +21,11 @@ class BaseEcosystem(object):
         default_version_scheme (str): The default version scheme to use for
             projects in this ecosystem if a they don't explicitly define one to
             use.
+        aliases (list): A list of alternate names for this ecosystem. These
+            should be lowercase.
     '''
 
     name = None
     default_backend = None
     default_version_scheme = None
+    aliases = []

--- a/anitya/lib/ecosystems/crates.py
+++ b/anitya/lib/ecosystems/crates.py
@@ -28,3 +28,4 @@ class CratesEcosystem(BaseEcosystem):
 
     name = 'crates.io'
     default_backend = 'crates.io'
+    aliases = ['Cargo']

--- a/anitya/librariesio_consumer.py
+++ b/anitya/librariesio_consumer.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of the Anitya project.
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+"""
+A `fedmsg consumer`_ that is designed to consume fedmsgs generated using
+`sse2fedmsg`_ with the `libraries.io firehose`_ SSE feed.
+
+Using this, it is possible for Anitya to discover new upstream releases using
+`libraries.io`_. At the moment, the SSE feed is served over HTTP, so we confirm
+the release is really available upstream before announce the new version.
+
+When ``message`` is referenced in this module, it means the fedmsg that has been
+deserialized to a Python dictionary with the following keys::
+  {
+    "body": {
+      "username": "jcline",
+      "i": 1,
+      "timestamp": 1486743185,
+      "msg_id": "2017-dcfee1a8-16d4-4684-afea-50aa24754677",
+      "topic": "org.fedoraproject.dev.sse2fedmsg.libraryio",
+      "msg": {
+        "retry": 500,
+        "data": {
+          "name": "react-sh",
+          "project": {
+            "status": null,
+            "repository_url": "https://github.com/heineiuo/react-sh",
+            "latest_release_published_at": "2017-02-10 16:11:54 UTC",
+            "description": "A super easy shell for react app.",
+            "language": null,
+            "platform": "NPM",
+            "rank": 7,
+            "keywords": [],
+            "package_manager_url": "https://www.npmjs.com/package/react-sh",
+            "stars": 0,
+            "latest_release_number": "0.4.0",
+            "normalized_licenses": [
+              "MIT"
+            ],
+            "forks": 0,
+            "homepage": "https://github.com/heineiuo/react-sh",
+            "name": "react-sh"
+          },
+          "platform": "NPM",
+          "published_at": "2017-02-10 16:11:54 UTC",
+          "version": "0.4.0",
+          "package_manager_url": "https://www.npmjs.com/package/react-sh"
+        },
+        "event": "event",
+        "id": null
+      }
+    }
+  }
+
+Note that the contents of ``msg`` is the actual server-sent event converted to
+JSON.
+
+
+.. libraries.io: https://libraries.io/
+.. libraries.io firehose: https://github.com/librariesio/firehose
+.. sse2fedmsg: https://pypi.python.org/pypi/sse2fedmsg
+.. fedmsg consumer: http://www.fedmsg.com/en/latest/consuming/#the-hub-consumer-approach
+"""
+from __future__ import absolute_import, unicode_literals
+
+import logging
+
+from fedmsg.consumers import FedmsgConsumer
+
+from anitya import config
+from anitya.lib import exceptions, plugins, model, utilities
+
+
+_log = logging.getLogger(__name__)
+
+
+class LibrariesioConsumer(FedmsgConsumer):
+    """
+    A fedmsg consumer.
+
+    Attributes:
+        topic (list): A list of strings that indicates the message topics this
+            consumer gets. This consumer accepts a single topic,
+            ``org.fedoraproject.prod.sse2fedmsg.libraryio``
+        config_key (str): A string that must be set to `True` in the fedmsg
+            configuration to enable this consumer.
+    """
+    topic = [
+        'org.fedoraproject.prod.sse2fedmsg.librariesio',
+    ]
+
+    config_key = 'anitya.libraryio.enabled'
+
+    def __init__(self, hub):
+        # If we're in development mode, add the dev versions of the topics so
+        # local playback with fedmsg-dg-replay works as expected.
+        if hub.config['environment'] == 'dev':
+            prefix, env = hub.config['topic_prefix'], hub.config['environment']
+            self.topic = self.topic + [
+                '.'.join([prefix, env] + topic.split('.')[3:])
+                for topic in self.topic
+            ]
+        _log.info('Subscribing to the following fedmsg topics: %r', self.topic)
+
+        model.initialize(config.config)
+
+        super(LibrariesioConsumer, self).__init__(hub)
+
+    def consume(self, message):
+        """
+        This method is called when a message with a topic this consumer
+        subscribes to arrives.
+
+        If the project is unknown to Anitya, a new :class:`Project` is created,
+        but only if the 'create_librariesio_projects' configuration key is set.
+        If it's an existing project, this will call Anitya's ``check_project_release``
+        API to update the latest version information. This is because we are
+        subscribed to libraries.io over HTTP and therefore have no
+        authentication.
+
+        Checking the version ourselves serves two purposes. Firstly, we connect
+        to libraries.io over HTTP so we don't have any authentication.
+        Secondly, we might map the libraries.io project to the wrong Anitya
+        project, so this is a good opportunity to catch those problems.
+
+        Args:
+            message (dict): The fedmsg to process.
+        """
+        librariesio_msg = message['body']['msg']['data']
+        name = librariesio_msg['name']
+        platform = librariesio_msg['platform'].lower()
+        version = librariesio_msg['version']
+        homepage = librariesio_msg['package_manager_url']
+        for ecosystem in plugins.ECOSYSTEM_PLUGINS.get_plugins():
+            if platform == ecosystem.name or platform in ecosystem.aliases:
+                break
+        else:
+            _log.debug('Dropped librariesio update to %s for %s (%s) since it is on the '
+                       'unsupported %s platform', version, name, homepage, platform)
+            return
+
+        session = model.Session()
+        project = model.Project.by_name_and_ecosystem(session, name, ecosystem.name)
+        if project is None and config.config['CREATE_LIBRARIESIO_PROJECTS'] is True:
+            try:
+                project = utilities.create_project(
+                    session,
+                    name,
+                    homepage,
+                    'anitya',
+                    backend=ecosystem.default_backend,
+                    check_release=True,
+                )
+                _log.info('Discovered new project at version %s via libraries.io: %r',
+                          version, project)
+            except exceptions.AnityaException as e:
+                _log.error('A new project was discovered via libraries.io, %r, '
+                           'but we failed with "%s"', project, str(e))
+        elif project is not None:
+            _log.info('libraries.io has found an update (version %s) for project %r',
+                      version, project)
+            # This will fetch the version, emit fedmsgs, add log entries, and
+            # commit the transaction.
+            try:
+                utilities.check_project_release(project, session)
+            except exceptions.AnityaPluginException as e:
+                _log.warning('libraries.io found an update for %r, but we failed with %s',
+                             project, str(e))
+
+        # Refresh the project object that was committed by either
+        # ``create_project`` or ``check_project_release`` above
+        project = model.Project.by_name_and_ecosystem(session, name, ecosystem.name)
+        if project and project.latest_version != version:
+            _log.info('libraries.io found %r had a latest version of %s, but Anitya found %s',
+                      project, version, project.latest_version)
+
+        model.Session.remove()

--- a/anitya/tests/request-data/anitya.tests.test_librariesio_consumer.LibrariesioConsumerTests.test_existing_project
+++ b/anitya/tests/request-data/anitya.tests.test_librariesio_consumer.LibrariesioConsumerTests.test_existing_project
@@ -1,0 +1,69 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      From: [admin@fedoraproject.org]
+      User-Agent: [Anitya 0.11.0 at upstream-monitoring.org]
+    method: GET
+    uri: https://pypi.python.org/pypi/ImageMetaTag/json
+  response:
+    body: {string: "{\n    \"info\": {\n        \"maintainer\": \"\", \n        \"\
+        docs_url\": null, \n        \"requires_python\": null, \n        \"maintainer_email\"\
+        : \"\", \n        \"cheesecake_code_kwalitee_id\": null, \n        \"keywords\"\
+        : \"\", \n        \"package_url\": \"http://pypi.python.org/pypi/ImageMetaTag\"\
+        , \n        \"author\": \"Malcolm Brooks\", \n        \"author_email\": \"\
+        Malcolm.E.Brooks@metoffice.gov.uk\", \n        \"download_url\": \"https://github.com/SciTools-incubator/image-meta-tag\"\
+        , \n        \"platform\": \"unix based\", \n        \"version\": \"0.1\",\
+        \ \n        \"cheesecake_documentation_id\": null, \n        \"_pypi_hidden\"\
+        : false, \n        \"description\": \"ImageMetaTag is a python package built\
+        \ around a wrapper for savefig in matplotlib, which adds metadata tags to\
+        \ supported image file formats.\\r\\n\\r\\nOnce the images have been tagged,\
+        \ it can also be used to manage an SQL database of images and their metadata.\
+        \ The image metadata can be used to produce an ImageMetaTag.ImageDict object:\
+        \ a structured/heirachical dictionary of dictionaries which can be used to\
+        \ easily create web pages to present large numbers of images.\\r\\n\\r\\nAs\
+        \ the image metadata tagging process involves reading the image using the\
+        \ Image library, a few common image post-processing options are included such\
+        \ as cropping, logo addition and colour palette manipulation to reduce filesizes.\\\
+        r\\n\\r\\nImageMetaTag is released under a BSD 3-Clause License.\\r\\n\\r\\\
+        nSupported image file formats: png\", \n        \"release_url\": \"http://pypi.python.org/pypi/ImageMetaTag/0.1\"\
+        , \n        \"downloads\": {\n            \"last_month\": 0, \n          \
+        \  \"last_week\": 0, \n            \"last_day\": 0\n        }, \n        \"\
+        _pypi_ordering\": 0, \n        \"classifiers\": [\n            \"Development\
+        \ Status :: 3 - Alpha\", \n            \"License :: OSI Approved :: BSD License\"\
+        , \n            \"Natural Language :: English\"\n        ], \n        \"bugtrack_url\"\
+        : \"https://github.com/SciTools-incubator/image-meta-tag/issues\", \n    \
+        \    \"name\": \"ImageMetaTag\", \n        \"license\": \"BSD3\", \n     \
+        \   \"summary\": \"Tags images created by matplotlib with metadata, builds\
+        \ databases and webpages.\", \n        \"home_page\": \"https://github.com/SciTools-incubator/image-meta-tag\"\
+        , \n        \"cheesecake_installability_id\": null\n    }, \n    \"releases\"\
+        : {\n        \"0.1\": []\n    }, \n    \"urls\": []\n}"}
+    headers:
+      Accept-Ranges: [bytes]
+      Access-Control-Allow-Origin: ['*']
+      Age: ['46860']
+      Cache-Control: ['max-age=600, public']
+      Connection: [keep-alive]
+      Content-Disposition: [inline]
+      Content-Length: ['2278']
+      Content-Type: [application/json; charset="UTF-8"]
+      Date: ['Sun, 15 Oct 2017 22:24:13 GMT']
+      Fastly-Debug-Digest: [7d5bd0ade32a30a4b50d66ebca725f4f4821a9581009319fbe78b465f013285a]
+      Server: [nginx/1.10.3]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Via: [1.1 varnish, 1.1 varnish]
+      X-Cache: ['HIT, MISS']
+      X-Cache-Hits: ['1, 0']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [deny]
+      X-PYPI-LAST-SERIAL: ['3251214']
+      X-Permitted-Cross-Domain-Policies: [none]
+      X-Served-By: ['cache-iad2141-IAD, cache-atl6220-ATL']
+      X-Timer: ['S1508106253.292525,VS0,VE13']
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/anitya/tests/request-data/anitya.tests.test_librariesio_consumer.LibrariesioConsumerTests.test_mismatched_versions
+++ b/anitya/tests/request-data/anitya.tests.test_librariesio_consumer.LibrariesioConsumerTests.test_mismatched_versions
@@ -1,0 +1,1 @@
+anitya.tests.test_librariesio_consumer.LibrariesioConsumerTests.test_existing_project

--- a/anitya/tests/request-data/anitya.tests.test_librariesio_consumer.LibrariesioConsumerTests.test_new_project_configured_on
+++ b/anitya/tests/request-data/anitya.tests.test_librariesio_consumer.LibrariesioConsumerTests.test_new_project_configured_on
@@ -1,0 +1,1 @@
+anitya.tests.test_librariesio_consumer.LibrariesioConsumerTests.test_existing_project

--- a/anitya/tests/test_config.py
+++ b/anitya/tests/test_config.py
@@ -50,6 +50,8 @@ social_auth_login_url = "/login/"
 social_auth_login_redirect_url = "/"
 social_auth_login_error_url = "/login-error/"
 
+create_librariesio_projects = true
+
 [anitya_log_config]
     version = 1
     disable_existing_loggers = true
@@ -163,6 +165,7 @@ class LoadTests(unittest.TestCase):
             'SOCIAL_AUTH_LOGIN_URL': '/login/',
             'SOCIAL_AUTH_LOGIN_REDIRECT_URL': '/',
             'SOCIAL_AUTH_LOGIN_ERROR_URL': '/login-error/',
+            'CREATE_LIBRARIESIO_PROJECTS': True,
         }
         config = anitya_config.load()
         self.assertEqual(sorted(expected_config.keys()), sorted(config.keys()))

--- a/anitya/tests/test_librariesio_consumer.py
+++ b/anitya/tests/test_librariesio_consumer.py
@@ -1,0 +1,239 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of the Anitya project.
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+"""
+Tests for the libraries.io fedmsg consumer.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+import unittest
+
+import mock
+
+from anitya import config
+from anitya.lib.exceptions import AnityaPluginException, AnityaException
+from anitya.librariesio_consumer import LibrariesioConsumer
+from anitya.lib.model import Project
+from anitya.tests.base import DatabaseTestCase
+
+
+@mock.patch('anitya.librariesio_consumer.model.initialize', mock.Mock())
+class LibrariesioConsumerTests(DatabaseTestCase):
+
+    def setUp(self):
+        super(LibrariesioConsumerTests, self).setUp()
+
+        self.supported_fedmsg = {
+            'body': {
+                'username': 'vagrant',
+                'i': 236,
+                'timestamp': 1488561045,
+                'msg_id': '2017-630afdfd-4780-48ce-ba99-3a306d8de2d2',
+                'topic': 'org.fedoraproject.dev.sse2fedmsg.librariesio',
+                'msg': {
+                    'retry': 500,
+                    'data': {
+                        'name': 'ImageMetaTag',
+                        'project': {
+                            'status': None,
+                            'repository_url': 'https://github.com/SciTools-incubator/',
+                            'latest_release_published_at': '2017-03-03 16:44:46 UTC',
+                            'description': 'Tags images created by matplotlib with ...',
+                            'language': 'Python',
+                            'platform': 'Pypi',
+                            'package_manager_url': 'https://pypi.python.org/pypi/ImageMetaTag/',
+                            'latest_release_number': '0.1',
+                            'rank': 4,
+                            'stars': 1,
+                            'keywords': [],
+                            'normalized_licenses': ['BSD-3-Clause'],
+                            'forks': 1,
+                            'homepage': 'https://github.com/SciTools-incubator/image-meta-tag',
+                            'name': 'ImageMetaTag'
+                        },
+                        'platform': 'Pypi',
+                        'published_at': '2017-03-03 16:44:46 UTC',
+                        'version': '0.1',
+                        'package_manager_url': 'https://pypi.python.org/pypi/ImageMetaTag/0.4.4'
+                    },
+                    'event': 'event',
+                    'id': None
+                }
+            }
+        }
+        self.mock_hub = mock.Mock(config={'environment': 'dev', 'topic_prefix': 'anitya'})
+
+    def test_dev_environment_topics(self):
+        """Assert when the environment is set to dev, both dev and prod topic is used."""
+        expected_topics = [
+            'org.fedoraproject.prod.sse2fedmsg.librariesio',
+            'anitya.dev.sse2fedmsg.librariesio',
+        ]
+        consumer = LibrariesioConsumer(self.mock_hub)
+
+        self.assertEqual(expected_topics, consumer.topic)
+
+    def test_prod_environment_topics(self):
+        """Assert when the environment is set to prod, only the prod topic is used."""
+        mock_hub = mock.Mock(config={'environment': 'prod', 'topic_prefix': 'anitya'})
+        consumer = LibrariesioConsumer(mock_hub)
+
+        self.assertEqual(['org.fedoraproject.prod.sse2fedmsg.librariesio'], consumer.topic)
+
+    @mock.patch('anitya.librariesio_consumer._log')
+    def test_no_ecosystem(self, mock_log):
+        """Assert that messages about platforms we don't support are handled gracefully"""
+        consumer = LibrariesioConsumer(self.mock_hub)
+        unsupported_fedmsg = {
+            'body': {
+                'username': 'vagrant',
+                'i': 211,
+                'timestamp': 1488560762,
+                'msg_id': '2017-a7dbddc2-8ce5-4291-9986-c8584ec97fdd',
+                'topic': 'org.fedoraproject.dev.sse2fedmsg.librariesio',
+                'msg': {
+                    'retry': 500,
+                    'data': {
+                        'name': 'GreatProject',
+                        'project': {
+                            'status': None,
+                            'repository_url': None,
+                            'latest_release_published_at': '2017-03-03 00:00:00 UTC',
+                            'description': 'A great description of the project',
+                            'language': None,
+                            'platform': 'GREAT',
+                            'package_manager_url': 'https://example.com/GreatProject.git',
+                            'latest_release_number': '1.5.0',
+                            'rank': 0,
+                            'stars': 0,
+                            'keywords': [],
+                            'normalized_licenses': ['GPL-3.0+'],
+                            'forks': 0,
+                            'homepage': 'http://example.com/GreatProject',
+                            'name': 'GreatProject',
+                        },
+                        'platform': 'GREAT',
+                        'published_at': '2017-03-03 00:00:00 UTC',
+                        'version': '1.5.0',
+                        'package_manager_url': 'https://example.com/GreatProject.git',
+                    },
+                    'event': 'event',
+                    'id': None,
+                }
+            }
+        }
+        self.assertEqual(0, self.session.query(Project).count())
+        consumer.consume(unsupported_fedmsg)
+        self.assertEqual(0, self.session.query(Project).count())
+        self.assertTrue('Dropped librariesio update' in mock_log.debug.call_args_list[0][0][0])
+
+    def test_new_project_configured_off(self):
+        """libraries.io events shouldn't create projects if the configuration is off."""
+        consumer = LibrariesioConsumer(self.mock_hub)
+        with mock.patch.dict(config.config, {'CREATE_LIBRARIESIO_PROJECTS': False}):
+            consumer.consume(self.supported_fedmsg)
+        self.assertEqual(0, self.session.query(Project).count())
+
+    def test_new_project_configured_on(self):
+        """Assert that a libraries.io event about an unknown project creates that project"""
+        consumer = LibrariesioConsumer(self.mock_hub)
+        with mock.patch.dict(config.config, {'CREATE_LIBRARIESIO_PROJECTS': True}):
+            consumer.consume(self.supported_fedmsg)
+        self.assertEqual(1, self.session.query(Project).count())
+        project = self.session.query(Project).first()
+        self.assertEqual('ImageMetaTag', project.name)
+        self.assertEqual('pypi', project.ecosystem_name)
+        self.assertEqual('0.1', project.latest_version)
+
+    @mock.patch('anitya.librariesio_consumer._log')
+    @mock.patch('anitya.librariesio_consumer.utilities.create_project')
+    def test_new_project_failure(self, mock_create, mock_log):
+        """Assert failures to create projects are logged as errors."""
+        mock_create.side_effect = AnityaException("boop")
+        consumer = LibrariesioConsumer(self.mock_hub)
+        with mock.patch.dict(config.config, {'CREATE_LIBRARIESIO_PROJECTS': True}):
+            consumer.consume(self.supported_fedmsg)
+        self.assertEqual(0, self.session.query(Project).count())
+        mock_log.error.assert_called_once_with(
+            'A new project was discovered via libraries.io, %r, but we failed with "%s"',
+            None, 'boop')
+
+    def test_existing_project(self):
+        """Assert that a libraries.io event about an existing project updates that project"""
+        project = Project(
+            name='ImageMetaTag',
+            homepage='https://pypi.python.org/pypi/ImageMetaTag',
+            ecosystem_name='pypi',
+            backend='PyPI',
+        )
+        self.session.add(project)
+        self.session.commit()
+        consumer = LibrariesioConsumer(self.mock_hub)
+
+        self.assertEqual(1, self.session.query(Project).count())
+        consumer.consume(self.supported_fedmsg)
+        self.assertEqual(1, self.session.query(Project).count())
+        project = self.session.query(Project).first()
+        self.assertEqual('ImageMetaTag', project.name)
+        self.assertEqual('pypi', project.ecosystem_name)
+        self.assertEqual('0.1', project.latest_version)
+
+    @mock.patch('anitya.librariesio_consumer.utilities.check_project_release')
+    def test_existing_project_check_failure(self, mock_check):
+        """Assert that when an existing project fails a version check nothing happens"""
+        consumer = LibrariesioConsumer(self.mock_hub)
+        mock_check.side_effect = AnityaPluginException()
+        project = Project(
+            name='ImageMetaTag',
+            homepage='https://pypi.python.org/pypi/ImageMetaTag',
+            ecosystem_name='pypi',
+            backend='PyPI',
+        )
+        self.session.add(project)
+        self.session.commit()
+        self.assertEqual(1, self.session.query(Project).count())
+        consumer.consume(self.supported_fedmsg)
+        self.assertEqual(1, self.session.query(Project).count())
+        project = self.session.query(Project).first()
+        self.assertIs(project.latest_version, None)
+
+    @mock.patch('anitya.librariesio_consumer._log')
+    def test_mismatched_versions(self, mock_log):
+        """Assert when libraries.io and Anitya disagree on version, it's logged"""
+        consumer = LibrariesioConsumer(self.mock_hub)
+        project = Project(
+            name='ImageMetaTag',
+            homepage='https://pypi.python.org/pypi/ImageMetaTag',
+            ecosystem_name='pypi',
+            backend='PyPI',
+        )
+        self.session.add(project)
+        self.session.commit()
+        self.supported_fedmsg['body']['msg']['data']['version'] = '0.2'
+        consumer.consume(self.supported_fedmsg)
+        project = self.session.query(Project).first()
+        self.assertEqual('0.1', project.latest_version)
+        self.assertIn(
+            'libraries.io has found an update (version %s) for project %r',
+            mock_log.info.call_args_list[1][0],
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ansible/roles/anitya-dev/files/fedmsg-hub.service
+++ b/ansible/roles/anitya-dev/files/fedmsg-hub.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=The fedmsg relay service
+After=network.target
+
+[Service]
+Environment="ANITYA_WEB_CONFIG=/home/vagrant/anitya.toml"
+ExecStart=/home/vagrant/.virtualenvs/anitya/bin/fedmsg-hub --config-filename %h/devel/fedmsg.d/fedmsg-config.py
+Type=simple
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/anitya-dev/files/fedmsg-relay.service
+++ b/ansible/roles/anitya-dev/files/fedmsg-relay.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=The fedmsg relay service
+After=network.target
+
+[Service]
+ExecStart=/home/vagrant/.virtualenvs/anitya/bin/fedmsg-relay --config-filename %h/devel/fedmsg.d/fedmsg-config.py
+Type=simple
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/anitya-dev/files/librariesio2fedmsg.service
+++ b/ansible/roles/anitya-dev/files/librariesio2fedmsg.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=librariesio2fedmsg turns SSE messages from libraries.io to fedmsg
+After=network.target
+Documentation=https://github.com/fedora-infra/sse2fedmsg/
+
+[Service]
+ExecStart=/home/vagrant/.virtualenvs/anitya/bin/sse2fedmsg librariesio http://firehose.libraries.io/events
+Type=simple
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/anitya-dev/tasks/librariesio.yml
+++ b/ansible/roles/anitya-dev/tasks/librariesio.yml
@@ -1,0 +1,42 @@
+---
+
+- name: Install sse2fedmsg
+  become_user: "{{ ansible_env.SUDO_USER }}"
+  pip: name={{ item }} virtualenv=/home/{{ ansible_env.SUDO_USER }}/.virtualenvs/anitya/
+  with_items:
+      - sse2fedmsg
+
+- name: Create the ~/.fedmsg.d directory
+  become_user: "{{ ansible_env.SUDO_USER }}"
+  file:
+    path: /home/{{ ansible_env.SUDO_USER }}/.fedmsg.d
+    state: directory
+
+- name: Install the required fedmsg config for librariesio2fedmsg
+  become_user: "{{ ansible_env.SUDO_USER }}"
+  copy:
+    remote_src: True
+    src: /home/{{ ansible_env.SUDO_USER }}/devel/fedmsg.d/fedmsg-config.py
+    dest: /home/{{ ansible_env.SUDO_USER }}/.fedmsg.d/config.py
+
+- name: Install the service files for librariesio2fedmsg
+  become_user: "{{ ansible_env.SUDO_USER }}"
+  copy:
+    src: "{{ item }}"
+    dest: /home/{{ ansible_env.SUDO_USER }}/.config/systemd/user/{{ item }}
+  with_items:
+    - fedmsg-hub.service
+    - fedmsg-relay.service
+    - librariesio2fedmsg.service
+
+- name: Reload the systemd daemon
+  become_user: "{{ ansible_env.SUDO_USER }}"
+  command: systemctl --user daemon-reload
+
+- name: Enable the librariesio services
+  become_user: "{{ ansible_env.SUDO_USER }}"
+  command: systemctl --user enable fedmsg-hub fedmsg-relay librariesio2fedmsg
+
+- name: Start the librariesio services
+  become_user: "{{ ansible_env.SUDO_USER }}"
+  command: systemctl --user start fedmsg-hub fedmsg-relay librariesio2fedmsg

--- a/ansible/roles/anitya-dev/tasks/main.yml
+++ b/ansible/roles/anitya-dev/tasks/main.yml
@@ -10,7 +10,6 @@
 - name: Install anitya system dependencies
   dnf: name={{ item }} state=present
   with_items:
-    - fedmsg
     - gcc
     - libffi-devel
     - openssl-devel
@@ -105,3 +104,4 @@
     creates: /home/{{ ansible_env.SUDO_USER }}/devel/anitya/static/docs/objects.inv
 
 - include: db.yml
+- include: librariesio.yml

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -79,3 +79,14 @@ has some helpful tips, but the anitya service can be started in the virtual mach
 
 Log output is viewable with ``journalctl`` and you can navigate to http://localhost:5000/ to
 view the web user interface.
+
+Tips
+^^^^
+
+Anitya publishes fedmsgs, and these are viewable with ``fedmsg-tail``::
+
+    $ workon anitya
+    $ fedmsg-tail
+
+This will also show you all incoming messages from `libraries.io's <https://libraries.io/>`_
+SSE feed.

--- a/fedmsg.d/fedmsg-config.py
+++ b/fedmsg.d/fedmsg-config.py
@@ -5,25 +5,29 @@ during development of anitya.
 import socket
 hostname = socket.gethostname().split('.')[0]
 
-config = dict(
-    endpoints={
+config = {
+    'endpoints': {
         "relay_outbound": ["tcp://127.0.0.1:4011"],
         "anitya.%s" % hostname: [
             "tcp://127.0.0.1:5011",
             "tcp://127.0.0.1:5012",
             "tcp://127.0.0.1:5013",
         ],
+        "sse2fedmsg.%s" % hostname: [
+            "tcp://127.0.0.1:5010",
+        ],
     },
 
-    relay_inbound="tcp://127.0.0.1:2013",
-    environment="dev",
-    high_water_mark=0,
-    io_threads=1,
-    post_init_sleep=0.2,
-    irc=[],
-    zmq_enabled=True,
-    zmq_strict=False,
+    'relay_inbound': "tcp://127.0.0.1:2013",
+    'environment': "dev",
+    'high_water_mark': 0,
+    'io_threads': 1,
+    'post_init_sleep': 0.2,
+    'irc': [],
+    'zmq_enabled': True,
+    'zmq_strict': False,
 
-    sign_messages=False,
-    validate_signatures=False,
-)
+    'sign_messages': False,
+    'validate_signatures': False,
+    'anitya.libraryio.enabled': True
+}

--- a/files/anitya.toml.sample
+++ b/files/anitya.toml.sample
@@ -45,6 +45,11 @@ oidc_scopes = [
     "https://release-monitoring.org/oidc/downstream",
 ]
 
+# If `true`, Anitya creates new projects from libraries.io messages in addition
+# to updating existing projects. This requires that the libraries.io fedmsg
+# consumer is running; defaults to false.
+create_librariesio_projects = false
+
 # The logging configuration, in dictConfig format.
 [anitya_log_config]
     version = 1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,7 +2,8 @@ alembic
 blinker
 bunch
 python-dateutil
-fedmsg
+dateutils
+fedmsg[commands,consumers]
 flask-openid
 # Need the fixes for https://github.com/puiterwijk/flask-oidc/issues/12
 #                and https://github.com/puiterwijk/flask-oidc/issues/24

--- a/setup.py
+++ b/setup.py
@@ -66,5 +66,9 @@ setup(
     include_package_data=True,
     scripts=['files/anitya_cron.py'],
     install_requires=get_requirements(),
-    test_suite='anitya.tests'
+    test_suite='anitya.tests',
+    entry_points="""
+    [moksha.consumer]
+    librariesio = anitya.librariesio_consumer:LibrariesioConsumer
+    """,
 )


### PR DESCRIPTION
This adds a fedmsg consumer that handles messages from libraries.io by
way of the sse2fedmsg bridge. This is not complete yet, but it mostly works and
I wanted some initial feedback to see what people thing. Things left to do are:

- Tests

- A way to handle when libraries.io announces a version with a prefix (like v) and Anitya doesn't. 

- What to do when anitya finds a different version than libraries.io

- What do do when anitya doesn't find any version at all

This also sets up the Vagrant environment to use this.