### PR TITLE
Add pagination to the GET api/v2/projects/ endpoint

### DIFF
--- a/anitya/app.py
+++ b/anitya/app.py
@@ -20,6 +20,7 @@ from bunch import Bunch
 from flask_restful import Api
 
 from anitya.config import config as anitya_config
+from anitya.lib.model import Session as SESSION, initialize as initialize_db
 import anitya.lib
 import anitya.authentication
 import anitya.mail_logging
@@ -30,6 +31,8 @@ __version__ = '0.11.0'
 # Create the application.
 APP = flask.Flask(__name__)
 APP.config.update(anitya_config)
+initialize_db(anitya_config)
+
 
 if APP.config['EMAIL_ERRORS']:
     # If email logging is configured, set up the anitya logger with an email
@@ -45,9 +48,6 @@ anitya.authentication.configure_openid(APP)
 
 # Set up the Flask Restful API endpoints
 APP.api = Api(APP)
-
-SESSION = anitya.lib.init(
-    APP.config['DB_URL'], debug=False, create=False)
 
 
 @APP.template_filter('format_examples')

--- a/anitya/config.py
+++ b/anitya/config.py
@@ -21,6 +21,7 @@
 
 from datetime import timedelta
 import logging
+import logging.config
 import os
 
 import pytoml

--- a/anitya/lib/__init__.py
+++ b/anitya/lib/__init__.py
@@ -29,6 +29,9 @@ def init(db_url, alembic_ini=None, debug=False, create=False):
     """ Create the tables in the database using the information from the
     url obtained.
 
+    :deprecated: This function is deprecated as of Anitya 0.12. Use the
+                 scoped session in :mod:`anitya.lib.model`
+
     :arg db_url, URL used to connect to the database. The URL contains
         information with regards to the database engine, the host to
         connect to, the user and password and the database name.

--- a/anitya/tests/base.py
+++ b/anitya/tests/base.py
@@ -27,6 +27,7 @@ import unittest
 import os
 
 import vcr
+import mock
 
 import anitya.lib
 import anitya.lib.model as model
@@ -79,6 +80,10 @@ class Modeltests(unittest.TestCase):
             if os.path.exists(dbfile):
                 os.unlink(dbfile)
         self.session = anitya.lib.init(DB_PATH, create=True, debug=False)
+        mock_query = mock.patch.object(
+            model.BASE, 'query', self.session.query_property(query_cls=model.BaseQuery))
+        mock_query.start()
+        self.addCleanup(mock_query.stop)
 
         anitya.lib.plugins.load_plugins(self.session)
         cwd = os.path.dirname(os.path.realpath(__file__))

--- a/anitya/tests/lib/test_model.py
+++ b/anitya/tests/lib/test_model.py
@@ -56,6 +56,95 @@ class InitalizeTests(unittest.TestCase):
         self.assertEqual('connect', mock_listen.call_args_list[0][0][1])
 
 
+class BaseQueryPaginateTests(Modeltests):
+    """Tests for the BaseQuery queries."""
+
+    def setUp(self):
+        super(BaseQueryPaginateTests, self).setUp()
+        self.query = model.BaseQuery(model.Project, session=self.session())
+
+    def test_defaults(self):
+        """Assert paginate defaults to the first page and 25 items."""
+        create_project(self.session)
+        page = self.query.paginate()
+        self.assertEqual(1, page.page)
+        self.assertEqual(3, page.total_items)
+        self.assertEqual(25, page.items_per_page)
+        # Default ordering is just by id
+        self.assertEqual(page.items[0].name, 'geany')
+        self.assertEqual(page.items[1].name, 'subsurface')
+        self.assertEqual(page.items[2].name, 'R2spec')
+
+    def test_multiple_pages(self):
+        """Assert multiple pages work with pagination."""
+        create_project(self.session)
+        page = self.query.paginate(items_per_page=2)
+        page2 = self.query.paginate(page=2, items_per_page=2)
+        self.assertEqual(1, page.page)
+        self.assertEqual(3, page.total_items)
+        self.assertEqual(2, page.items_per_page)
+        self.assertEqual(page.items[0].name, 'geany')
+        self.assertEqual(page.items[1].name, 'subsurface')
+
+        self.assertEqual(2, page2.page)
+        self.assertEqual(3, page2.total_items)
+        self.assertEqual(2, page2.items_per_page)
+        self.assertEqual(page2.items[0].name, 'R2spec')
+
+    def test_no_results(self):
+        """Assert an empty page is returned when page * items_per_page > total_items."""
+        create_project(self.session)
+        page = self.query.paginate(page=1000)
+        self.assertEqual(1000, page.page)
+        self.assertEqual(3, page.total_items)
+        self.assertEqual(25, page.items_per_page)
+        self.assertEqual(0, len(page.items))
+
+    def test_nonsense_page(self):
+        """Assert a page number less than 1 raises a ValueError."""
+        self.assertRaises(ValueError, self.query.paginate, 0)
+        self.assertRaises(ValueError, self.query.paginate, -1)
+
+    def test_nonsense_items_per_page(self):
+        """Assert an items_per_page number less than 1 raises a ValueError."""
+        self.assertRaises(ValueError, self.query.paginate, 1, 0)
+        self.assertRaises(ValueError, self.query.paginate, 1, -1)
+
+    def test_order_by(self):
+        """Assert you can alter the order of page results."""
+        create_project(self.session)
+        page = self.query.paginate(order_by=model.Project.name)
+        self.assertEqual(1, page.page)
+        self.assertEqual(3, page.total_items)
+        self.assertEqual(25, page.items_per_page)
+        self.assertEqual(page.items[0].name, 'R2spec')
+        self.assertEqual(page.items[1].name, 'geany')
+        self.assertEqual(page.items[2].name, 'subsurface')
+
+    def test_as_dict(self):
+        expected_dict = {
+            u'items_per_page': 1,
+            u'page': 1,
+            u'total_items': 3,
+            u'items': [{
+                'id': 3,
+                'backend': u'custom',
+                'name': u'R2spec',
+                'homepage': u'https://fedorahosted.org/r2spec/',
+                'regex': None,
+                'version': None,
+                'version_url': None,
+                'versions': [],
+            }],
+        }
+        create_project(self.session)
+        page = self.query.paginate(order_by=model.Project.name, items_per_page=1)
+        actual_dict = page.as_dict()
+        actual_dict['items'][0].pop('updated_on')
+        actual_dict['items'][0].pop('created_on')
+        self.assertEqual(expected_dict, actual_dict)
+
+
 class ProjectTests(Modeltests):
     """Tests for the Project model."""
 

--- a/anitya/tests/test_flask_api_v2.py
+++ b/anitya/tests/test_flask_api_v2.py
@@ -22,6 +22,7 @@
 '''
 Tests for the Flask-RESTful based v2 API
 '''
+from __future__ import unicode_literals
 
 import json
 import os.path
@@ -61,7 +62,7 @@ class AnonymousAccessTests(_APItestsMixin, Modeltests):
         self.assertEqual(output.status_code, 200)
         data = _read_json(output)
 
-        self.assertEqual(data, [])
+        self.assertEqual(data, {'page': 1, 'items_per_page': 25, 'total_items': 0, 'items': []})
 
         create_project(self.session)
 
@@ -69,44 +70,126 @@ class AnonymousAccessTests(_APItestsMixin, Modeltests):
         self.assertEqual(output.status_code, 200)
         data = _read_json(output)
 
-        for item in data:
+        for item in data['items']:
             del item['created_on']
             del item['updated_on']
 
-        exp = [
-            {
-                "id": 1,
-                "backend": "custom",
-                "homepage": "http://www.geany.org/",
-                "name": "geany",
-                "regex": "DEFAULT",
-                "version": None,
-                "version_url": "http://www.geany.org/Download/Releases",
-                "versions": []
-            },
-            {
-                "id": 3,
-                "backend": "custom",
-                "homepage": "https://fedorahosted.org/r2spec/",
-                "name": "R2spec",
-                "regex": None,
-                "version": None,
-                "version_url": None,
-                "versions": []
-            },
-            {
-                "id": 2,
-                "backend": "custom",
-                "homepage": "http://subsurface.hohndel.org/",
-                "name": "subsurface",
-                "regex": "DEFAULT",
-                "version": None,
-                "version_url": "http://subsurface.hohndel.org/downloads/",
-                "versions": []
-            }
-        ]
+        exp = {
+            'page': 1,
+            'items_per_page': 25,
+            'total_items': 3,
+            'items': [
+                {
+                    "id": 3,
+                    "backend": "custom",
+                    "homepage": "https://fedorahosted.org/r2spec/",
+                    "name": "R2spec",
+                    "regex": None,
+                    "version": None,
+                    "version_url": None,
+                    "versions": []
+                },
+                {
+                    "id": 1,
+                    "backend": "custom",
+                    "homepage": "http://www.geany.org/",
+                    "name": "geany",
+                    "regex": "DEFAULT",
+                    "version": None,
+                    "version_url": "http://www.geany.org/Download/Releases",
+                    "versions": []
+                },
+                {
+                    "id": 2,
+                    "backend": "custom",
+                    "homepage": "http://subsurface.hohndel.org/",
+                    "name": "subsurface",
+                    "regex": "DEFAULT",
+                    "version": None,
+                    "version_url": "http://subsurface.hohndel.org/downloads/",
+                    "versions": []
+                }
+            ]
+        }
 
         self.assertEqual(data, exp)
+
+    def test_list_projects_items_per_page(self):
+        api_endpoint = '/api/v2/projects/?items_per_page=1'
+        output = self.app.get(api_endpoint)
+        self.assertEqual(output.status_code, 200)
+        data = _read_json(output)
+
+        self.assertEqual(data, {'page': 1, 'items_per_page': 1, 'total_items': 0, 'items': []})
+
+        create_project(self.session)
+
+        output = self.app.get(api_endpoint)
+        self.assertEqual(output.status_code, 200)
+        data = _read_json(output)
+
+        for item in data['items']:
+            del item['created_on']
+            del item['updated_on']
+
+        exp = {
+            'page': 1,
+            'items_per_page': 1,
+            'total_items': 3,
+            'items': [
+                {
+                    "id": 3,
+                    "backend": "custom",
+                    "homepage": "https://fedorahosted.org/r2spec/",
+                    "name": "R2spec",
+                    "regex": None,
+                    "version": None,
+                    "version_url": None,
+                    "versions": []
+                },
+            ]
+        }
+
+        self.assertEqual(data, exp)
+
+    def test_list_projects_items_per_page_with_page(self):
+        api_endpoint = '/api/v2/projects/?items_per_page=1&page=2'
+        output = self.app.get(api_endpoint)
+        self.assertEqual(output.status_code, 200)
+        data = _read_json(output)
+
+        self.assertEqual(data, {'page': 2, 'items_per_page': 1, 'total_items': 0, 'items': []})
+
+        create_project(self.session)
+
+        output = self.app.get(api_endpoint)
+        self.assertEqual(output.status_code, 200)
+        data = _read_json(output)
+
+        for item in data['items']:
+            del item['created_on']
+            del item['updated_on']
+
+        exp = {
+            'page': 2,
+            'items_per_page': 1,
+            'total_items': 3,
+            'items': [
+                {
+                    "id": 1,
+                    "backend": "custom",
+                    "homepage": "http://www.geany.org/",
+                    "name": "geany",
+                    "regex": "DEFAULT",
+                    "version": None,
+                    "version_url": "http://www.geany.org/Download/Releases",
+                    "versions": []
+                },
+            ]
+        }
+
+        self.assertEqual(data, exp)
+
 
 class AuthenticationRequiredTests(_APItestsMixin, Modeltests):
     """Test anonymous access is blocked to APIs requiring authentication"""

--- a/anitya/tests/test_flask_api_v2.py
+++ b/anitya/tests/test_flask_api_v2.py
@@ -190,6 +190,58 @@ class AnonymousAccessTests(_APItestsMixin, Modeltests):
 
         self.assertEqual(data, exp)
 
+    def test_list_projects_items_per_page_too_big(self):
+        """Assert unreasonably large items per page results in an error."""
+        api_endpoint = '/api/v2/projects/?items_per_page=500'
+        output = self.app.get(api_endpoint)
+        self.assertEqual(output.status_code, 400)
+        data = _read_json(output)
+
+        self.assertEqual(
+            data, {u'message': {u'items_per_page': u'Value must be less than or equal to 250.'}})
+
+    def test_list_projects_items_per_page_negative(self):
+        """Assert a negative value for items_per_page results in an error."""
+        api_endpoint = '/api/v2/projects/?items_per_page=-25'
+        output = self.app.get(api_endpoint)
+        self.assertEqual(output.status_code, 400)
+        data = _read_json(output)
+
+        self.assertEqual(
+            data, {u'message': {u'items_per_page': u'Value must be greater than or equal to 1.'}})
+
+    def test_list_projects_items_per_page_non_integer(self):
+        """Assert a non-integer for items_per_page results in an error."""
+        api_endpoint = '/api/v2/projects/?items_per_page=twenty'
+        output = self.app.get(api_endpoint)
+        self.assertEqual(output.status_code, 400)
+        data = _read_json(output)
+
+        self.assertEqual(
+            data,
+            {u'message': {u'items_per_page': u"invalid literal for int() with base 10: 'twenty'"}}
+        )
+
+    def test_list_projects_page_negative(self):
+        """Assert a negative value for a page results in an error."""
+        api_endpoint = '/api/v2/projects/?page=-25'
+        output = self.app.get(api_endpoint)
+        self.assertEqual(output.status_code, 400)
+        data = _read_json(output)
+
+        self.assertEqual(
+            data, {u'message': {u'page': u'Value must be greater than or equal to 1.'}})
+
+    def test_list_projects_page_non_integer(self):
+        """Assert a non-integer value for a page results in an error."""
+        api_endpoint = '/api/v2/projects/?page=twenty'
+        output = self.app.get(api_endpoint)
+        self.assertEqual(output.status_code, 400)
+        data = _read_json(output)
+
+        self.assertEqual(
+            data, {u'message': {u'page': u"invalid literal for int() with base 10: 'twenty'"}})
+
 
 class AuthenticationRequiredTests(_APItestsMixin, Modeltests):
     """Test anonymous access is blocked to APIs requiring authentication"""


### PR DESCRIPTION
This contains 3 commits, which should all be atomic and self-contained, so you can review them separately (oldest to newest, obviously).

It moves the scoped session creation to the model module, then adds a query property to models with a custom Query class that provides pagination for all models. Finally, it uses this in the new REST API.