### PR TITLE
Provide select-able version schemes for projects

### DIFF
--- a/alembic/versions/8075a90bbac0_add_a_version_scheme_column_to_projects.py
+++ b/alembic/versions/8075a90bbac0_add_a_version_scheme_column_to_projects.py
@@ -1,0 +1,29 @@
+"""
+Add a version scheme column to Projects
+
+Revision ID: 8075a90bbac0
+Revises: 9c29da0af3af
+Create Date: 2017-03-09 21:32:35.672952
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '8075a90bbac0'
+down_revision = '9c29da0af3af'
+
+
+def upgrade():
+    op.add_column('projects_versions', sa.Column('type', sa.String(length=50),
+                  nullable=False, server_default='PEP-440'))
+    # Once we initialize all the rows with a default, we can drop the server
+    # default. We want it to be set automatically by a pre-flush hook in Anitya
+    # or explicitly by outside users.
+    op.alter_column('projects_versions', 'type', server_default=None)
+    op.add_column('projects', sa.Column('version_scheme', sa.String(length=50),
+                  nullable=False, server_default='PEP-440'))
+
+
+def downgrade():
+    op.drop_column('projects_versions', 'type')
+    op.drop_column('projects', 'version_scheme')

--- a/anitya/forms.py
+++ b/anitya/forms.py
@@ -6,6 +6,7 @@ from wtforms import TextField, TextAreaField, validators, SelectField
 from wtforms import BooleanField
 
 from anitya.compat import FlaskForm
+from anitya.lib.model import version_classes
 
 
 class ProjectForm(FlaskForm):
@@ -16,6 +17,11 @@ class ProjectForm(FlaskForm):
         'Backend',
         [validators.Required()],
         choices=[(item, item) for item in []]
+    )
+    version_scheme = SelectField(
+        'Version Scheme',
+        [validators.Required()],
+        choices=[(item, item) for item in version_classes]
     )
     version_url = TextField('Version URL', [validators.optional()])
     version_prefix = TextField('Version prefix', [validators.optional()])

--- a/anitya/lib/__init__.py
+++ b/anitya/lib/__init__.py
@@ -74,10 +74,12 @@ def init(db_url, alembic_ini=None, debug=False, create=False):
 def create_project(
         session, name, homepage, user_id, backend='custom',
         version_url=None, version_prefix=None, regex=None,
-        check_release=False):
+        check_release=False, version_scheme=None):
     """ Create the project in the database.
 
     """
+    if version_scheme is None:
+        version_scheme = anitya.lib.model.PEP440_VERSION
     # Set the ecosystem if there's one associated with the given backend
     backend_ref = anitya.lib.model.Backend.by_name(session, name=backend)
     ecosystem_ref = backend_ref.default_ecosystem
@@ -90,6 +92,7 @@ def create_project(
         version_url=version_url,
         regex=regex,
         version_prefix=version_prefix,
+        version_scheme=version_scheme,
     )
 
     session.add(project)
@@ -119,7 +122,8 @@ def create_project(
 
 def edit_project(
         session, project, name, homepage, backend, version_url,
-        version_prefix, regex, insecure, user_id, check_release=False):
+        version_prefix, regex, insecure, user_id, check_release=False,
+        version_scheme=None):
     """ Edit a project in the database.
 
     """
@@ -157,6 +161,10 @@ def edit_project(
         old = project.insecure
         project.insecure = insecure
         changes['insecure'] = {'old': old, 'new': project.insecure}
+    if version_scheme and version_scheme != project.version_scheme:
+        old = project.version_scheme
+        project.version_scheme = version_scheme
+        changes['version_scheme'] = {'old': old, 'new': project.version_scheme}
 
     try:
         if changes:

--- a/anitya/lib/events.py
+++ b/anitya/lib/events.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions
+# of the GNU General Public License v.2, or (at your option) any later
+# version.  This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.  You
+# should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# Any Red Hat trademarks that are incorporated in the source
+# code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission
+# of Red Hat, Inc.
+"""
+This module contains the `SQLAlchemy event listeners`_ for Anitya.
+
+Anitya uses `SQLAlchemy event listeners`_ to perform tasks based on database
+events. For example, when a new project is committed to the database, Anitya
+publishes a message using `fedmsg`_.
+
+.. note::
+    In the future many events in this module should be accomplished with
+    ``SessionEvents.pending_to_persistent``, but unfortunately that's new in
+    1.1.0 and for the moment we need to support older versions of SQLAlchemy.
+
+.. _SQLAlchemy event listeners:
+    http://docs.sqlalchemy.org/en/latest/core/event.html
+.. _fedmsg: http://www.fedmsg.com/
+"""
+from __future__ import unicode_literals, absolute_import
+
+import logging
+
+from sqlalchemy import event
+
+from anitya.app import SESSION
+from anitya.lib import model
+
+
+_log = logging.getLogger(__name__)
+
+
+@event.listens_for(SESSION, 'before_flush')
+def set_version_types(session, flush_context, instances):
+    """
+    Set the correct type on ProjectVersion objects when their associated
+    project is updated.
+
+    See the SQLAlchemy `before_flush`_ documentation for full API details.
+
+    .. _before_flush:
+        http://docs.sqlalchemy.org/en/latest/orm/events.html\
+                #sqlalchemy.orm.events.SessionEvents.before_flush
+
+    Args:
+        session (sqlalchemy.orm.session.Session): The session being flushed.
+        flush_context (sqlalchemy.orm.session.UOWTransaction): Internal
+            UOWTransaction object which handles the details of the flush.
+        instances: Usually None, this is the collection of objects which can be
+            passed to the Session.flush() method (note this usage is deprecated).
+    """
+    def set_version_type(obj):
+        if isinstance(obj, model.Project):
+            for version in obj.versions_obj:
+                _log.debug('Updating %r version %r to %s', obj, version, obj.version_scheme)
+                version.type = obj.version_scheme
+                session.add(version)
+    for obj in session.dirty:
+        set_version_type(obj)
+    for obj in session.new:
+        set_version_type(obj)

--- a/anitya/lib/exceptions.py
+++ b/anitya/lib/exceptions.py
@@ -63,3 +63,20 @@ class AnityaInvalidMappingException(AnityaException):
                 project_name=self.project_name,
                 link=self.link,
             )
+
+
+class InvalidVersion(AnityaException):
+    """
+    Raised when the version string is not valid for the given version scheme.
+
+    Args:
+        version (str): The version string that failed to parse.
+        exception (Exception): The underlying exception that triggered this one.
+    """
+
+    def __init__(self, version, exception=None):
+        self.version = version
+        self.exception = exception
+
+    def __str__(self):
+        return 'Invalid version "{v}": {e}'.format(v=self.version, e=self.exception)

--- a/anitya/lib/model.py
+++ b/anitya/lib/model.py
@@ -10,17 +10,23 @@ anitya mapping of python classes to Database Tables.
 """
 
 import datetime
+import inspect
 import logging
+import re
+import sys
 import time
 
 __requires__ = ['SQLAlchemy >= 0.7']  # NOQA
 import pkg_resources  # NOQA
+from packaging import version as pep440_version
+import semantic_version
 
 import sqlalchemy as sa
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.exc import NoResultFound
 
+from anitya.lib import exceptions
 import anitya
 
 
@@ -28,6 +34,16 @@ BASE = declarative_base()
 
 
 _log = logging.getLogger(__name__)
+
+
+# Check for a leading 'v' in versions
+_leading_v = re.compile(r'v\d.*')
+
+
+# Constants for the various versions we support
+GENERIC_VERSION = u'Generic Version'
+PEP440_VERSION = u'PEP-440'
+SEMANTIC_VERSION = u'Semantic Version'
 
 
 def _paginate_query(query, page):
@@ -324,6 +340,36 @@ class Packages(BASE):
 
 
 class Project(BASE):
+    """
+    Models an upstream project and maps it to a database table.
+
+    Attributes:
+        id (sa.Integer): The database primary key.
+        name (sa.String): The upstream project's name.
+        homepage (sa.String): The URL for the project's home page.
+        backend (sa.String): The name of the backend to use when fetching updates;
+            this is a foreign key to a :class:`Backend`.
+        ecosystem_name (sa.String): The name of the ecosystem this project is a part
+            of. This is a foreign key to :class:`Ecosystem` and may be null.
+        ecosystem (Ecosystem): The :class:`Ecosystem` this project is a part of.
+        version_url (sa.String): The url to use when polling for new versions. This
+            may be ignored if this project is part of an ecosystem with a fixed
+            URL (e.g. Cargo projects are on https://crates.io).
+        regex (sa.String): A Python ``re`` style regular expression that is applied
+            to the HTML from ``version_url`` to find versions.
+        insecure (sa.Boolean): Whether or not to validate the x509 certificate
+            offered by the server at ``version_url``. Defaults to ``False``.
+        latest_version (sa.Boolean): The latest version for the project, as determined
+            by the version sorting algorithm.
+        logs (sa.Text): The result of the last update.
+        updated_on (sa.DateTime): When the project was last updated.
+        created_on (sa.DateTime): When the project was created in Anitya.
+        packages (list): List of :class:`Package` objects which represent the
+            downstream packages for this project.
+        version_scheme (sa.String): The version scheme to use for this project.
+            This needs to be a valid value for the ``type`` column of ProjectVersion.
+    """
+
     __tablename__ = 'projects'
 
     id = sa.Column(sa.Integer, primary_key=True)
@@ -348,6 +394,8 @@ class Project(BASE):
             name="FK_ECOSYSTEM_FOR_PROJECT"),
         nullable=True
     )
+    version_scheme = sa.Column(sa.String(50), nullable=False, default=PEP440_VERSION)
+
     ecosystem = relationship("Ecosystem", back_populates="projects")
     version_url = sa.Column(sa.String(200), nullable=True)
     regex = sa.Column(sa.String(200), nullable=True)
@@ -373,8 +421,17 @@ class Project(BASE):
     def versions(self):
         ''' Return list of all versions stored, sorted from newest to oldest.
         '''
-        return list(reversed(anitya.order_versions(
-            [v.version for v in self.versions_obj])))
+        try:
+            versions = [str(v) for v in sorted(self.versions_obj)]
+        except anitya.lib.exceptions.InvalidVersion:
+            versions = [v.version for v in self.versions_obj]
+
+        return list(reversed(versions))
+
+    @property
+    def version_class(self):
+        """The model class for the version scheme used on this project"""
+        return version_classes[self.version_scheme]
 
     def __repr__(self):
         return '<Project(%s, %s)>' % (self.name, self.homepage)
@@ -632,6 +689,20 @@ class Project(BASE):
 
 
 class ProjectVersion(BASE):
+    """
+    Represents a version for a project.
+
+    Attributes:
+        project_id (sa.Integer): A foreign key to the project this version is
+            associated with.
+        project (Project): The project object with the ``project_id`` foreign
+            key.
+        version (str): A string representing a version.
+        type (str): The version type (e.g. 'PEP-440', 'Semantic Version', etc.).
+            This must match the polymorphic identity of a sub-class. SQLAlchemy
+            will use this to determine the Python class to use when creating the
+            object from the database row.
+    """
     __tablename__ = 'projects_versions'
 
     project_id = sa.Column(
@@ -643,8 +714,333 @@ class ProjectVersion(BASE):
         primary_key=True,
     )
     version = sa.Column(sa.String(50), primary_key=True)
+    type = sa.Column(sa.String(50))
 
     project = sa.orm.relation('Project', backref='versions_obj')
+
+    __mapper_args__ = {
+        'polymorphic_on': type,
+        'polymorphic_identity': GENERIC_VERSION,
+    }
+
+    def __str__(self):
+        """
+        Return a parsed, string version of this instance's version.
+
+        If parsing fails, the original version string is returned.
+        """
+        try:
+            return str(self.parse())
+        except anitya.lib.exceptions.InvalidVersion:
+            return self.version
+
+    def parse(self):
+        """
+        Parse the version string to an object representing the version.
+
+        When sub-classing this class to support SQLAlchemy's single-table
+        inheritance, this method must return an object that supports comparison
+        operations, or re-implement the comparison functions.
+
+        Returns:
+            str: The version string. Sub-classes may return a different type.
+        """
+        # If there's a prefix set on the project, strip it if it's present
+        version = self.version
+        if self.project:
+            prefix = self.project.version_prefix
+            if prefix and self.version.startswith(prefix):
+                version = self.version[len(prefix):]
+
+        # Many projects prefix their tags with 'v', so strip it if it's present
+        if _leading_v.match(version):
+            version = version.lstrip('v')
+
+        return version
+
+    def prerelease(self):
+        """
+        Check if a version is a pre-release version.
+
+        This basic version implementation does not have a concept of
+        pre-releases.
+        """
+        return False
+
+    def postrelease(self):
+        """
+        Check if a version is a post-release version.
+
+        This basic version implementation does not have a concept of
+        post-releases.
+        """
+        return False
+
+    def newer(self, other_versions):
+        """
+        Check a version against a set of other versions to see if it's newer.
+
+        Example:
+            >>> version = ProjectVersion(version='1.1.0')
+            >>> version.newer([ProjectVersion(version='1.0.0')])
+            True
+            >>> version.newer(['1.0.0', '0.0.1'])  # You can pass strings!
+            True
+            >>> version.newer(['1.2.0', '2.0.1'])
+            False
+
+        Args:
+            other_versions (list): A list of version strings or ProjecVersion
+                objects to check the `version` string against.
+
+        Returns:
+            bool: True if self is the newest version, ``False otherwise``.
+
+        Raises:
+            anitya.exceptions.InvalidVersion: if one or more of the version
+                strings provided cannot be parsed.
+        """
+        if isinstance(other_versions, (ProjectVersion, str)):
+            other_versions = [other_versions]
+        cast_versions = []
+        for version in other_versions:
+            if not isinstance(version, type(self)):
+                version = type(self)(version=version)
+            cast_versions.append(version)
+        return all([self.parse() > v.parse() for v in cast_versions])
+
+    def __lt__(self, other):
+        """Support < comparison via objects returned from :meth:`parse`"""
+        try:
+            parsed_self = self.parse()
+        except exceptions.InvalidVersion:
+            parsed_self = None
+        try:
+            parsed_other = other.parse()
+        except exceptions.InvalidVersion:
+            parsed_other = None
+
+        # Handle the cases where one or both aren't parsable. Parsable versions
+        # always sort higher than unparsable versions.
+        if not parsed_self and not parsed_other:
+            return self.version.__lt__(other.version)
+        if not parsed_other:
+            return False
+        if not parsed_self:
+            return True
+
+        return parsed_self.__lt__(parsed_other)
+
+    def __le__(self, other):
+        """Support <= comparison via objects returned from :meth:`parse`"""
+        try:
+            parsed_self = self.parse()
+        except exceptions.InvalidVersion:
+            parsed_self = None
+        try:
+            parsed_other = other.parse()
+        except exceptions.InvalidVersion:
+            parsed_other = None
+
+        # Handle the cases where one or both aren't parsable. Parsable versions
+        # always sort higher than unparsable versions.
+        if not parsed_self and not parsed_other:
+            return self.version.__le__(other.version)
+        if not parsed_other:
+            return False
+        if not parsed_self:
+            return True
+        return parsed_self.__le__(parsed_other)
+
+    def __gt__(self, other):
+        """Support > comparison via objects returned from :meth:`parse`"""
+        try:
+            parsed_self = self.parse()
+        except exceptions.InvalidVersion:
+            parsed_self = None
+        try:
+            parsed_other = other.parse()
+        except exceptions.InvalidVersion:
+            parsed_other = None
+
+        # Handle the cases where one or both aren't parsable. Parsable versions
+        # always sort higher than unparsable versions.
+        if not parsed_self and not parsed_other:
+            return self.version.__gt__(other.version)
+        if not parsed_other:
+            return True
+        if not parsed_self:
+            return False
+        return parsed_self.__gt__(parsed_other)
+
+    def __ge__(self, other):
+        """Support >= comparison via objects returned from :meth:`parse`"""
+        try:
+            parsed_self = self.parse()
+        except exceptions.InvalidVersion:
+            parsed_self = None
+        try:
+            parsed_other = other.parse()
+        except exceptions.InvalidVersion:
+            parsed_other = None
+
+        # Handle the cases where one or both aren't parsable. Parsable versions
+        # always sort higher than unparsable versions.
+        if not parsed_self and not parsed_other:
+            return self.version.__ge__(other.version)
+        if not parsed_other:
+            return True
+        if not parsed_self:
+            return False
+        return parsed_self.__ge__(parsed_other)
+
+    def __eq__(self, other):
+        """Support == comparison via objects returned from :meth:`parse`"""
+        try:
+            parsed_self = self.parse()
+        except exceptions.InvalidVersion:
+            parsed_self = None
+        try:
+            parsed_other = other.parse()
+        except exceptions.InvalidVersion:
+            parsed_other = None
+
+        if not parsed_self or not parsed_other:
+            return self.version.__eq__(other.version)
+        return parsed_self.__eq__(parsed_other)
+
+
+class Pep440Version(ProjectVersion):
+    """
+    A PEP-440-compliant version.
+    """
+
+    __mapper_args__ = {
+        'polymorphic_identity': PEP440_VERSION,
+    }
+
+    def __str__(self):
+        """Parse the version, allowing for LegacyVersions"""
+        return str(pep440_version.parse(self.version))
+
+    def parse(self):
+        """
+        Parse the version string.
+
+        This accounts for and strips leading 'v' characters for version strings.
+
+        Returns:
+            packaging.version.Version: If the string is a PEP-440 compliant version.
+            packaging.version.LegacyVersion: If the string isn't PEP-440 compliant,
+                but can still be parsed.
+
+        Raises:
+            anitya.exceptions.InvalidVersion: if one or more of the version
+                strings provided cannot be parsed.
+        """
+        version = super(Pep440Version, self).parse()
+        try:
+            return pep440_version.Version(version)
+        except pep440_version.InvalidVersion as e:
+            raise exceptions.InvalidVersion(version, e)
+
+    def prerelease(self):
+        """
+        Check if a version is a pre-release version.
+
+        Example:
+
+            >>> version = Pep440Version(version='1.0a1')
+            >>> version.prerelease()
+            True
+            >>> version = Pep440Version(version='1.0')
+            >>> version.prerelease()
+            False
+
+        Returns:
+            bool: True if this is a pre-release, False otherwise.
+        """
+        try:
+            return self.parse().is_prerelease
+        except pep440_version.InvalidVersion:
+            return False
+
+    def postrelease(self):
+        """
+        Check if a version is a post-release version.
+
+        Example:
+            >>> version = Pep440Version(version='1.0.post1')
+            >>> version.postrelease()
+            True
+            >>> version = Pep440Version(version='1.0')
+            >>> version.prerelease()
+            False
+
+        Returns:
+            bool: True if this is a post-release, False otherwise.
+        """
+        try:
+            return self.parse().is_postrelease
+        except pep440_version.InvalidVersion:
+            return False
+
+
+class SemanticVersion(ProjectVersion):
+    """
+    Semantic version compliant version.
+    """
+
+    __mapper_args__ = {
+        'polymorphic_identity': SEMANTIC_VERSION,
+    }
+
+    def parse(self):
+        """
+        Parse the version string.
+
+        Returns:
+            semantic_version.Version: A parsed version object.
+
+        Raises:
+            anitya.exceptions.InvalidVersion: if one or more of the version
+                strings provided cannot be parsed.
+        """
+        version = super(SemanticVersion, self).parse()
+        try:
+            return semantic_version.Version(version, partial=True)
+        except ValueError as e:
+            raise exceptions.InvalidVersion(version, e)
+
+    def prerelease(self):
+        """
+        Check if a version is a pre-release version.
+
+        Example:
+
+            >>> version = SemanticVersion(version='1.0.0-alpha')
+            >>> version.prerelease()
+            True
+            >>> version = SemanticVersion(version='1.0.0')
+            >>> version.prerelease()
+            False
+        """
+        try:
+            if self.parse().prerelease:
+                return True
+        except ValueError:
+            pass
+        return False
+
+    def postrelease(self):
+        """
+        Check if a version is a post-release version.
+
+        Returns:
+            False: The semantic version scheme does not include the concept of
+                post-releases.
+        """
+        return False
 
 
 class ProjectFlag(BASE):
@@ -770,3 +1166,11 @@ class Run(BASE):
             cls.created_on.desc()
         )
         return query.first()
+
+
+#: A dictionary of available version types where the key is their name and the
+#: value is the class.
+version_classes = dict()
+for _name, _object in inspect.getmembers(sys.modules[__name__]):
+    if inspect.isclass(_object) and issubclass(_object, ProjectVersion):
+        version_classes[_object.__mapper_args__['polymorphic_identity']] = _object

--- a/anitya/templates/project_new.html
+++ b/anitya/templates/project_new.html
@@ -28,14 +28,17 @@
             <tr>
               {{ render_field_in_row(form.backend, tabindex=3) }}
             </tr>
+            <tr>
+              {{ render_field_in_row(form.version_scheme, tabindex=4) }}
+            </tr>
             <tr id="version_url_row">
-              {{ render_field_in_row(form.version_url, tabindex=4) }}
+              {{ render_field_in_row(form.version_url, tabindex=5) }}
             </tr>
             <tr id="version_prefix_row">
-              {{ render_field_in_row(form.version_prefix, tabindex=5) }}
+              {{ render_field_in_row(form.version_prefix, tabindex=6) }}
             </tr>
             <tr id="regex_row">
-              {{ render_field_in_row(form.regex, tabindex=6) }}
+              {{ render_field_in_row(form.regex, tabindex=7) }}
             </tr>
             <tr id="default_regex_row">
               <td><label>Default regex:</label></td>
@@ -46,19 +49,19 @@
               <td id="example_urls"></td>
             </tr>
             <tr id="insecure_row">
-              {{ render_field_in_row(form.insecure, tabindex=7) }}
+              {{ render_field_in_row(form.insecure, tabindex=8) }}
             </tr>
             <tr id="check_release_row">
-              {{ render_field_in_row(form.check_release, tabindex=8) }}
+              {{ render_field_in_row(form.check_release, tabindex=9) }}
             </tr>
 
             {%- if context == 'Add' -%}
             <tr>
-              {{ render_field_in_row(form.distro, tabindex=9) }}
+              {{ render_field_in_row(form.distro, tabindex=10) }}
               <td></td>
             </tr>
             <tr>
-              {{ render_field_in_row(form.package_name, tabindex=10) }}
+              {{ render_field_in_row(form.package_name, tabindex=11) }}
               <td></td>
             </tr>
             {%- endif -%}

--- a/anitya/tests/base.py
+++ b/anitya/tests/base.py
@@ -129,6 +129,7 @@ def create_project(session):
         version_url='http://www.geany.org/Download/Releases',
         regex='DEFAULT',
         user_id='noreply@fedoraproject.org',
+        version_scheme=anitya.lib.model.PEP440_VERSION,
     )
 
     anitya.lib.create_project(
@@ -138,6 +139,7 @@ def create_project(session):
         version_url='http://subsurface.hohndel.org/downloads/',
         regex='DEFAULT',
         user_id='noreply@fedoraproject.org',
+        version_scheme=anitya.lib.model.PEP440_VERSION,
     )
 
     anitya.lib.create_project(
@@ -145,6 +147,7 @@ def create_project(session):
         name='R2spec',
         homepage='https://fedorahosted.org/r2spec/',
         user_id='noreply@fedoraproject.org',
+        version_scheme=anitya.lib.model.PEP440_VERSION,
     )
 
 
@@ -158,7 +161,8 @@ def create_ecosystem_projects(session):
         name='pypi_and_npm',
         homepage='https://example.com/not-a-real-pypi-project',
         backend='PyPI',
-        user_id='noreply@fedoraproject.org'
+        user_id='noreply@fedoraproject.org',
+        version_scheme=anitya.lib.model.PEP440_VERSION,
     )
 
     anitya.lib.create_project(
@@ -166,7 +170,8 @@ def create_ecosystem_projects(session):
         name='pypi_and_npm',
         homepage='https://example.com/not-a-real-npmjs-project',
         backend='npmjs',
-        user_id='noreply@fedoraproject.org'
+        user_id='noreply@fedoraproject.org',
+        version_scheme=anitya.lib.model.PEP440_VERSION,
     )
 
     anitya.lib.create_project(
@@ -174,7 +179,8 @@ def create_ecosystem_projects(session):
         name='rubygems_and_maven',
         homepage='https://example.com/not-a-real-rubygems-project',
         backend='Rubygems',
-        user_id='noreply@fedoraproject.org'
+        user_id='noreply@fedoraproject.org',
+        version_scheme=anitya.lib.model.PEP440_VERSION,
     )
 
     anitya.lib.create_project(
@@ -182,7 +188,8 @@ def create_ecosystem_projects(session):
         name='rubygems_and_maven',
         homepage='https://example.com/not-a-real-maven-project',
         backend='Maven Central',
-        user_id='noreply@fedoraproject.org'
+        user_id='noreply@fedoraproject.org',
+        version_scheme=anitya.lib.model.PEP440_VERSION,
     )
 
 
@@ -214,6 +221,7 @@ def create_flagged_project(session):
         version_url='http://www.geany.org/Download/Releases',
         regex='DEFAULT',
         user_id='noreply@fedoraproject.org',
+        version_scheme=anitya.lib.model.PEP440_VERSION,
     )
 
     session.add(project)

--- a/anitya/tests/lib/backends/test_bitbucket.py
+++ b/anitya/tests/lib/backends/test_bitbucket.py
@@ -18,6 +18,7 @@
 # License and may only be used or replicated with the express permission
 # of Red Hat, Inc.
 #
+from __future__ import unicode_literals
 
 '''
 anitya tests for the bitbucket backend.
@@ -52,6 +53,8 @@ class BitBucketBackendtests(Modeltests):
             homepage='https://bitbucket.org/zzzeek/sqlalchemy',
             version_url='zzzeek/sqlalchemy',
             backend=BACKEND,
+            version_prefix='rel_',
+            version_scheme=model.GENERIC_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -61,6 +64,7 @@ class BitBucketBackendtests(Modeltests):
             homepage='http://bitbucket.org/foo/bar',
             version_url='foobar/bar',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -69,16 +73,17 @@ class BitBucketBackendtests(Modeltests):
             name='cherrypy',
             homepage='https://bitbucket.org/cherrypy/cherrypy',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
+            version_prefix='cherrypy-',
         )
         self.session.add(project)
         self.session.commit()
-
 
     def test_get_version(self):
         """ Test the get_version function of the BitBucket backend. """
         pid = 1
         project = model.Project.get(self.session, pid)
-        exp = 'rel_1_1_3'
+        exp = '1_1_3'
         obs = backend.BitBucketBackend.get_version(project)
         self.assertEqual(obs, exp)
 
@@ -92,7 +97,7 @@ class BitBucketBackendtests(Modeltests):
 
         pid = 3
         project = model.Project.get(self.session, pid)
-        exp = 'v5.2.0'
+        exp = '5.2.0'
         obs = backend.BitBucketBackend.get_version(project)
         self.assertEqual(obs, exp)
 
@@ -100,44 +105,44 @@ class BitBucketBackendtests(Modeltests):
         """ Test the get_versions function of the BitBucket backend. """
         pid = 1
         project = model.Project.get(self.session, pid)
-        exp = [
-            'rel_0_1_0', 'rel_0_1_1', 'rel_0_1_2', 'rel_0_1_3',
-            'rel_0_1_4', 'rel_0_1_5', 'rel_0_1_6', 'rel_0_1_7',
-            'rel_0_2_0', 'rel_0_2_1', 'rel_0_2_2', 'rel_0_2_3',
-            'rel_0_2_4', 'rel_0_2_5', 'rel_0_2_6', 'rel_0_2_7',
-            'rel_0_2_8', 'rel_0_3_0', 'rel_0_3_1', 'rel_0_3_2',
-            'rel_0_3_3', 'rel_0_3_4', 'rel_0_3_5', 'rel_0_3_6',
-            'rel_0_3_7', 'rel_0_3_8', 'rel_0_3_9', 'rel_0_3_10',
-            'rel_0_3_11', 'rel_0_4beta1', 'rel_0_4beta2', 'rel_0_4beta3',
-            'rel_0_4beta4', 'rel_0_4beta6', 'rel_0_4_0', 'rel_0_4_1',
-            'rel_0_4_2', 'rel_0_4_2a', 'rel_0_4_2b', 'rel_0_4_2p3',
-            'rel_0_4_3', 'rel_0_4_4', 'rel_0_4_5', 'rel_0_4_6',
-            'rel_0_4_7', 'rel_0_4_7p1', 'rel_0_4_8', 'rel_0_5beta1',
-            'rel_0_5beta2', 'rel_0_5beta3', 'rel_0_5rc1', 'rel_0_5rc2',
-            'rel_0_5rc3', 'rel_0_5rc4', 'rel_0_5_0', 'rel_0_5_1',
-            'rel_0_5_2', 'rel_0_5_3', 'rel_0_5_4', 'rel_0_5_4p1',
-            'rel_0_5_4p2', 'rel_0_5_5', 'rel_0_5_6', 'rel_0_5_7',
-            'rel_0_5_8', 'rel_0_6beta1', 'rel_0_6beta2', 'rel_0_6beta3',
-            'rel_0_6_0', 'rel_0_6_1', 'rel_0_6_2', 'rel_0_6_3',
-            'rel_0_6_4', 'rel_0_6_5', 'rel_0_6_6', 'rel_0_6_7', 'rel_0_6_8',
-            'rel_0_6_9', 'rel_0_7b1', 'rel_0_7b2', 'rel_0_7b3',
-            'rel_0_7b4', 'rel_0_7_0', 'rel_0_7_1', 'rel_0_7_2',
-            'rel_0_7_3', 'rel_0_7_4', 'rel_0_7_5', 'rel_0_7_6',
-            'rel_0_7_7', 'rel_0_7_8', 'rel_0_7_9', 'rel_0_7_10',
-            'rel_0_8_0', 'rel_0_8_0b1', 'rel_0_8_0b2', 'rel_0_8_1',
-            'rel_0_8_2', 'rel_0_8_3', 'rel_0_8_4', 'rel_0_8_5',
-            'rel_0_8_6', 'rel_0_8_7', 'rel_0_9_0', 'rel_0_9_0b1',
-            'rel_0_9_1', 'rel_0_9_2', 'rel_0_9_3', 'rel_0_9_4',
-            'rel_0_9_5', 'rel_0_9_6', 'rel_0_9_7', 'rel_0_9_8',
-            'rel_0_9_9', 'rel_0_9_10', 'rel_1_0_0', 'rel_1_0_0b1',
-            'rel_1_0_0b2', 'rel_1_0_0_b3', 'rel_1_0_0b4', 'rel_1_0_0b5',
-            'rel_1_0_1', 'rel_1_0_2', 'rel_1_0_3', 'rel_1_0_4',
-            'rel_1_0_5', 'rel_1_0_6', 'rel_1_0_7', 'rel_1_0_8',
-            'rel_1_0_9', 'rel_1_0_10', 'rel_1_0_11', 'rel_1_0_12',
-            'rel_1_0_13', 'rel_1_0_14', 'rel_1_0_15', 'rel_1_1_0',
-            'rel_1_1_0b1', 'rel_1_1_0b2', 'rel_1_1_0b3', 'rel_1_1_1',
-            'rel_1_1_2', 'rel_1_1_3'
-        ]
+        exp = sorted([
+            '0_1_0', '0_1_1', '0_1_2', '0_1_3',
+            '0_1_4', '0_1_5', '0_1_6', '0_1_7',
+            '0_2_0', '0_2_1', '0_2_2', '0_2_3',
+            '0_2_4', '0_2_5', '0_2_6', '0_2_7',
+            '0_2_8', '0_3_0', '0_3_1', '0_3_2',
+            '0_3_3', '0_3_4', '0_3_5', '0_3_6',
+            '0_3_7', '0_3_8', '0_3_9', '0_3_10',
+            '0_3_11', '0_4beta1', '0_4beta2', '0_4beta3',
+            '0_4beta4', '0_4beta6', '0_4_0', '0_4_1',
+            '0_4_2', '0_4_2a', '0_4_2b', '0_4_2p3',
+            '0_4_3', '0_4_4', '0_4_5', '0_4_6',
+            '0_4_7', '0_4_7p1', '0_4_8', '0_5beta1',
+            '0_5beta2', '0_5beta3', '0_5rc1', '0_5rc2',
+            '0_5rc3', '0_5rc4', '0_5_0', '0_5_1',
+            '0_5_2', '0_5_3', '0_5_4', '0_5_4p1',
+            '0_5_4p2', '0_5_5', '0_5_6', '0_5_7',
+            '0_5_8', '0_6beta1', '0_6beta2', '0_6beta3',
+            '0_6_0', '0_6_1', '0_6_2', '0_6_3',
+            '0_6_4', '0_6_5', '0_6_6', '0_6_7', '0_6_8',
+            '0_6_9', '0_7b1', '0_7b2', '0_7b3',
+            '0_7b4', '0_7_0', '0_7_1', '0_7_2',
+            '0_7_3', '0_7_4', '0_7_5', '0_7_6',
+            '0_7_7', '0_7_8', '0_7_9', '0_7_10',
+            '0_8_0', '0_8_0b1', '0_8_0b2', '0_8_1',
+            '0_8_2', '0_8_3', '0_8_4', '0_8_5',
+            '0_8_6', '0_8_7', '0_9_0', '0_9_0b1',
+            '0_9_1', '0_9_2', '0_9_3', '0_9_4',
+            '0_9_5', '0_9_6', '0_9_7', '0_9_8',
+            '0_9_9', '0_9_10', '1_0_0', '1_0_0b1',
+            '1_0_0b2', '1_0_0_b3', '1_0_0b4', '1_0_0b5',
+            '1_0_1', '1_0_2', '1_0_3', '1_0_4',
+            '1_0_5', '1_0_6', '1_0_7', '1_0_8',
+            '1_0_9', '1_0_10', '1_0_11', '1_0_12',
+            '1_0_13', '1_0_14', '1_0_15', '1_1_0',
+            '1_1_0b1', '1_1_0b2', '1_1_0b3', '1_1_1',
+            '1_1_2', '1_1_3'
+        ])
         obs = backend.BitBucketBackend.get_ordered_versions(project)
         self.assertEqual(obs, exp)
 
@@ -152,20 +157,56 @@ class BitBucketBackendtests(Modeltests):
         pid = 3
         project = model.Project.get(self.session, pid)
         exp = [
-            'cherrypy-2.0.0-beta', 'cherrypy-2.0.0', 'cherrypy-2.1.0-alpha',
-            'cherrypy-2.1.0-rc1', 'cherrypy-2.1.0-rc2', 'cherrypy-2.1.1',
-            'cherrypy-2.2.0beta', 'cherrypy-2.2.0rc1', 'cherrypy-2.2.0',
-            'cherrypy-2.2.1', 'cherrypy-2.3.0', 'cherrypy-3.0.0beta',
-            'cherrypy-3.0.0beta2', 'cherrypy-3.0.0RC1', 'cherrypy-3.0.0',
-            'cherrypy-3.0.1', 'cherrypy-3.0.2', 'cherrypy-3.0.3',
-            'cherrypy-3.0.4', 'cherrypy-3.1.0beta', 'cherrypy-3.1.0beta2',
-            'cherrypy-3.1.0beta3', 'cherrypy-3.1.0', 'cherrypy-3.1.1',
-            'cherrypy-3.1.2', 'cherrypy-3.2.0beta', 'cherrypy-3.2.0rc1',
-            'cherrypy-3.2.0', 'cherrypy-3.2.1', 'cherrypy-3.2.2rc1',
-            'cherrypy-3.2.2', 'rdelon-experimental', 'trunk', '3.2.3',
-            '3.2.4', '3.2.5', '3.2.6', '3.3.0', '3.4.0', '3.5.0',
-            '3.6.0', '3.7.0', '3.8.0', '3.8.1', '3.8.2', '4.0.0', '5.0.0',
-            '5.0.1', '5.1.0', 'v5.2.0'
+            'rdelon-experimental',
+            'trunk',
+            '2.0.0b0',
+            '2.0.0',
+            '2.1.0a0',
+            '2.1.0rc1',
+            '2.1.0rc2',
+            '2.1.1',
+            '2.2.0b0',
+            '2.2.0rc1',
+            '2.2.0',
+            '2.2.1',
+            '2.3.0',
+            '3.0.0b0',
+            '3.0.0b2',
+            '3.0.0rc1',
+            '3.0.0',
+            '3.0.1',
+            '3.0.2',
+            '3.0.3',
+            '3.0.4',
+            '3.1.0b0',
+            '3.1.0b2',
+            '3.1.0b3',
+            '3.1.0',
+            '3.1.1',
+            '3.1.2',
+            '3.2.0b0',
+            '3.2.0rc1',
+            '3.2.0',
+            '3.2.1',
+            '3.2.2rc1',
+            '3.2.2',
+            '3.2.3',
+            '3.2.4',
+            '3.2.5',
+            '3.2.6',
+            '3.3.0',
+            '3.4.0',
+            '3.5.0',
+            '3.6.0',
+            '3.7.0',
+            '3.8.0',
+            '3.8.1',
+            '3.8.2',
+            '4.0.0',
+            '5.0.0',
+            '5.0.1',
+            '5.1.0',
+            '5.2.0',
         ]
         obs = backend.BitBucketBackend.get_ordered_versions(project)
         self.assertEqual(obs, exp)

--- a/anitya/tests/lib/backends/test_cpan.py
+++ b/anitya/tests/lib/backends/test_cpan.py
@@ -55,6 +55,7 @@ class CpanBackendtests(Modeltests):
             name='SOAP',
             homepage='http://search.cpan.org/dist/SOAP/',
             backend=BACKEND,
+            version_scheme=model.SEMANTIC_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -63,6 +64,7 @@ class CpanBackendtests(Modeltests):
             name='foo',
             homepage='http://search.cpan.org/dist/foo/',
             backend=BACKEND,
+            version_scheme=model.SEMANTIC_VERSION,
         )
         self.session.add(project)
         self.session.commit()

--- a/anitya/tests/lib/backends/test_crates.py
+++ b/anitya/tests/lib/backends/test_crates.py
@@ -47,11 +47,13 @@ class CratesBackendTests(Modeltests):
             name='itoa',
             homepage='https://crates.io/crates/itoa',
             backend='crates.io',
+            version_scheme=model.SEMANTIC_VERSION,
         )
         project2 = model.Project(
             name='pleasedontmakethisprojectitllbreakmytests',
             homepage='https://crates.io/crates/somenonsensehomepage',
             backend='crates.io',
+            version_scheme=model.SEMANTIC_VERSION,
         )
         self.session.add(project1)
         self.session.add(project2)

--- a/anitya/tests/lib/backends/test_custom.py
+++ b/anitya/tests/lib/backends/test_custom.py
@@ -52,6 +52,7 @@ class CustomBackendtests(Modeltests):
             version_url='http://www.geany.org/Download/Releases',
             regex='DEFAULT',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -61,6 +62,7 @@ class CustomBackendtests(Modeltests):
             homepage='https://pypi.python.org/pypi/repo_manager_fake',
             regex='DEFAULT',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -71,6 +73,7 @@ class CustomBackendtests(Modeltests):
             version_url='http://subsurface.hohndel.org/downloads/',
             regex='DEFAULT',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()

--- a/anitya/tests/lib/backends/test_drupal6.py
+++ b/anitya/tests/lib/backends/test_drupal6.py
@@ -22,6 +22,7 @@
 '''
 anitya tests for the custom backend.
 '''
+from __future__ import unicode_literals
 
 __requires__ = ['SQLAlchemy >= 0.7']
 import pkg_resources
@@ -55,6 +56,7 @@ class Drupal6Backendtests(Modeltests):
             name='wysiwyg',
             homepage='https://www.drupal.org/project/wysiwyg',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -63,6 +65,7 @@ class Drupal6Backendtests(Modeltests):
             name='foo',
             homepage='http://pecl.php.net/package/foo',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -71,6 +74,7 @@ class Drupal6Backendtests(Modeltests):
             name='admin_menu',
             homepage='https://www.drupal.org/project/admin_menu',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -94,7 +98,7 @@ class Drupal6Backendtests(Modeltests):
 
         pid = 3
         project = model.Project.get(self.session, pid)
-        exp = '3.0-alpha4'
+        exp = '3.0a4'
         obs = backend.Drupal6Backend.get_version(project)
         self.assertEqual(obs, exp)
 
@@ -102,7 +106,7 @@ class Drupal6Backendtests(Modeltests):
         """ Test the get_versions function of the debian backend. """
         pid = 1
         project = model.Project.get(self.session, pid)
-        exp = ['2.x-dev', '2.0-alpha1', '2.0', '2.1', '2.2', '2.3', '2.4']
+        exp = ['2.x-dev', '2.0a1', '2.0', '2.1', '2.2', '2.3', '2.4']
         obs = backend.Drupal6Backend.get_ordered_versions(project)
         self.assertEqual(obs, exp)
 
@@ -116,9 +120,9 @@ class Drupal6Backendtests(Modeltests):
 
         pid = 3
         project = model.Project.get(self.session, pid)
-        exp = ['1.x-dev', '1.0-beta', '1.0', '1.1', '1.2', '1.3', '1.4',
-               '1.5', '1.6', '1.7', '1.8', '1.9', '3.x-dev', '3.0-alpha1',
-               '3.0-alpha2', '3.0-alpha3', '3.0-alpha4']
+        exp = ['1.x-dev', '3.x-dev', '1.0b0', '1.0', '1.1', '1.2', '1.3', '1.4',
+               '1.5', '1.6', '1.7', '1.8', '1.9', '3.0a1',
+               '3.0a2', '3.0a3', '3.0a4']
         obs = backend.Drupal6Backend.get_ordered_versions(project)
         self.assertEqual(obs, exp)
 

--- a/anitya/tests/lib/backends/test_drupal7.py
+++ b/anitya/tests/lib/backends/test_drupal7.py
@@ -22,6 +22,7 @@
 '''
 anitya tests for the custom backend.
 '''
+from __future__ import unicode_literals
 
 __requires__ = ['SQLAlchemy >= 0.7']
 import pkg_resources
@@ -55,6 +56,7 @@ class Drupal7Backendtests(Modeltests):
             name='wysiwyg',
             homepage='https://www.drupal.org/project/wysiwyg',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -63,6 +65,7 @@ class Drupal7Backendtests(Modeltests):
             name='foo',
             homepage='http://pecl.php.net/package/foo',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -71,6 +74,7 @@ class Drupal7Backendtests(Modeltests):
             name='admin_menu',
             homepage='https://www.drupal.org/project/admin_menu',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -94,7 +98,7 @@ class Drupal7Backendtests(Modeltests):
 
         pid = 3
         project = model.Project.get(self.session, pid)
-        exp = '3.0-rc5'
+        exp = '3.0rc5'
         obs = backend.Drupal7Backend.get_version(project)
         self.assertEqual(obs, exp)
 
@@ -116,7 +120,7 @@ class Drupal7Backendtests(Modeltests):
 
         pid = 3
         project = model.Project.get(self.session, pid)
-        exp = ['3.x-dev', '3.0-rc1', '3.0-rc2', '3.0-rc3', '3.0-rc4', '3.0-rc5']
+        exp = ['3.x-dev', '3.0rc1', '3.0rc2', '3.0rc3', '3.0rc4', '3.0rc5']
         obs = backend.Drupal7Backend.get_ordered_versions(project)
         self.assertEqual(obs, exp)
 

--- a/anitya/tests/lib/backends/test_folder.py
+++ b/anitya/tests/lib/backends/test_folder.py
@@ -54,6 +54,7 @@ class FolderBackendtests(Modeltests):
             homepage='https://www.gnu.org/software/gnash/',
             version_url='http://ftp.gnu.org/pub/gnu/gnash/',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -63,6 +64,7 @@ class FolderBackendtests(Modeltests):
             homepage='https://pypi.python.org/pypi/repo_manager_fake',
             backend=BACKEND,
             insecure=True,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -72,6 +74,7 @@ class FolderBackendtests(Modeltests):
             homepage='http://subsurface.hohndel.org/',
             version_url='http://subsurface.hohndel.org/downloads/',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()

--- a/anitya/tests/lib/backends/test_github.py
+++ b/anitya/tests/lib/backends/test_github.py
@@ -52,6 +52,7 @@ class GithubBackendtests(Modeltests):
             homepage='https://github.com/fedora-infra/fedocal',
             version_url='fedora-infra/fedocal',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -61,6 +62,7 @@ class GithubBackendtests(Modeltests):
             homepage='http://github.com/foo/bar',
             version_url='foobar/bar',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -69,6 +71,7 @@ class GithubBackendtests(Modeltests):
             name='pkgdb2',
             homepage='https://github.com/fedora-infra/pkgdb2',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -101,7 +104,7 @@ class GithubBackendtests(Modeltests):
         pid = 1
         project = model.Project.get(self.session, pid)
         exp = [
-            u'v0.9.3',
+            u'0.9.3',
             u'0.10', u'0.11', u'0.11.1', u'0.12',
             u'0.13', u'0.13.1', u'0.13.2', u'0.13.3',
             u'0.14',
@@ -131,6 +134,7 @@ class GithubBackendtests(Modeltests):
         project = model.Project(
             version_url='codehaus-plexus/plexus-archiver',
             version_prefix='plexus-archiver-',
+            version_scheme=model.PEP440_VERSION,
         )
         version = backend.GithubBackend().get_version(project)
         self.assertEqual(u'3.3', version)

--- a/anitya/tests/lib/backends/test_gnome.py
+++ b/anitya/tests/lib/backends/test_gnome.py
@@ -51,6 +51,7 @@ class GnomeBackendtests(Modeltests):
             name='evolution-data-server',
             homepage='https://git.gnome.org/browse/evolution-data-server/',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -59,6 +60,7 @@ class GnomeBackendtests(Modeltests):
             name='fake',
             homepage='https://pypi.python.org/pypi/repo_manager_fake',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -67,6 +69,7 @@ class GnomeBackendtests(Modeltests):
             name='gnome-control-center',
             homepage='https://git.gnome.org/browse/gnome-control-center/',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()

--- a/anitya/tests/lib/backends/test_gnu.py
+++ b/anitya/tests/lib/backends/test_gnu.py
@@ -22,6 +22,7 @@
 '''
 anitya tests for the custom backend.
 '''
+from __future__ import absolute_import, unicode_literals
 
 __requires__ = ['SQLAlchemy >= 0.7']
 import pkg_resources
@@ -56,6 +57,7 @@ class GnuBackendtests(Modeltests):
             homepage='https://www.gnu.org/software/gnash/',
             version_url='http://ftp.gnu.org/pub/gnu/gnash/',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -64,6 +66,7 @@ class GnuBackendtests(Modeltests):
             name='fake',
             homepage='https://pypi.python.org/pypi/repo_manager_fake',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -73,6 +76,7 @@ class GnuBackendtests(Modeltests):
             homepage='http://subsurface.hohndel.org/',
             version_url='http://subsurface.hohndel.org/downloads/',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()

--- a/anitya/tests/lib/backends/test_google.py
+++ b/anitya/tests/lib/backends/test_google.py
@@ -22,6 +22,7 @@
 '''
 anitya tests for the custom backend.
 '''
+from __future__ import unicode_literals
 
 __requires__ = ['SQLAlchemy >= 0.7']
 import pkg_resources
@@ -55,6 +56,7 @@ class GoogleBackendtests(Modeltests):
             name='arduino',
             homepage='https://code.google.com/p/arduino/',
             backend=BACKEND,
+            version_scheme=model.GENERIC_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -63,6 +65,7 @@ class GoogleBackendtests(Modeltests):
             name='foo',
             homepage='https://code.google.com/p/foo',
             backend=BACKEND,
+            version_scheme=model.GENERIC_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -72,7 +75,7 @@ class GoogleBackendtests(Modeltests):
         """ Test the get_version function of the custom backend. """
         pid = 1
         project = model.Project.get(self.session, pid)
-        exp = '0023'
+        exp = '1.0.5'
         obs = backend.GoogleBackend.get_version(project)
         self.assertEqual(obs, exp)
 
@@ -90,8 +93,9 @@ class GoogleBackendtests(Modeltests):
         pid = 1
         project = model.Project.get(self.session, pid)
         exp = [
-            '1.0', '1.0.1', '1.0.2', '1.0.3', '1.0.4', '1.0.5', '0017',
-            '0018', '0019', '0020', '0021', '0022', '0023']
+            '0017', '0018', '0019', '0020', '0021', '0022', '0023',
+            '1.0', '1.0.1', '1.0.2', '1.0.3', '1.0.4', '1.0.5'
+        ]
         obs = backend.GoogleBackend.get_ordered_versions(project)
         self.assertEqual(obs, exp)
 

--- a/anitya/tests/lib/backends/test_maven.py
+++ b/anitya/tests/lib/backends/test_maven.py
@@ -22,6 +22,7 @@
 '''
 anitya tests for the Maven backend.
 '''
+from __future__ import unicode_literals
 
 __requires__ = ['SQLAlchemy >= 0.7']
 
@@ -48,12 +49,16 @@ class MavenBackendTest(Modeltests):
 
     def assert_plexus_version(self, **kwargs):
         project = model.Project(backend=BACKEND, **kwargs)
+        self.session.add(project)
+        self.session.flush()
         exp = '1.3.8'
         obs = MavenBackend.get_version(project)
         self.assertEqual(obs, exp)
 
     def assert_invalid(self, **kwargs):
         project = model.Project(backend=BACKEND, **kwargs)
+        self.session.add(project)
+        self.session.flush()
         self.assertRaises(
             AnityaPluginException,
             MavenBackend.get_version,
@@ -64,6 +69,7 @@ class MavenBackendTest(Modeltests):
         self.assert_invalid(
             name='foo',
             homepage='http://example.com',
+            version_scheme=model.PEP440_VERSION,
         )
 
     def test_maven_coordinates_in_version_url(self):
@@ -71,12 +77,14 @@ class MavenBackendTest(Modeltests):
             name='plexus-maven-plugin',
             version_url='org.codehaus.plexus:plexus-maven-plugin',
             homepage='http://plexus.codehaus.org/',
+            version_scheme=model.PEP440_VERSION,
         )
 
     def test_maven_coordinates_in_name(self):
         self.assert_plexus_version(
             name='org.codehaus.plexus:plexus-maven-plugin',
             homepage='http://plexus.codehaus.org/',
+            version_scheme=model.PEP440_VERSION,
         )
 
     def test_maven_bad_coordinates(self):
@@ -84,6 +92,7 @@ class MavenBackendTest(Modeltests):
             name='plexus-maven-plugin',
             homepage='http://plexus.codehaus.org/',
             version_url='plexus-maven-plugin',
+            version_scheme=model.PEP440_VERSION,
         )
 
     def test_maven_get_version_by_url(self):
@@ -91,6 +100,7 @@ class MavenBackendTest(Modeltests):
             name='plexus-maven-plugin',
             homepage='http://repo1.maven.org/maven2/'\
                      'org/codehaus/plexus/plexus-maven-plugin/',
+            version_scheme=model.PEP440_VERSION,
         )
 
     def test_maven_get_versions(self):
@@ -99,8 +109,9 @@ class MavenBackendTest(Modeltests):
             name='plexus-maven-plugin',
             version_url='org.codehaus.plexus:plexus-maven-plugin',
             homepage='http://plexus.codehaus.org/',
+            version_scheme=model.PEP440_VERSION,
         )
-        exp = ['1.1-alpha-7', '1.1', '1.1.1', '1.1.2', '1.1.3', '1.2', '1.3',
+        exp = ['1.1a7', '1.1', '1.1.1', '1.1.2', '1.1.3', '1.2', '1.3',
                '1.3.1', '1.3.2', '1.3.3', '1.3.4', '1.3.5', '1.3.6', '1.3.7',
                '1.3.8']
         obs = MavenBackend.get_ordered_versions(project)

--- a/anitya/tests/lib/backends/test_npmjs.py
+++ b/anitya/tests/lib/backends/test_npmjs.py
@@ -51,6 +51,7 @@ class NpmjsBackendtests(Modeltests):
             name='request',
             homepage='https://www.npmjs.org/package/request',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -59,6 +60,7 @@ class NpmjsBackendtests(Modeltests):
             name='foobarasd',
             homepage='https://www.npmjs.org/package/foobarasd',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -67,6 +69,7 @@ class NpmjsBackendtests(Modeltests):
             name='colors',
             homepage='https://www.npmjs.org/package/colors',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -136,7 +139,7 @@ class NpmjsBackendtests(Modeltests):
         project = model.Project.get(self.session, pid)
         exp = [
             u'0.3.0', u'0.5.0', u'0.5.1',
-            u'0.6.0', u'0.6.0-1', u'0.6.1', u'0.6.2',
+            u'0.6.0', u'0.6.0.post1', u'0.6.1', u'0.6.2',
             u'1.0.0', u'1.0.1', u'1.0.2', u'1.0.3',
             u'1.1.0',
         ]

--- a/anitya/tests/lib/backends/test_rubygems.py
+++ b/anitya/tests/lib/backends/test_rubygems.py
@@ -68,7 +68,7 @@ class RubygemsBackendtests(Modeltests):
         """ Test the get_version function of the rubygems backend. """
         pid = 1
         project = model.Project.get(self.session, pid)
-        exp = '1.4.3.0001'
+        exp = '1.4.3.1'
         obs = backend.RubygemsBackend.get_version(project)
         self.assertEqual(obs, exp)
 
@@ -85,7 +85,7 @@ class RubygemsBackendtests(Modeltests):
         """ Test the get_versions function of the rubygems backend. """
         pid = 1
         project = model.Project.get(self.session, pid)
-        exp = ['1.4.3.0001']
+        exp = ['1.4.3.1']
         obs = backend.RubygemsBackend.get_ordered_versions(project)
         self.assertEqual(obs, exp)
 

--- a/anitya/tests/lib/backends/test_sourceforge.py
+++ b/anitya/tests/lib/backends/test_sourceforge.py
@@ -51,6 +51,7 @@ class SourceforgeBackendtests(Modeltests):
             name='filezilla',
             homepage='http://sourceforge.net/projects/filezilla/',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -59,6 +60,7 @@ class SourceforgeBackendtests(Modeltests):
             name='foobar',
             homepage='http://sourceforge.net/projects/foobar',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()
@@ -67,6 +69,7 @@ class SourceforgeBackendtests(Modeltests):
             name='file-folder-ren',
             homepage='http://sourceforge.net/projects/file-folder-ren/',
             backend=BACKEND,
+            version_scheme=model.PEP440_VERSION,
         )
         self.session.add(project)
         self.session.commit()

--- a/anitya/tests/lib/test_events.py
+++ b/anitya/tests/lib/test_events.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions
+# of the GNU General Public License v.2, or (at your option) any later
+# version.  This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.  You
+# should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# Any Red Hat trademarks that are incorporated in the source
+# code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission
+# of Red Hat, Inc.
+"""
+Tests for :mod:`anitya.lib.versions`
+"""
+from __future__ import absolute_import, unicode_literals
+
+from anitya.lib import events, model
+from anitya.tests import base
+
+
+class SetVersionTypesTests(base.Modeltests):
+    """Tests for the :func:`events.set_version_types` function"""
+
+    def test_set_version_types_new(self):
+        """Assert new projects have their version type adjusted"""
+        session = self.session()
+        project = model.Project(
+            name='test',
+            homepage='http://www.example.com/',
+            backend='PyPI',
+            version_scheme=model.PEP440_VERSION,
+        )
+        version = model.ProjectVersion(project=project, version='1.0.0')
+
+        session.add(project)
+        session.add(version)
+
+        self.assertEqual(model.GENERIC_VERSION, version.type)
+        events.set_version_types(session, None, None)
+        self.assertEqual(model.PEP440_VERSION, version.type)
+
+    def test_set_version_types_dirty(self):
+        """Assert dirty projects have their version type adjusted"""
+        session = self.session()
+        project = model.Project(
+            name='test',
+            homepage='http://www.example.com/',
+            backend='PyPI',
+            version_scheme=model.GENERIC_VERSION,
+            ecosystem_name='pypi',
+        )
+        version = model.ProjectVersion(project=project, version='1.0.0')
+        session.add(project)
+        session.add(version)
+        session.commit()
+
+        # Reload the object and modify it so it enters the dirty state
+        project = session.query(model.Project).first()
+        self.assertEqual(model.GENERIC_VERSION, project.versions_obj[0].type)
+        project.version_scheme = model.PEP440_VERSION
+        session.add(project)
+        events.set_version_types(session, None, None)
+        self.assertEqual(model.PEP440_VERSION, project.versions_obj[0].type)

--- a/anitya/tests/lib/test_model.py
+++ b/anitya/tests/lib/test_model.py
@@ -23,23 +23,25 @@
 anitya tests of the model.
 '''
 
-__requires__ = ['SQLAlchemy >= 0.7']
-import pkg_resources
+__requires__ = ['SQLAlchemy >= 0.7']  # noqa
+import pkg_resources  # noqa
 
 import datetime
 import unittest
 
+import mock
 
+from anitya.lib import exceptions
+from anitya.tests import base
 import anitya.lib.model as model
-from anitya.tests.base import Modeltests, create_distro, create_project, create_package
 
 
-class Modeltests(Modeltests):
+class Modeltests(base.Modeltests):
     """ Model tests. """
 
     def test_init_distro(self):
         """ Test the __init__ function of Distro. """
-        create_distro(self.session)
+        base.create_distro(self.session)
         self.assertEqual(2, model.Distro.all(self.session, count=True))
 
         distros = model.Distro.all(self.session)
@@ -48,7 +50,7 @@ class Modeltests(Modeltests):
 
     def test_init_project(self):
         """ Test the __init__ function of Project. """
-        create_project(self.session)
+        base.create_project(self.session)
         self.assertEqual(3, model.Project.all(self.session, count=True))
 
         projects = model.Project.all(self.session)
@@ -58,7 +60,7 @@ class Modeltests(Modeltests):
 
     def test_log_search(self):
         """ Test the Log.search function. """
-        create_project(self.session)
+        base.create_project(self.session)
 
         logs = model.Log.search(self.session)
         self.assertEqual(len(logs), 3)
@@ -91,7 +93,7 @@ class Modeltests(Modeltests):
 
     def test_distro_search(self):
         """ Test the Distro.search function. """
-        create_distro(self.session)
+        base.create_distro(self.session)
 
         logs = model.Distro.search(self.session, '*', count=True)
         self.assertEqual(logs, 2)
@@ -110,9 +112,9 @@ class Modeltests(Modeltests):
 
     def test_packages_by_id(self):
         """ Test the Packages.by_id function. """
-        create_project(self.session)
-        create_distro(self.session)
-        create_package(self.session)
+        base.create_project(self.session)
+        base.create_distro(self.session)
+        base.create_package(self.session)
 
         pkg = model.Packages.by_id(self.session, 1)
         self.assertEqual(pkg.package_name, 'geany')
@@ -120,16 +122,16 @@ class Modeltests(Modeltests):
 
     def test_packages__repr__(self):
         """ Test the Packages.__repr__ function. """
-        create_project(self.session)
-        create_distro(self.session)
-        create_package(self.session)
+        base.create_project(self.session)
+        base.create_distro(self.session)
+        base.create_package(self.session)
 
         pkg = model.Packages.by_id(self.session, 1)
         self.assertEqual(str(pkg), '<Packages(1, Fedora: geany)>')
 
     def test_project_all(self):
         """ Test the Project.all function. """
-        create_project(self.session)
+        base.create_project(self.session)
 
         projects = model.Project.all(self.session, count=True)
         self.assertEqual(projects, 3)
@@ -142,7 +144,7 @@ class Modeltests(Modeltests):
 
     def test_project_search(self):
         """ Test the Project.search function. """
-        create_project(self.session)
+        base.create_project(self.session)
 
         projects = model.Project.search(self.session, '*', count=True)
         self.assertEqual(projects, 3)
@@ -202,6 +204,347 @@ class Modeltests(Modeltests):
             backend='foobar'
         )
 
+
+class ProjectVersionTests(base.Modeltests):
+    """Tests for the :class:`model.ProjectVersion` model."""
+
+    def test_identity_string(self):
+        """Assert the generic version constant is what we expect.
+
+        .. note::
+            If this test starts failing because the constant was modified, you
+            *must* write a migration to change the type column on existing
+            versions.
+        """
+        self.assertEqual('Generic Version', model.GENERIC_VERSION)
+
+    def test_type_identity(self):
+        """Assert the class polymorphic identity is set in the type column."""
+        version = model.ProjectVersion(version='v1.0.0')
+        self.assertEqual(model.GENERIC_VERSION, version.type)
+        self.assertEqual(
+            model.GENERIC_VERSION, model.ProjectVersion.__mapper_args__['polymorphic_identity'])
+
+    def test_str(self):
+        """Assert __str__ calls parse"""
+        version = model.ProjectVersion(version='v1.0.0')
+        self.assertEqual('1.0.0', str(version))
+
+    def test_str_parse_error(self):
+        """Assert __str__ calls parse"""
+        version = model.ProjectVersion(version='v1.0.0')
+        version.parse = mock.Mock(side_effect=exceptions.InvalidVersion('boop'))
+        self.assertEqual('v1.0.0', str(version))
+
+    def test_parse_no_v(self):
+        """Assert parsing a version sans leading 'v' works."""
+        version = model.ProjectVersion(version='1.0.0')
+        self.assertEqual('1.0.0', version.parse())
+
+    def test_parse_leading_v(self):
+        """Assert parsing a version with a leading 'v' works."""
+        version = model.ProjectVersion(version='v1.0.0')
+        self.assertEqual('1.0.0', version.parse())
+
+    def test_parse_odd_version(self):
+        """Assert parsing an odd version works."""
+        version = model.ProjectVersion(version='release_1_0_0')
+        self.assertEqual('release_1_0_0', version.parse())
+
+    def test_parse_v_not_alone(self):
+        """Assert leading 'v' isn't stripped if it's not followed by a number."""
+        version = model.ProjectVersion(version='version1.0.0')
+        self.assertEqual('version1.0.0', version.parse())
+
+    def test_prerelease(self):
+        """Assert prerelease is defined and returns False"""
+        version = model.ProjectVersion(version='v1.0.0')
+        self.assertFalse(version.prerelease())
+
+    def test_postrelease(self):
+        """Assert postrelease is defined and returns False"""
+        version = model.ProjectVersion(version='v1.0.0')
+        self.assertFalse(version.postrelease())
+
+    def test_newer(self):
+        """Assert newer is functional."""
+        version = model.ProjectVersion(version='v1.0.0')
+        newer_version = model.ProjectVersion(version='v2.0.0')
+        self.assertFalse(version.newer(newer_version))
+        self.assertTrue(newer_version.newer(version))
+
+    def test_newer_with_strings(self):
+        """Assert newer handles string arguments"""
+        version = model.ProjectVersion(version='v1.0.0')
+        self.assertFalse(version.newer('v2.0.0'))
+
+    def test_lt(self):
+        """Assert ProjectVersion supports < comparison."""
+        old_version = model.ProjectVersion(version='v1.0.0')
+        new_version = model.ProjectVersion(version='v1.1.0')
+        self.assertTrue(old_version < new_version)
+        self.assertFalse(new_version < old_version)
+
+    def test_le(self):
+        """Assert ProjectVersion supports <= comparison."""
+        old_version = model.ProjectVersion(version='v1.0.0')
+        equally_old_version = model.ProjectVersion(version='v1.0.0')
+        new_version = model.ProjectVersion(version='v1.1.0')
+        self.assertTrue(old_version <= new_version)
+        self.assertTrue(old_version <= equally_old_version)
+        self.assertFalse(new_version <= old_version)
+
+    def test_gt(self):
+        """Assert ProjectVersion supports > comparison."""
+        old_version = model.ProjectVersion(version='v1.0.0')
+        new_version = model.ProjectVersion(version='v1.1.0')
+        self.assertTrue(new_version > old_version)
+        self.assertFalse(old_version > new_version)
+
+    def test_ge(self):
+        """Assert ProjectVersion supports >= comparison."""
+        old_version = model.ProjectVersion(version='v1.0.0')
+        equally_new_version = model.ProjectVersion(version='v1.1.0')
+        new_version = model.ProjectVersion(version='v1.1.0')
+        self.assertFalse(old_version >= new_version)
+        self.assertTrue(new_version >= equally_new_version)
+        self.assertTrue(new_version >= old_version)
+
+    def test_eq(self):
+        """Assert ProjectVersion supports == comparison."""
+        old_version = model.ProjectVersion(version='v1.0.0')
+        new_version = model.ProjectVersion(version='v1.0.0')
+        self.assertTrue(new_version == old_version)
+
+
+class Pep440VersionTests(ProjectVersionTests):
+    """Tests for the :class:`model.Pep440Version` model."""
+
+    def test_identity_string(self):
+        """Assert the PEP-440 version constant is what we expect.
+
+        .. note::
+            If this test starts failing because the constant was modified, you
+            *must* write a migration to change the type column on existing
+            versions.
+        """
+        self.assertEqual('PEP-440', model.PEP440_VERSION)
+
+    def test_type_identity(self):
+        """Assert the class polymorphic identity is set in the type column."""
+        version = model.Pep440Version(version='v1.0.0')
+        self.assertEqual(model.PEP440_VERSION, version.type)
+        self.assertEqual(
+            model.PEP440_VERSION, model.Pep440Version.__mapper_args__['polymorphic_identity'])
+
+    def test_str(self):
+        """Assert __str__ calls parse"""
+        version = model.Pep440Version(version='v1.0.0-alpha1')
+        self.assertEqual('1.0.0a1', str(version))
+
+    def test_str_parse_error(self):
+        """Assert __str__ falls back to the raw version string with parsing fails"""
+        version = model.Pep440Version(version='thisisntaversion')
+        self.assertEqual('thisisntaversion', str(version))
+
+    def test_parse_no_v(self):
+        """Assert parsing a version sans leading 'v' works."""
+        version = model.Pep440Version(version='1.0.0')
+        self.assertEqual('1.0.0', str(version.parse()))
+
+    def test_parse_leading_v(self):
+        """Assert parsing a version with a leading 'v' works."""
+        version = model.Pep440Version(version='v1.0.0')
+        self.assertEqual('1.0.0', str(version.parse()))
+
+    def test_parse_odd_version(self):
+        """Assert parsing an odd version works."""
+        version = model.Pep440Version(version='version1.0.0')
+        self.assertRaises(exceptions.InvalidVersion, version.parse)
+
+    def test_prerelease_false(self):
+        """Assert prerelease is defined and returns False"""
+        version = model.Pep440Version(version='v1.0.0')
+        self.assertFalse(version.prerelease())
+
+    def test_prerelease_true(self):
+        """Assert prerelease is defined and returns False"""
+        version = model.Pep440Version(version='v1.0.0-alpha1')
+        self.assertTrue(version.prerelease())
+
+    def test_postrelease_false(self):
+        """Assert postrelease is defined and returns False"""
+        version = model.Pep440Version(version='v1.0.0')
+        self.assertFalse(version.postrelease())
+
+    def test_postrelease_true(self):
+        """Assert postrelease is defined and returns False"""
+        version = model.Pep440Version(version='v1.0.0.post1')
+        self.assertTrue(version.postrelease())
+
+    def test_newer(self):
+        """Assert newer is functional."""
+        version = model.Pep440Version(version='v1.1.0')
+        newer_version = model.Pep440Version(version='v1.11.0')
+        self.assertFalse(version.newer(newer_version))
+        self.assertTrue(newer_version.newer(version))
+
+    def test_newer_with_strings(self):
+        """Assert newer handles string arguments"""
+        version = model.Pep440Version(version='v1.1.1')
+        self.assertFalse(version.newer('v1.11.0'))
+        self.assertTrue(version.newer('v1.1.0'))
+
+    def test_lt(self):
+        """Assert Pep440Version supports < comparison."""
+        old_version = model.Pep440Version(version='v1.1.0')
+        new_version = model.Pep440Version(version='v1.11.0')
+        self.assertTrue(old_version < new_version)
+        self.assertFalse(new_version < old_version)
+
+    def test_le(self):
+        """Assert Pep440Version supports <= comparison."""
+        old_version = model.Pep440Version(version='v1.0.0')
+        equally_old_version = model.Pep440Version(version='v1.0.0')
+        new_version = model.Pep440Version(version='v1.1.0')
+        self.assertTrue(old_version <= new_version)
+        self.assertTrue(old_version <= equally_old_version)
+        self.assertFalse(new_version <= old_version)
+
+    def test_gt(self):
+        """Assert Pep440Version supports > comparison."""
+        old_version = model.Pep440Version(version='v1.0.0')
+        new_version = model.Pep440Version(version='v1.1.0')
+        self.assertTrue(new_version > old_version)
+        self.assertFalse(old_version > new_version)
+
+    def test_ge(self):
+        """Assert Pep440Version supports >= comparison."""
+        old_version = model.Pep440Version(version='v1.0.0')
+        equally_new_version = model.Pep440Version(version='v1.1.0')
+        new_version = model.Pep440Version(version='v1.1.0')
+        self.assertFalse(old_version >= new_version)
+        self.assertTrue(new_version >= equally_new_version)
+        self.assertTrue(new_version >= old_version)
+
+    def test_eq(self):
+        """Assert Pep440Version supports == comparison."""
+        old_version = model.Pep440Version(version='v1.0.0')
+        new_version = model.Pep440Version(version='v1.0.0')
+        self.assertTrue(new_version == old_version)
+
+
+class SemanticVersionTests(ProjectVersionTests):
+    """Tests for the :class:`model.SemanticVersion` model."""
+
+    def test_identity_string(self):
+        """Assert the PEP-440 version constant is what we expect.
+
+        .. note::
+            If this test starts failing because the constant was modified, you
+            *must* write a migration to change the type column on existing
+            versions.
+        """
+        self.assertEqual('Semantic Version', model.SEMANTIC_VERSION)
+
+    def test_type_identity(self):
+        """Assert the class polymorphic identity is set in the type column."""
+        version = model.SemanticVersion(version='v1.0.0')
+        self.assertEqual(model.SEMANTIC_VERSION, version.type)
+        self.assertEqual(
+            model.SEMANTIC_VERSION, model.SemanticVersion.__mapper_args__['polymorphic_identity'])
+
+    def test_str(self):
+        """Assert __str__ calls parse"""
+        version = model.SemanticVersion(version='v1.0.0-alpha1')
+        self.assertEqual('1.0.0-alpha1', str(version))
+
+    def test_str_parse_error(self):
+        """Assert __str__ falls back to the raw version string with parsing fails"""
+        version = model.SemanticVersion(version='thisisntaversion')
+        self.assertEqual('thisisntaversion', str(version))
+
+    def test_parse_no_v(self):
+        """Assert parsing a version sans leading 'v' works."""
+        version = model.SemanticVersion(version='1.0.0')
+        self.assertEqual('1.0.0', str(version.parse()))
+
+    def test_parse_leading_v(self):
+        """Assert parsing a version with a leading 'v' works."""
+        version = model.SemanticVersion(version='v1.0.0')
+        self.assertEqual('1.0.0', str(version.parse()))
+
+    def test_parse_odd_version(self):
+        """Assert parsing an odd version raises an exception."""
+        version = model.SemanticVersion(version='version1.0.0')
+        self.assertRaises(exceptions.InvalidVersion, version.parse)
+
+    def test_prerelease_false(self):
+        """Assert prerelease is defined and returns False"""
+        version = model.SemanticVersion(version='v1.0.0')
+        self.assertFalse(version.prerelease())
+
+    def test_prerelease_true(self):
+        """Assert prerelease is defined and returns False"""
+        version = model.SemanticVersion(version='v1.0.0-alpha1')
+        self.assertTrue(version.prerelease())
+
+    def test_postrelease_false(self):
+        """Assert postrelease is defined and returns False"""
+        version = model.SemanticVersion(version='v1.0.0-post1')
+        self.assertFalse(version.postrelease())
+
+    def test_newer(self):
+        """Assert newer is functional."""
+        version = model.SemanticVersion(version='v1.1.0')
+        newer_version = model.SemanticVersion(version='v1.11.0')
+        self.assertFalse(version.newer(newer_version))
+        self.assertTrue(newer_version.newer(version))
+
+    def test_newer_with_strings(self):
+        """Assert newer handles string arguments"""
+        version = model.SemanticVersion(version='v1.1.1')
+        self.assertFalse(version.newer('v1.11.0'))
+        self.assertTrue(version.newer('v1.1.0'))
+
+    def test_lt(self):
+        """Assert SemanticVersion supports < comparison."""
+        old_version = model.SemanticVersion(version='v1.1.0')
+        new_version = model.SemanticVersion(version='v1.11.0')
+        self.assertTrue(old_version < new_version)
+        self.assertFalse(new_version < old_version)
+
+    def test_le(self):
+        """Assert SemanticVersion supports <= comparison."""
+        old_version = model.SemanticVersion(version='v1.0.0')
+        equally_old_version = model.SemanticVersion(version='v1.0.0')
+        new_version = model.SemanticVersion(version='v1.1.0')
+        self.assertTrue(old_version <= new_version)
+        self.assertTrue(old_version <= equally_old_version)
+        self.assertFalse(new_version <= old_version)
+
+    def test_gt(self):
+        """Assert SemanticVersion supports > comparison."""
+        old_version = model.SemanticVersion(version='v1.0.0')
+        new_version = model.SemanticVersion(version='v1.1.0')
+        self.assertTrue(new_version > old_version)
+        self.assertFalse(old_version > new_version)
+
+    def test_ge(self):
+        """Assert SemanticVersion supports >= comparison."""
+        old_version = model.SemanticVersion(version='v1.0.0')
+        equally_new_version = model.SemanticVersion(version='v1.1.0')
+        new_version = model.SemanticVersion(version='v1.1.0')
+        self.assertFalse(old_version >= new_version)
+        self.assertTrue(new_version >= equally_new_version)
+        self.assertTrue(new_version >= old_version)
+
+    def test_eq(self):
+        """Assert SemanticVersion supports == comparison."""
+        old_version = model.SemanticVersion(version='v1.0.0')
+        new_version = model.SemanticVersion(version='v1.0.0')
+        self.assertTrue(new_version == old_version)
+
+
 if __name__ == '__main__':
-    SUITE = unittest.TestLoader().loadTestsFromTestCase(Modeltests)
-    unittest.TextTestRunner(verbosity=2).run(SUITE)
+    unittest.main(verbosity=2)

--- a/anitya/tests/test_flask.py
+++ b/anitya/tests/test_flask.py
@@ -80,6 +80,7 @@ class NewProjectTests(Modeltests):
             data = {
                 'csrf_token': csrf_token,
                 'name': 'repo_manager',
+                'version_scheme': 'PEP-440',
                 'homepage': 'https://pypi.python.org/pypi/repo_manager',
                 'backend': 'PyPI',
             }
@@ -135,6 +136,7 @@ class NewProjectTests(Modeltests):
             data = {
                 'csrf_token': csrf_token,
                 'name': 'requests',
+                'version_scheme': 'PEP-440',
                 'homepage': 'https://pypi.python.org/pypi/requests',
                 'backend': 'PyPI',
             }
@@ -201,6 +203,7 @@ class NewProjectTests(Modeltests):
                 'name': 'repo_manager',
                 'homepage': 'https://pypi.python.org/pypi/repo_manager',
                 'backend': 'PyPI',
+                'version_scheme': 'PEP-440',
                 'csrf_token': output.data.split(
                     b'name="csrf_token" type="hidden" value="')[1].split(b'">')[0],
             }

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -539,6 +539,7 @@ def new_project():
                 regex=form.regex.data.strip() or None,
                 user_id=flask.g.auth.openid,
                 check_release=form.check_release.data,
+                version_scheme=form.version_scheme.data,
             )
             SESSION.commit()
 
@@ -607,6 +608,7 @@ def edit_project(project_id):
                 insecure=form.insecure.data,
                 user_id=flask.g.auth.openid,
                 check_release=form.check_release.data,
+                version_scheme=form.version_scheme.data,
             )
             flask.flash('Project edited')
             flask.session['justedit'] = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,10 @@ flask
 flask-openid
 flask-wtf
 markupsafe
+packaging
 python-openid; python_version < '3.0'
 python3-openid; python_version >= '3.0'
+semantic_version
 sqlalchemy
 # https://github.com/ironfroggy/straight.plugin/issues/17#issuecomment-41466275
 straight.plugin==1.4.0-post-1


### PR DESCRIPTION
I'm _really_ sorry about the size of this patch. I didn't mean it to get this big, but I'm not sure anything can be broken out of the commit.

This patch provides select-able versions for projects by using
SQLAlchemy's single table inheritance feature. Each version type is
implemented as a sub-class of the ``ProjectVersion`` model and
SQLAlchemy creates the correct Python class via the new ``type`` column
in the ``ProjectVersion`` table. I have implemented two version
comparison schemes:

* PEP-440 via the [packaging](https://github.com/pypa/packaging) library.
  This version is very flexible since it has a LegacyVersion class that
  parses everything. It should probably be the default version for
  projects.

* Semantic version scheme via
  [semanticversion](http://pythonhosted.org/semantic_version/).

It would be good to also have a calendar version scheme, but this PR is
already much larger than I wanted.

Many of the tests had to be adjusted since the way versions are sorted
has been altered.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>