### PR TITLE
Add code coverage support with pytest-cov and codecov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,14 @@
+[run]
+branch = True
+include =
+    anitya/*
+
+[report]
+fail_under = 83
+precision = 2
+exclude_lines =
+    pragma: no cover
+    if __name__ == .__main__.:
+omit =
+    anitya/tests/*
+

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ anitya.db
 client_secrets.json
 oidc_credentials.json
 anitya/static/docs/
+coverage.xml
+htmlcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ install:
   - pip install tox
 script:
   - tox
+after_success:
+  - source .tox/${TOXENV}/bin/activate && pip install codecov && codecov
 
 env:
   global:

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,7 @@
 coverage
 flake8
 pytest
+pytest-cov
 vcrpy
 unittest2
 mock

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py27,py35,py36,lint,docs
 
 [testenv]
+passenv = TRAVIS TRAVIS_*
 deps =
     -rrequirements.txt
     -rtest_requirements.txt
@@ -11,11 +12,15 @@ deps =
 # rather than trying to detect if we're in an already fixed venv
 # (without this, reused environments will fail on the 'uninstall' command)
 recreate=True
+whitelist_externals =
+    rm
 commands =
     - pip uninstall -y python-openid python3-openid
     py27: pip install python-openid
     py35,py36: pip install python3-openid
-    py.test
+    rm -rf htmlcov coverage.xml
+    py.test --cov-config .coveragerc --cov=anitya --cov-report term \
+        --cov-report xml --cov-report html
 
 [testenv:docs]
 changedir = docs


### PR DESCRIPTION
This generates code coverage reports with pytest-cov and enables
integration with codecov to report coverage on PRs.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>