### PR TITLE
Update tox.ini and setup Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: false
+language: python
+install:
+  - pip install -U setuptools pip
+  # We need this until the pkg_resources statement in setup.py is pushed into
+  # a downstream patch.
+  - pip install sqlalchemy jinja2
+  - pip install tox
+script:
+  - tox
+
+env:
+  global:
+    - PYTHONWARNINGS=always::DeprecationWarning
+  matrix:
+    - TOXENV=lint
+    - TOXENV=docs
+    - TOXENV: py27
+matrix:
+  include:
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,9 @@
 [tox]
-envlist = py26,py27,py35,lint,docs
-skip_missing_interpreters = True
+envlist = py27,py35,py36,lint,docs
 
 [testenv]
-# The rpm bindings aren't available via PyPI
-sitepackages = True
-# Need to ensure all PyPI published dependencies are installed in the venv
-install_command = pip install --ignore-installed {opts} {packages}
 deps =
+    -rrequirements.txt
     -rtest_requirements.txt
 # tox doesn't appear to understand environment markers properly yet,
 # so we use conditional commands to work around that
@@ -29,9 +25,10 @@ deps =
     -rrequirements.txt
 whitelist_externals =
     mkdir
-    sphinx-build
+    rm
 commands=
     mkdir -p _static
+    rm -rf _build
     sphinx-build -W -b html -d {envtmpdir}/doctrees .  _build/html
 
 [testenv:lint]


### PR DESCRIPTION
Note: This depends on #448 getting merged

This updates the tox.ini file and creates a ``.travis.yml`` file for CI builds. [Here's a passing build from a branch based on #448](https://travis-ci.org/jeremycline/anitya/builds/211108058).

One thing I'd like to propose as part of this is dropping Python 2.6 support. I wouldn't be opposed to dropping 2.7 support in the near future, but release-monitoring.org is still using 2.7 so I'm not quite ready for that, yet.