### PR TITLE
Stop using pkg_resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ sudo: false
 language: python
 install:
   - pip install -U setuptools pip
-  # We need this until the pkg_resources statement in setup.py is pushed into
-  # a downstream patch.
-  - pip install sqlalchemy jinja2
   - pip install tox
 script:
   - tox

--- a/anitya/lib/__init__.py
+++ b/anitya/lib/__init__.py
@@ -11,9 +11,6 @@ anitya internal library.
 
 import logging
 
-__requires__ = ['SQLAlchemy >= 0.7']  # NOQA
-import pkg_resources  # NOQA
-
 import sqlalchemy as sa
 from sqlalchemy import create_engine
 from sqlalchemy.exc import SQLAlchemyError

--- a/anitya/lib/model.py
+++ b/anitya/lib/model.py
@@ -24,9 +24,6 @@ import datetime
 import logging
 import time
 
-__requires__ = ['SQLAlchemy >= 0.7']  # NOQA
-import pkg_resources  # NOQA
-
 import sqlalchemy as sa
 from sqlalchemy.orm import validates
 from sqlalchemy.ext.declarative import declarative_base

--- a/anitya/tests/lib/backends/test_cpan.py
+++ b/anitya/tests/lib/backends/test_cpan.py
@@ -23,9 +23,6 @@
 anitya tests for the custom backend.
 '''
 
-__requires__ = ['SQLAlchemy >= 0.7']
-import pkg_resources
-
 import json
 import unittest
 

--- a/anitya/tests/lib/backends/test_drupal6.py
+++ b/anitya/tests/lib/backends/test_drupal6.py
@@ -23,9 +23,6 @@
 anitya tests for the custom backend.
 '''
 
-__requires__ = ['SQLAlchemy >= 0.7']
-import pkg_resources
-
 import json
 import unittest
 

--- a/anitya/tests/lib/backends/test_drupal7.py
+++ b/anitya/tests/lib/backends/test_drupal7.py
@@ -23,9 +23,6 @@
 anitya tests for the custom backend.
 '''
 
-__requires__ = ['SQLAlchemy >= 0.7']
-import pkg_resources
-
 import json
 import unittest
 

--- a/anitya/tests/lib/backends/test_freshmeat.py
+++ b/anitya/tests/lib/backends/test_freshmeat.py
@@ -23,9 +23,6 @@
 anitya tests for the custom backend.
 '''
 
-__requires__ = ['SQLAlchemy >= 0.7']
-import pkg_resources
-
 import json
 import unittest
 

--- a/anitya/tests/lib/backends/test_gnu.py
+++ b/anitya/tests/lib/backends/test_gnu.py
@@ -23,9 +23,6 @@
 anitya tests for the custom backend.
 '''
 
-__requires__ = ['SQLAlchemy >= 0.7']
-import pkg_resources
-
 import json
 import unittest
 

--- a/anitya/tests/lib/backends/test_google.py
+++ b/anitya/tests/lib/backends/test_google.py
@@ -23,9 +23,6 @@
 anitya tests for the custom backend.
 '''
 
-__requires__ = ['SQLAlchemy >= 0.7']
-import pkg_resources
-
 import json
 import unittest
 

--- a/anitya/tests/lib/backends/test_hackage.py
+++ b/anitya/tests/lib/backends/test_hackage.py
@@ -23,9 +23,6 @@
 anitya tests for the custom backend.
 '''
 
-__requires__ = ['SQLAlchemy >= 0.7']
-import pkg_resources
-
 import json
 import unittest
 

--- a/anitya/tests/lib/backends/test_launchpad.py
+++ b/anitya/tests/lib/backends/test_launchpad.py
@@ -23,9 +23,6 @@
 anitya tests for the custom backend.
 '''
 
-__requires__ = ['SQLAlchemy >= 0.7']
-import pkg_resources
-
 import json
 import unittest
 

--- a/anitya/tests/lib/backends/test_maven.py
+++ b/anitya/tests/lib/backends/test_maven.py
@@ -23,8 +23,6 @@
 anitya tests for the Maven backend.
 '''
 
-__requires__ = ['SQLAlchemy >= 0.7']
-
 import unittest
 
 from anitya.lib.backends.maven import MavenBackend

--- a/anitya/tests/lib/backends/test_pagure.py
+++ b/anitya/tests/lib/backends/test_pagure.py
@@ -23,9 +23,6 @@
 anitya tests for the pagure backend.
 '''
 
-__requires__ = ['SQLAlchemy >= 0.7']
-import pkg_resources
-
 import json
 import unittest
 

--- a/anitya/tests/lib/backends/test_pear.py
+++ b/anitya/tests/lib/backends/test_pear.py
@@ -23,9 +23,6 @@
 anitya tests for the custom backend.
 '''
 
-__requires__ = ['SQLAlchemy >= 0.7']
-import pkg_resources
-
 import json
 import unittest
 

--- a/anitya/tests/lib/backends/test_pecl.py
+++ b/anitya/tests/lib/backends/test_pecl.py
@@ -23,9 +23,6 @@
 anitya tests for the custom backend.
 '''
 
-__requires__ = ['SQLAlchemy >= 0.7']
-import pkg_resources
-
 import json
 import unittest
 

--- a/anitya/tests/lib/backends/test_pypi.py
+++ b/anitya/tests/lib/backends/test_pypi.py
@@ -23,9 +23,6 @@
 anitya tests for the pypi backend.
 '''
 
-__requires__ = ['SQLAlchemy >= 0.7']
-import pkg_resources
-
 import json
 import unittest
 

--- a/anitya/tests/lib/backends/test_stackage.py
+++ b/anitya/tests/lib/backends/test_stackage.py
@@ -23,9 +23,6 @@
 anitya tests for the custom backend.
 '''
 
-__requires__ = ['SQLAlchemy >= 0.7']
-import pkg_resources
-
 import json
 import unittest
 

--- a/anitya/tests/lib/test_anityalib.py
+++ b/anitya/tests/lib/test_anityalib.py
@@ -22,9 +22,6 @@
 '''
 anitya tests for the anitya.lib module.
 '''
-__requires__ = ['SQLAlchemy >= 0.7']
-import pkg_resources
-
 import unittest
 
 import anitya.lib

--- a/anitya/tests/lib/test_model.py
+++ b/anitya/tests/lib/test_model.py
@@ -23,9 +23,6 @@
 anitya tests of the model.
 '''
 
-__requires__ = ['SQLAlchemy >= 0.7']
-import pkg_resources
-
 import datetime
 import unittest
 

--- a/anitya/tests/lib/test_plugins.py
+++ b/anitya/tests/lib/test_plugins.py
@@ -23,9 +23,6 @@
 anitya tests of the plugins.
 '''
 
-__requires__ = ['SQLAlchemy >= 0.7']
-import pkg_resources
-
 import datetime
 import unittest
 

--- a/anitya/tests/test_distro.py
+++ b/anitya/tests/test_distro.py
@@ -23,9 +23,6 @@
 anitya tests for the Distro object.
 '''
 
-__requires__ = ['SQLAlchemy >= 0.7']
-import pkg_resources
-
 import unittest
 import sys
 import os

--- a/anitya/tests/test_flask.py
+++ b/anitya/tests/test_flask.py
@@ -23,9 +23,6 @@
 anitya tests for the flask application.
 '''
 
-__requires__ = ['SQLAlchemy >= 0.8']  # NOQA
-import pkg_resources  # NOQA
-
 import unittest
 
 import mock

--- a/anitya/tests/test_flask_admin.py
+++ b/anitya/tests/test_flask_admin.py
@@ -23,9 +23,6 @@
 anitya tests for the flask application.
 '''
 
-__requires__ = ['SQLAlchemy >= 0.8']
-import pkg_resources
-
 import datetime
 import json
 import unittest

--- a/anitya/tests/test_flask_api.py
+++ b/anitya/tests/test_flask_api.py
@@ -23,9 +23,6 @@
 anitya tests for the flask API.
 '''
 
-__requires__ = ['SQLAlchemy >= 0.7']
-import pkg_resources
-
 import json
 import unittest
 import sys

--- a/anitya/tests/test_flask_api_v2.py
+++ b/anitya/tests/test_flask_api_v2.py
@@ -23,9 +23,6 @@
 Tests for the Flask-RESTful based v2 API
 '''
 
-__requires__ = ['SQLAlchemy >= 0.7']
-import pkg_resources
-
 import json
 import os.path
 

--- a/anitya/tests/test_project.py
+++ b/anitya/tests/test_project.py
@@ -23,9 +23,6 @@
 anitya tests for the Project object.
 '''
 
-__requires__ = ['SQLAlchemy >= 0.7']
-import pkg_resources
-
 import unittest
 
 import anitya.lib.model as model

--- a/createdb.py
+++ b/createdb.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 #-*- coding: utf-8 -*-
 
-## These two lines are needed to run on EL6
-__requires__ = ['SQLAlchemy >= 0.7', 'jinja2 >= 2.4']
-import pkg_resources
-
 from anitya.app import APP
 import anitya.lib
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,10 +10,11 @@ flask-openid
 flask-oidc >= 1.1.1
 flask-restful
 flask-wtf
+jinja2 >= 2.4
 markupsafe
 python-openid; python_version < '3.0'
 python3-openid; python_version >= '3.0'
-sqlalchemy
+sqlalchemy >= 0.9
 # https://github.com/ironfroggy/straight.plugin/issues/17#issuecomment-41466275
 straight.plugin==1.4.0-post-1
 pytoml

--- a/runserver.py
+++ b/runserver.py
@@ -2,10 +2,6 @@
 # -*- coding: utf-8 -*-
 """ The flask application """
 
-## These two lines are needed to run on EL6
-__requires__ = ['SQLAlchemy >= 0.7', 'jinja2 >= 2.4']
-import pkg_resources
-
 import argparse
 import sys
 import os

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,6 @@
 Setup script
 """
 
-# Required to build on EL6
-__requires__ = ['SQLAlchemy >= 0.7', 'jinja2 >= 2.4']
-import pkg_resources
-
 from setuptools import setup, find_packages
 import re
 


### PR DESCRIPTION
This drops all the various pkg_resources statements. Firstly, we no
longer support Python 2.6 and the statements were to support installing
Anitya on EL6 which no longer works since we don't support 2.6.

Secondly, this is a downstream packaging concern that I would prefer to
carry as a patch. It causes all sorts of problems. For example, having
it in the setup.py means you must have SQLAlchemy installed before you
can install Anitya which is annoying.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>