### PR TITLE
 Issue #460: Handling rpm library being missing

### DIFF
--- a/anitya/lib/backends/__init__.py
+++ b/anitya/lib/backends/__init__.py
@@ -64,7 +64,7 @@ except ImportError:
                 yield (1, int(subfield.group('num')))
 
     def _compare_rpm_field(lhs, rhs):
-        # Short circuit for exact matches (include both being None)
+        # Short circuit for exact matches (including both being None)
         if lhs == rhs:
             return 0
         # Otherwise assume both inputs are strings
@@ -84,7 +84,6 @@ except ImportError:
             return -1 if lhs_sf < rhs_sf else 1
         # No relevant differences found between LHS and RHS
         return 0
-
 
     def _compare_rpm_labels(lhs, rhs):
         lhs_epoch, lhs_version, lhs_release = lhs

--- a/anitya/lib/backends/__init__.py
+++ b/anitya/lib/backends/__init__.py
@@ -22,6 +22,81 @@ import anitya.app
 from anitya.lib.exceptions import AnityaPluginException
 import six
 
+try:
+    from rpm import labelCompare as _compare_rpm_labels
+except ImportError:
+    # Emulate RPM field comparisons as described in
+    # http://stackoverflow.com/questions/3206319/how-do-i-compare-rpm-versions-in-python/3206477#3206477
+    #
+    # * Search each string for alphabetic fields [a-zA-Z]+ and
+    #   numeric fields [0-9]+ separated by junk [^a-zA-Z0-9]*.
+    # * Successive fields in each string are compared to each other.
+    # * Alphabetic sections are compared lexicographically, and the
+    #   numeric sections are compared numerically.
+    # * In the case of a mismatch where one field is numeric and one is
+    #   alphabetic, the numeric field is always considered greater (newer).
+    # * In the case where one string runs out of fields, the other is always
+    #   considered greater (newer).
+
+    import warnings
+    warnings.warn("Failed to import 'rpm', emulating RPM label comparisons")
+
+    try:
+        from itertools import zip_longest
+    except ImportError:
+        from itertools import izip_longest as zip_longest
+
+    _subfield_pattern = re.compile(
+        r'(?P<junk>[^a-zA-Z0-9]*)((?P<text>[a-zA-Z]+)|(?P<num>[0-9]+))'
+    )
+
+    def _iter_rpm_subfields(field):
+        """Yield subfields as 2-tuples that sort in the desired order
+
+        Text subfields are yielded as (0, text_value)
+        Numeric subfields are yielded as (1, int_value)
+        """
+        for subfield in _subfield_pattern.finditer(field):
+            text = subfield.group('text')
+            if text is not None:
+                yield (0, text)
+            else:
+                yield (1, int(subfield.group('num')))
+
+    def _compare_rpm_field(lhs, rhs):
+        # Short circuit for exact matches (include both being None)
+        if lhs == rhs:
+            return 0
+        # Otherwise assume both inputs are strings
+        lhs_subfields = _iter_rpm_subfields(lhs)
+        rhs_subfields = _iter_rpm_subfields(rhs)
+        for lhs_sf, rhs_sf in zip_longest(lhs_subfields, rhs_subfields):
+            if lhs_sf == rhs_sf:
+                # When both subfields are the same, move to next subfield
+                continue
+            if lhs_sf is None:
+                # Fewer subfields in LHS, so it's less than/older than RHS
+                return -1
+            if rhs_sf is None:
+                # More subfields in LHS, so it's greater than/newer than RHS
+                return 1
+            # Found a differing subfield, so it determines the relative order
+            return -1 if lhs_sf < rhs_sf else 1
+        # No relevant differences found between LHS and RHS
+        return 0
+
+
+    def _compare_rpm_labels(lhs, rhs):
+        lhs_epoch, lhs_version, lhs_release = lhs
+        rhs_epoch, rhs_version, rhs_release = rhs
+        result = _compare_rpm_field(lhs_epoch, rhs_epoch)
+        if result:
+            return result
+        result = _compare_rpm_field(lhs_version, rhs_version)
+        if result:
+            return result
+        return _compare_rpm_field(lhs_release, rhs_release)
+
 
 REGEX = '%(name)s(?:[-_]?(?:minsrc|src|source))?[-_]([^-/_\s]+?)(?i)(?:[-_]'\
         '(?:minsrc|src|source|asc))?\.(?:tar|t[bglx]z|tbz2|zip)'
@@ -129,8 +204,7 @@ def split_rc(version):
 
 
 def rpm_cmp(v1, v2):
-    import rpm
-    diff = rpm.labelCompare((None, v1, None), (None, v2, None))
+    diff = _compare_rpm_labels((None, v1, None), (None, v2, None))
     return diff
 
 

--- a/anitya/tests/lib/backends/tests.py
+++ b/anitya/tests/lib/backends/tests.py
@@ -33,6 +33,18 @@ from anitya.lib.exceptions import AnityaPluginException
 import anitya
 
 
+class TestRpmCmp(unittest.TestCase):
+
+    def test_equal_version(self):
+        self.assertEqual(0, backends.rpm_cmp('1.2.0-1.fc25', '1.2.0-1.fc25'))
+
+    def test_larger_version(self):
+        self.assertEqual(1, backends.rpm_cmp('1.2.0-1.fc25', '1.1.0-3.fc25'))
+
+    def test_smaller_version(self):
+        self.assertEqual(-1, backends.rpm_cmp('1.1.0-3.fc25', '1.2.0-1.fc25'))
+
+
 class BaseBackendTests(unittest.TestCase):
 
     def setUp(self):

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
 recreate=True
 commands =
     - pip uninstall -y python-openid python3-openid
-    py26,py27: pip install python-openid
+    py27: pip install python-openid
     py35: pip install python3-openid
     nosetests
 


### PR DESCRIPTION
RPM bindings are not available when running in an
isolated virtual environment, in a non-system
Python installation, or on a non-RPM distro.

This adds a fallback implementation of
`rpm.labelCompare` for use when the
system library is unavailable.