### PR TITLE
Remove the ecosystems and backends tables

### DIFF
--- a/alembic/versions/b9201d816075_remove_the_backends_and_ecosystems_.py
+++ b/alembic/versions/b9201d816075_remove_the_backends_and_ecosystems_.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""Remove the backends and ecosystems tables
+
+Revision ID: b9201d816075
+Revises: 9c29da0af3af
+Create Date: 2017-03-22 18:46:06.281100
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+from anitya.lib import plugins
+
+# revision identifiers, used by Alembic.
+revision = 'b9201d816075'
+down_revision = '9c29da0af3af'
+
+
+def upgrade():
+    """Drop the Backends and Ecosystems tables and remove foreign keys."""
+    op.drop_constraint(u'projects_backend_fkey', 'projects', type_='foreignkey')
+    op.drop_constraint(u'FK_ECOSYSTEM_FOR_PROJECT', 'projects', type_='foreignkey')
+    op.create_index(
+        op.f('ix_projects_ecosystem_name'), 'projects', ['ecosystem_name'], unique=False)
+    op.drop_table('ecosystems')
+    op.drop_table('backends')
+
+
+def downgrade():
+    """Restore the Backends and Ecosystems tables."""
+    op.drop_index(op.f('ix_projects_ecosystem_name'), table_name='projects')
+    op.create_table(
+        'backends',
+        sa.Column('name', sa.VARCHAR(length=200), autoincrement=False, nullable=False),
+        sa.PrimaryKeyConstraint('name', name=u'backends_pkey'),
+        postgresql_ignore_search_path=False
+    )
+    # We have to populate the backends table before we can add the ecosystems
+    # table with its foreign key constraint.
+    for backend in plugins.BACKEND_PLUGINS.get_plugins():
+        op.execute("INSERT INTO backends (name) VALUES ('{}');".format(backend.name))
+
+    op.create_table(
+        'ecosystems',
+        sa.Column('name', sa.VARCHAR(length=200), autoincrement=False, nullable=False),
+        sa.Column(
+            'default_backend_name',
+            sa.VARCHAR(length=200),
+            autoincrement=False,
+            nullable=True
+        ),
+        sa.ForeignKeyConstraint(
+            ['default_backend_name'],
+            [u'backends.name'],
+            name=u'ecosystems_default_backend_name_fkey',
+            onupdate=u'CASCADE',
+            ondelete=u'CASCADE'
+        ),
+        sa.PrimaryKeyConstraint('name', name=u'ecosystems_pkey'),
+        sa.UniqueConstraint('default_backend_name', name=u'ecosystems_default_backend_name_key')
+    )
+    for ecosystem in plugins.ECOSYSTEM_PLUGINS.get_plugins():
+        op.execute("""
+            INSERT INTO ecosystems (name, default_backend_name)
+            VALUES ('{name}', '{default}');""".format(
+                name=ecosystem.name, default=ecosystem.default_backend))
+
+    op.create_foreign_key(
+        u'FK_ECOSYSTEM_FOR_PROJECT',
+        'projects',
+        'ecosystems',
+        ['ecosystem_name'],
+        ['name'],
+        onupdate=u'CASCADE',
+        ondelete=u'SET NULL'
+    )
+    op.create_foreign_key(
+        u'projects_backend_fkey',
+        'projects', 'backends',
+        ['backend'],
+        ['name'],
+        onupdate=u'CASCADE',
+        ondelete=u'CASCADE'
+    )

--- a/anitya/lib/__init__.py
+++ b/anitya/lib/__init__.py
@@ -79,14 +79,15 @@ def create_project(
 
     """
     # Set the ecosystem if there's one associated with the given backend
-    backend_ref = anitya.lib.model.Backend.by_name(session, name=backend)
-    ecosystem_ref = backend_ref.default_ecosystem
+    ecosystems = [e for e in anitya.lib.plugins.ECOSYSTEM_PLUGINS.get_plugins()
+                  if e.default_backend == backend]
+    ecosystem_name = ecosystems[0].name if len(ecosystems) == 1 else None
 
     project = anitya.lib.model.Project(
         name=name,
         homepage=homepage,
         backend=backend,
-        ecosystem=ecosystem_ref,
+        ecosystem_name=ecosystem_name,
         version_url=version_url,
         regex=regex,
         version_prefix=version_prefix,

--- a/anitya/tests/lib/test_plugins.py
+++ b/anitya/tests/lib/test_plugins.py
@@ -54,16 +54,6 @@ EXPECTED_ECOSYSTEMS = {
 class Pluginstests(Modeltests):
     """ Plugins tests. """
 
-    def _check_db_contents(self, expected_backends, expected_ecosystems):
-        backends = model.Backend.all(self.session)
-        backend_names_from_db = sorted(backend.name for backend in backends)
-        self.assertEqual(sorted(backend_names_from_db), sorted(expected_backends))
-        ecosystems = model.Ecosystem.all(self.session)
-        ecosystems_from_db = dict((eco.name, eco.default_backend.name)
-                                  for eco in ecosystems)
-        self.assertEqual(ecosystems_from_db, expected_ecosystems)
-
-
     def test_load_all_plugins(self):
         """ Test the plugins.load_all_plugins function. """
         all_plugins = plugins.load_all_plugins(self.session)
@@ -77,16 +67,12 @@ class Pluginstests(Modeltests):
                               for plugin in ecosystem_plugins)
         self.assertEqual(ecosystems, EXPECTED_ECOSYSTEMS)
 
-        self._check_db_contents(EXPECTED_BACKENDS, EXPECTED_ECOSYSTEMS)
-
     def test_load_plugins(self):
         """ Test the plugins.load_plugins function. """
         backend_plugins = plugins.load_plugins(self.session)
         self.assertEqual(len(backend_plugins), len(EXPECTED_BACKENDS))
         backend_names = sorted(plugin.name for plugin in backend_plugins)
         self.assertEqual(sorted(backend_names), sorted(EXPECTED_BACKENDS))
-
-        self._check_db_contents(EXPECTED_BACKENDS, EXPECTED_ECOSYSTEMS)
 
     def test_plugins_get_plugin_names(self):
         """ Test the plugins.get_plugin_names function. """


### PR DESCRIPTION
These tables are in the database for historical reasons, but they don't
need to remain there. This removes the tables with a migration, removes
the models, and adjusts the code that used the models previously.

This came up in #332 since I found myself writing a migration involving ecosystems and wondering what the point was.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>