### PR TITLE
Implement version plugins

### DIFF
--- a/anitya/lib/ecosystems/__init__.py
+++ b/anitya/lib/ecosystems/__init__.py
@@ -10,7 +10,19 @@
 
 
 class BaseEcosystem(object):
-    ''' The base class that all the different ecosystems should extend. '''
+    '''
+    The base class that all the different ecosystems should extend.
+
+    Attributes:
+        name (str): The ecosystem name. This name is used to associate projects
+            with an ecosystem and is user-facing. It is also used in URLs.
+        default_backend (str): The default backend to use for projects in this
+            ecosystem if they don't explicitly define one to use.
+        default_version_scheme (str): The default version scheme to use for
+            projects in this ecosystem if a they don't explicitly define one to
+            use.
+    '''
 
     name = None
     default_backend = None
+    default_version_scheme = None

--- a/anitya/lib/exceptions.py
+++ b/anitya/lib/exceptions.py
@@ -82,3 +82,23 @@ class AnityaInvalidMappingException(AnityaException):
                 project_name=self.project_name,
                 link=self.link,
             )
+
+
+class InvalidVersion(AnityaException):
+    """
+    Raised when the version string is not valid for the given version scheme.
+
+    Args:
+        version (str): The version string that failed to parse.
+        exception (Exception): The underlying exception that triggered this one.
+    """
+
+    def __init__(self, version, exception=None):
+        self.version = version
+        self.exception = exception
+
+    def __str__(self):
+        if self.exception:
+            return 'Invalid version "{v}": {e}'.format(v=self.version, e=str(self.exception))
+        else:
+            return 'Invalid version "{v}"'.format(v=self.version)

--- a/anitya/lib/plugins.py
+++ b/anitya/lib/plugins.py
@@ -24,6 +24,7 @@ from straight.plugin import load
 
 from anitya.lib.backends import BaseBackend
 from anitya.lib.ecosystems import BaseEcosystem
+from anitya.lib.versions import Version
 
 _log = logging.getLogger(__name__)
 
@@ -54,6 +55,7 @@ class _PluginManager(object):
 
 BACKEND_PLUGINS = _PluginManager('anitya.lib.backends', BaseBackend)
 ECOSYSTEM_PLUGINS = _PluginManager('anitya.lib.ecosystems', BaseEcosystem)
+VERSION_PLUGINS = _PluginManager('anitya.lib.versions', Version)
 
 
 def _load_backend_plugins(session):

--- a/anitya/lib/versions/__init__.py
+++ b/anitya/lib/versions/__init__.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions
+# of the GNU General Public License v.2, or (at your option) any later
+# version.  This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.  You
+# should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# Any Red Hat trademarks that are incorporated in the source
+# code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission
+# of Red Hat, Inc.
+"""
+This package defines a set of version scheme plugins.
+
+Anitya attempts to determine the newest version for a project. To do this, it
+must be able to both parse and compare all the major version schemes, and handle
+unknown version schemes in a reasonable way.
+"""
+from __future__ import unicode_literals
+
+from .base import Version, v_prefix  # noqa: F401

--- a/anitya/lib/versions/__init__.py
+++ b/anitya/lib/versions/__init__.py
@@ -23,8 +23,27 @@ This package defines a set of version scheme plugins.
 Anitya attempts to determine the newest version for a project. To do this, it
 must be able to both parse and compare all the major version schemes, and handle
 unknown version schemes in a reasonable way.
+
+The general approach is as follows:
+
+1. If a project has its ``version_scheme`` column defined in the database, that
+   version scheme is used.
+
+2. If the project does not have ``version_scheme`` set, but is in an ecosystem
+   with a default version scheme, the ecosystem default is used.
+
+2. If the project is not a part of an ecosystem or if the ecosystem has no
+   default scheme, but the backend it uses has a default version scheme defined,
+   the backend default is used.
+
+4. If all else fails, Anitya uses the value of :data:`GLOBAL_DEFAULT`.
 """
 from __future__ import unicode_literals
 
 from .base import Version, v_prefix  # noqa: F401
 from .rpm import RpmVersion  # noqa: F401
+
+
+#: The default version scheme to use when the project itself, its ecosystem,
+#: and its backend all have no version scheme set.
+GLOBAL_DEFAULT = 'RPM'

--- a/anitya/lib/versions/__init__.py
+++ b/anitya/lib/versions/__init__.py
@@ -27,3 +27,4 @@ unknown version schemes in a reasonable way.
 from __future__ import unicode_literals
 
 from .base import Version, v_prefix  # noqa: F401
+from .rpm import RpmVersion  # noqa: F401

--- a/anitya/lib/versions/base.py
+++ b/anitya/lib/versions/base.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions
+# of the GNU General Public License v.2, or (at your option) any later
+# version.  This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.  You
+# should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# Any Red Hat trademarks that are incorporated in the source
+# code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission
+# of Red Hat, Inc.
+from __future__ import unicode_literals
+
+import functools
+import re
+
+from anitya.lib.exceptions import InvalidVersion
+
+
+#: A regular expression to determine if the version string contains a 'v' prefix.
+v_prefix = re.compile(r'v\d.*')
+
+
+@functools.total_ordering
+class Version(object):
+    """The base class for versions."""
+
+    name = 'Generic Version'
+
+    def __init__(self, version=None, prefix=None):
+        self.version = version
+        self.prefix = prefix
+
+    def __str__(self):
+        """
+        Return a parsed, string version of this instance's version.
+        If parsing fails, the original version string is returned.
+        """
+        try:
+            return str(self.parse())
+        except InvalidVersion:
+            return self.version
+
+    def parse(self):
+        """
+        Parse the version string to an object representing the version.
+
+        This does some minimal string processing, stripping any prefix set on
+        project.
+
+        Returns:
+            str: The version string. Sub-classes may return a different type.
+            object: Sub-classes may return a special class that represents the
+                version. This must support comparison operations and return
+                a parsed, prefix-stripped version when ``__str__`` is invoked.
+
+        Raises:
+            InvalidVersion: If the version cannot be parsed.
+        """
+        # If there's a prefix set on the project, strip it if it's present
+        version = self.version
+        if self.prefix and self.version.startswith(self.prefix):
+            version = self.version[len(self.prefix):]
+
+        # Many projects prefix their tags with 'v', so strip it if it's present
+        if v_prefix.match(version):
+            version = version[1:]
+
+        return version
+
+    def prerelease(self):
+        """
+        Check if a version is a pre-release version.
+
+        This basic version implementation does not have a concept of
+        pre-releases.
+        """
+        return False
+
+    def postrelease(self):
+        """
+        Check if a version is a post-release version.
+
+        This basic version implementation does not have a concept of
+        post-releases.
+        """
+        return False
+
+    def newer(self, other_versions):
+        """
+        Check a version against a list of other versions to see if it's newer.
+
+        Example:
+            >>> version = Version(version='1.1.0')
+            >>> version.newer([Version(version='1.0.0')])
+            True
+            >>> version.newer(['1.0.0', '0.0.1'])  # You can pass strings!
+            True
+            >>> version.newer(['1.2.0', '2.0.1'])
+            False
+
+        Args:
+            other_versions (list): A list of version strings or Version
+                objects to check the `version` string against.
+        Returns:
+            bool: True if self is the newest version, ``False otherwise``.
+        Raises:
+            InvalidVersion: if one or more of the version
+                strings provided cannot be parsed.
+        """
+        if isinstance(other_versions, (Version, str)):
+            other_versions = [other_versions]
+        cast_versions = []
+        for version in other_versions:
+            if not isinstance(version, type(self)):
+                version = type(self)(version=version)
+            cast_versions.append(version)
+        return all([self.parse() > v.parse() for v in cast_versions])
+
+    def __lt__(self, other):
+        """Support < comparison via objects returned from :meth:`parse`"""
+        try:
+            parsed_self = self.parse()
+        except InvalidVersion:
+            parsed_self = None
+        try:
+            parsed_other = other.parse()
+        except InvalidVersion:
+            parsed_other = None
+
+        # Handle the cases where one or both aren't parsable. Parsable versions
+        # always sort higher than unparsable versions.
+        if not parsed_self and not parsed_other:
+            return self.version.__lt__(other.version)
+        if not parsed_other:
+            return False
+        if not parsed_self:
+            return True
+
+        return parsed_self.__lt__(parsed_other)
+
+    def __eq__(self, other):
+        """Support == comparison via objects returned from :meth:`parse`"""
+        try:
+            parsed_self = self.parse()
+        except InvalidVersion:
+            parsed_self = None
+        try:
+            parsed_other = other.parse()
+        except InvalidVersion:
+            parsed_other = None
+
+        if not parsed_self or not parsed_other:
+            return self.version.__eq__(other.version)
+        return parsed_self.__eq__(parsed_other)

--- a/anitya/lib/versions/rpm.py
+++ b/anitya/lib/versions/rpm.py
@@ -1,0 +1,204 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions
+# of the GNU General Public License v.2, or (at your option) any later
+# version.  This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.  You
+# should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# Any Red Hat trademarks that are incorporated in the source
+# code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission
+# of Red Hat, Inc.
+"""
+This adds support for comparing project versions using the RPM version rules.
+"""
+from __future__ import unicode_literals
+
+import functools
+import re
+
+from .base import Version
+
+
+try:
+    from rpm import labelCompare as _compare_rpm_labels
+except ImportError:
+    # Emulate RPM field comparisons as described in
+    # http://stackoverflow.com/questions/3206319/how-do-i-compare-rpm-versions-in-python/3206477#3206477
+    #
+    # * Search each string for alphabetic fields [a-zA-Z]+ and
+    #   numeric fields [0-9]+ separated by junk [^a-zA-Z0-9]*.
+    # * Successive fields in each string are compared to each other.
+    # * Alphabetic sections are compared lexicographically, and the
+    #   numeric sections are compared numerically.
+    # * In the case of a mismatch where one field is numeric and one is
+    #   alphabetic, the numeric field is always considered greater (newer).
+    # * In the case where one string runs out of fields, the other is always
+    #   considered greater (newer).
+
+    import warnings
+    warnings.warn("Failed to import 'rpm', emulating RPM label comparisons")
+
+    try:
+        from itertools import zip_longest
+    except ImportError:
+        from itertools import izip_longest as zip_longest
+
+    _subfield_pattern = re.compile(
+        r'(?P<junk>[^a-zA-Z0-9]*)((?P<text>[a-zA-Z]+)|(?P<num>[0-9]+))'
+    )
+
+    def _iter_rpm_subfields(field):
+        """Yield subfields as 2-tuples that sort in the desired order
+
+        Text subfields are yielded as (0, text_value)
+        Numeric subfields are yielded as (1, int_value)
+        """
+        for subfield in _subfield_pattern.finditer(field):
+            text = subfield.group('text')
+            if text is not None:
+                yield (0, text)
+            else:
+                yield (1, int(subfield.group('num')))
+
+    def _compare_rpm_field(lhs, rhs):
+        # Short circuit for exact matches (including both being None)
+        if lhs == rhs:
+            return 0
+        # Otherwise assume both inputs are strings
+        lhs_subfields = _iter_rpm_subfields(lhs)
+        rhs_subfields = _iter_rpm_subfields(rhs)
+        for lhs_sf, rhs_sf in zip_longest(lhs_subfields, rhs_subfields):
+            if lhs_sf == rhs_sf:
+                # When both subfields are the same, move to next subfield
+                continue
+            if lhs_sf is None:
+                # Fewer subfields in LHS, so it's less than/older than RHS
+                return -1
+            if rhs_sf is None:
+                # More subfields in LHS, so it's greater than/newer than RHS
+                return 1
+            # Found a differing subfield, so it determines the relative order
+            return -1 if lhs_sf < rhs_sf else 1
+        # No relevant differences found between LHS and RHS
+        return 0
+
+    def _compare_rpm_labels(lhs, rhs):
+        lhs_epoch, lhs_version, lhs_release = lhs
+        rhs_epoch, rhs_version, rhs_release = rhs
+        result = _compare_rpm_field(lhs_epoch, rhs_epoch)
+        if result:
+            return result
+        result = _compare_rpm_field(lhs_version, rhs_version)
+        if result:
+            return result
+        return _compare_rpm_field(lhs_release, rhs_release)
+
+
+@functools.total_ordering
+class RpmVersion(Version):
+    """
+    This implements an RPM version plugin.
+
+    It sorts versions using the rpm Python binding, if available, and falls
+    back to a pure Python implementation if they are not installed.
+    """
+
+    name = u'RPM'
+
+    _rc_upstream_regex = re.compile(
+        "(.*?)\.?(-?(rc|pre|beta|alpha|dev)([0-9]*))", re.I)
+
+    @classmethod
+    def split_rc(cls, version):
+        """ Split (upstream) version into version and release candidate string +
+        release candidate number if possible
+
+        Code from Till Maas as part of
+        `cnucnu <https://fedorapeople.org/cgit/till/public_git/cnucnu.git/>`_
+
+        Args:
+            version (str): A version string to split.
+
+        Returns:
+            tuple: A tuple of (version, release_string, release_number) where release_string
+                is one of (rc, pre, beta, alpha, dev).
+        """
+        match = cls._rc_upstream_regex.match(version)
+        if not match:
+            return (version, "", "")
+
+        return (match.group(1), match.group(3), match.group(4))
+
+    def prerelease(self):
+        """
+        Check if a version is a pre-release version.
+
+        This recognizes versions containing "rc", "pre", "beta", "alpha", and
+        "dev" as being pre-release versions.
+        """
+        return self.split_rc(self.parse())[1] != ''
+
+    def __eq__(self, other):
+        """
+        Compare two versions for equality using the RPM rules with pre-release
+        support.
+        """
+        v1, rc1, rcn1 = self.split_rc(self.parse())
+        v2, rc2, rcn2 = self.split_rc(other.parse())
+        result = _compare_rpm_labels((None, v1, None), (None, v2, None))
+        if result != 0:
+            return False
+
+        if rc1 == rc2 and rcn1 == rcn2:
+            return True
+        else:
+            return False
+
+    def __lt__(self, other):
+        v1, rc1, rcn1 = self.split_rc(self.parse())
+        v2, rc2, rcn2 = self.split_rc(other.parse())
+        result = _compare_rpm_labels((None, v1, None), (None, v2, None))
+        if result == -1:
+            return True
+        elif result == 1:
+            return False
+
+        if rc1 and rc2:
+            # both are rc, higher rc is newer
+            rc1_text = rc1.lower()
+            rc2_text = rc2.lower()
+            # rc > pre > beta > alpha
+            if rc1_text < rc2_text:
+                return True
+            if rc1_text > rc2_text:
+                return False
+            if rcn1 and rcn2:
+                # both have rc number
+                return int(rcn1) < int(rcn2)
+            if rcn1:
+                # only first has rc number, then it is newer
+                return False
+            if rcn2:
+                # only second has rc number, then it is newer
+                return True
+            # both rc numbers are missing or same
+            return False
+
+        if rc1:
+            # only first is rc, then second is newer
+            return True
+        if rc2:
+            # only second is rc, then first is newer
+            return False
+
+        # neither is a rc
+        return False

--- a/anitya/tests/lib/backends/test_init.py
+++ b/anitya/tests/lib/backends/test_init.py
@@ -33,18 +33,6 @@ from anitya.lib.exceptions import AnityaPluginException
 import anitya
 
 
-class TestRpmCmp(unittest.TestCase):
-
-    def test_equal_version(self):
-        self.assertEqual(0, backends.rpm_cmp('1.2.0-1.fc25', '1.2.0-1.fc25'))
-
-    def test_larger_version(self):
-        self.assertEqual(1, backends.rpm_cmp('1.2.0-1.fc25', '1.1.0-3.fc25'))
-
-    def test_smaller_version(self):
-        self.assertEqual(-1, backends.rpm_cmp('1.1.0-3.fc25', '1.2.0-1.fc25'))
-
-
 class BaseBackendTests(unittest.TestCase):
 
     def setUp(self):

--- a/anitya/tests/lib/test_exceptions.py
+++ b/anitya/tests/lib/test_exceptions.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2017 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions
+# of the GNU General Public License v.2, or (at your option) any later
+# version.  This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.  You
+# should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# Any Red Hat trademarks that are incorporated in the source
+# code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission
+# of Red Hat, Inc.
+
+import unittest
+
+from anitya.lib import exceptions
+
+
+class InvalidVersionTests(unittest.TestCase):
+    """Tests for :class:`exceptions.InvalidVersion`."""
+
+    def test_str(self):
+        """Assert the __str__ method provides a human-readable value."""
+        e = exceptions.InvalidVersion('notaversion')
+        self.assertEqual('Invalid version "notaversion"', str(e))
+
+    def test_str_with_wrapped_exception(self):
+        """Assert the __str__ method provides a human-readable value including the exception."""
+        e = exceptions.InvalidVersion('notaversion', IOError('womp womp'))
+        self.assertEqual('Invalid version "notaversion": womp womp', str(e))

--- a/anitya/tests/lib/test_model.py
+++ b/anitya/tests/lib/test_model.py
@@ -29,6 +29,7 @@ import unittest
 import mock
 
 import anitya.lib.model as model
+from anitya.lib import versions
 from anitya.tests.base import Modeltests, create_distro, create_project, create_package
 
 
@@ -211,6 +212,28 @@ class ProjectTests(Modeltests):
             backend='custom',
             ecosystem_name='Nope',
         )
+
+    def test_get_version_class(self):
+        project = model.Project(
+            name='test',
+            homepage='http://example.com',
+            backend='custom',
+            ecosystem_name='pypi',
+            version_scheme='RPM',
+        )
+        version_class = project.get_version_class()
+        self.assertEqual(version_class, versions.RpmVersion)
+
+    def test_get_version_class_missing(self):
+        project = model.Project(
+            name='test',
+            homepage='http://example.com',
+            backend='custom',
+            ecosystem_name='pypi',
+            version_scheme='Invalid',
+        )
+        version_class = project.get_version_class()
+        self.assertEqual(version_class, None)
 
     def test_project_all(self):
         """ Test the Project.all function. """

--- a/anitya/tests/lib/test_plugins.py
+++ b/anitya/tests/lib/test_plugins.py
@@ -28,6 +28,7 @@ import unittest
 
 from anitya.lib import plugins
 from anitya.lib import model
+from anitya.lib.versions import Version
 from anitya.tests.base import Modeltests
 
 EXPECTED_BACKENDS = [
@@ -46,6 +47,19 @@ EXPECTED_ECOSYSTEMS = {
     "maven": "Maven Central",
     "crates.io": "crates.io",
 }
+
+
+class VersionPluginsTests(unittest.TestCase):
+    """Tests for the version scheme plugins."""
+
+    def test_version_plugin_names(self):
+        plugin_names = plugins.VERSION_PLUGINS.get_plugin_names()
+        self.assertEqual(['RPM'], plugin_names)
+
+    def test_version_plugin_classes(self):
+        version_plugins = plugins.VERSION_PLUGINS.get_plugins()
+        for plugin in version_plugins:
+            self.assertTrue(issubclass(plugin, Version))
 
 
 class Pluginstests(Modeltests):

--- a/anitya/tests/lib/versions/test_base.py
+++ b/anitya/tests/lib/versions/test_base.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions
+# of the GNU General Public License v.2, or (at your option) any later
+# version.  This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.  You
+# should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# Any Red Hat trademarks that are incorporated in the source
+# code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission
+# of Red Hat, Inc.
+from __future__ import unicode_literals
+
+import unittest
+
+import mock
+
+from anitya.lib import exceptions
+from anitya.lib.versions import base
+
+
+class VersionTests(unittest.TestCase):
+    """Tests for the :class:`anitya.lib.versions.Version` model."""
+
+    def test_identity_string(self):
+        """Assert the generic version constant is what we expect.
+        .. note::
+            If this test starts failing because the constant was modified, you
+            *must* write a migration to change the type column on existing
+            versions.
+        """
+        self.assertEqual('Generic Version', base.Version.name)
+
+    def test_str(self):
+        """Assert __str__ calls parse"""
+        version = base.Version(version='v1.0.0')
+        self.assertEqual('1.0.0', str(version))
+
+    def test_str_parse_error(self):
+        """Assert __str__ calls parse"""
+        version = base.Version(version='v1.0.0')
+        version.parse = mock.Mock(side_effect=exceptions.InvalidVersion('boop'))
+        self.assertEqual('v1.0.0', str(version))
+
+    def test_parse_no_v(self):
+        """Assert parsing a version sans leading 'v' works."""
+        version = base.Version(version='1.0.0')
+        self.assertEqual('1.0.0', version.parse())
+
+    def test_parse_leading_v(self):
+        """Assert parsing a version with a leading 'v' works."""
+        version = base.Version(version='v1.0.0')
+        self.assertEqual('1.0.0', version.parse())
+
+    def test_parse_odd_version(self):
+        """Assert parsing an odd version works."""
+        version = base.Version(version='release_1_0_0')
+        self.assertEqual('release_1_0_0', version.parse())
+
+    def test_parse_v_not_alone(self):
+        """Assert leading 'v' isn't stripped if it's not followed by a number."""
+        version = base.Version(version='version1.0.0')
+        self.assertEqual('version1.0.0', version.parse())
+
+    def test_parse_with_prefix_no_v(self):
+        version = base.Version(version='release1.0.0', prefix='release')
+        self.assertEqual('1.0.0', version.parse())
+
+    def test_parse_with_prefix_with_v(self):
+        version = base.Version(version='release-v1.0.0', prefix='release-')
+        self.assertEqual('1.0.0', version.parse())
+
+    def test_prerelease(self):
+        """Assert prerelease is defined and returns False"""
+        version = base.Version(version='v1.0.0')
+        self.assertFalse(version.prerelease())
+
+    def test_postrelease(self):
+        """Assert postrelease is defined and returns False"""
+        version = base.Version(version='v1.0.0')
+        self.assertFalse(version.postrelease())
+
+    def test_newer_single_version(self):
+        """Assert newer is functional with a single instance of Version."""
+        version = base.Version(version='v1.0.0')
+        newer_version = base.Version(version='v2.0.0')
+        self.assertFalse(version.newer(newer_version))
+        self.assertTrue(newer_version.newer(version))
+
+    def test_newer_multiple_versions(self):
+        """Assert newer is functional with multiple instances of Version."""
+        version = base.Version(version='v1.0.0')
+        version2 = base.Version(version='v1.1.0')
+        newer_version = base.Version(version='v2.0.0')
+        self.assertFalse(version.newer(newer_version))
+        self.assertTrue(newer_version.newer([version, version2]))
+
+    def test_newer_with_strings(self):
+        """Assert newer handles string arguments."""
+        version = base.Version(version='v1.0.0')
+        self.assertFalse(version.newer('v2.0.0'))
+
+    def test_lt(self):
+        """Assert Version supports < comparison."""
+        old_version = base.Version(version='v1.0.0')
+        new_version = base.Version(version='v1.1.0')
+        self.assertTrue(old_version < new_version)
+        self.assertFalse(new_version < old_version)
+
+    def test_lt_one_unparsable(self):
+        """Assert unparsable versions sort lower than parsable ones."""
+        unparsable_version = base.Version(version='blarg')
+        unparsable_version.parse = mock.Mock(side_effect=exceptions.InvalidVersion('blarg'))
+        new_version = base.Version(version='v1.0.0')
+        self.assertTrue(unparsable_version < new_version)
+        self.assertFalse(new_version < unparsable_version)
+
+    def test_lt_both_unparsable(self):
+        """Assert unparsable versions resort to string sorting."""
+        alphabetically_lower = base.Version(version='arg')
+        alphabetically_lower.parse = mock.Mock(side_effect=exceptions.InvalidVersion('arg'))
+        alphabetically_higher = base.Version(version='blarg')
+        alphabetically_higher.parse = mock.Mock(side_effect=exceptions.InvalidVersion('blarg'))
+        self.assertTrue(alphabetically_lower < alphabetically_higher)
+
+    def test_le(self):
+        """Assert Version supports <= comparison."""
+        old_version = base.Version(version='v1.0.0')
+        equally_old_version = base.Version(version='v1.0.0')
+        new_version = base.Version(version='v1.1.0')
+        self.assertTrue(old_version <= new_version)
+        self.assertTrue(old_version <= equally_old_version)
+        self.assertFalse(new_version <= old_version)
+
+    def test_gt(self):
+        """Assert Version supports > comparison."""
+        old_version = base.Version(version='v1.0.0')
+        new_version = base.Version(version='v1.1.0')
+        self.assertTrue(new_version > old_version)
+        self.assertFalse(old_version > new_version)
+
+    def test_ge(self):
+        """Assert Version supports >= comparison."""
+        old_version = base.Version(version='v1.0.0')
+        equally_new_version = base.Version(version='v1.1.0')
+        new_version = base.Version(version='v1.1.0')
+        self.assertFalse(old_version >= new_version)
+        self.assertTrue(new_version >= equally_new_version)
+        self.assertTrue(new_version >= old_version)
+
+    def test_eq(self):
+        """Assert Version supports == comparison."""
+        v1 = base.Version(version='v1.0.0')
+        v2 = base.Version(version='v1.0.0')
+        self.assertTrue(v1 == v2)
+
+    def test_eq_one_with_v(self):
+        """Assert Versions where one just has a v prefix are still equal"""
+        v1 = base.Version(version='1.0.0')
+        v2 = base.Version(version='v1.0.0')
+        self.assertTrue(v1 == v2)
+
+    def test_eq_one_with_prefix(self):
+        """Assert Versions where one just has a v prefix are still equal"""
+        v1 = base.Version(version='1.0.0')
+        v2 = base.Version(version='prefix1.0.0', prefix='prefix')
+        self.assertTrue(v1 == v2)
+
+    def test_eq_both_unparsable(self):
+        """Assert unparsable versions that are the same string are equal."""
+        v1 = base.Version(version='arg')
+        v2 = base.Version(version='arg')
+        v1.parse = mock.Mock(side_effect=exceptions.InvalidVersion('arg'))
+        v2.parse = mock.Mock(side_effect=exceptions.InvalidVersion('arg'))
+        self.assertEqual(v1, v2)

--- a/anitya/tests/lib/versions/test_rpm.py
+++ b/anitya/tests/lib/versions/test_rpm.py
@@ -1,0 +1,244 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions
+# of the GNU General Public License v.2, or (at your option) any later
+# version.  This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.  You
+# should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# Any Red Hat trademarks that are incorporated in the source
+# code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission
+# of Red Hat, Inc.
+from __future__ import unicode_literals
+
+import unittest
+
+import mock
+
+from anitya.lib import exceptions
+from anitya.lib.versions import rpm
+
+
+class RpmVersionTests(unittest.TestCase):
+    """Tests for the :class:`anitya.lib.versions.Version` model."""
+
+    def test_identity_string(self):
+        """Assert the generic version constant is what we expect.
+
+        .. note::
+            If this test starts failing because the constant was modified, you
+            *must* write a migration to change the type column on existing
+            projects.
+        """
+        self.assertEqual('RPM', rpm.RpmVersion.name)
+
+    def test_split_rc_prerelease_tag(self):
+        result = rpm.RpmVersion.split_rc('1.8.23-alpha1')
+        self.assertEqual(('1.8.23', 'alpha', '1'), result)
+
+    def test_split_rc_no_prerelease_tag(self):
+        result = rpm.RpmVersion.split_rc('1.8.23')
+        self.assertEqual(('1.8.23', '', ''), result)
+
+    def test_str(self):
+        """Assert __str__ calls parse"""
+        version = rpm.RpmVersion(version='v1.0.0')
+        self.assertEqual('1.0.0', str(version))
+
+    def test_str_parse_error(self):
+        """Assert __str__ calls parse"""
+        version = rpm.RpmVersion(version='v1.0.0')
+        version.parse = mock.Mock(side_effect=exceptions.InvalidVersion('boop'))
+        self.assertEqual('v1.0.0', str(version))
+
+    def test_parse_no_v(self):
+        """Assert parsing a version sans leading 'v' works."""
+        version = rpm.RpmVersion(version='1.0.0')
+        self.assertEqual('1.0.0', version.parse())
+
+    def test_parse_leading_v(self):
+        """Assert parsing a version with a leading 'v' works."""
+        version = rpm.RpmVersion(version='v1.0.0')
+        self.assertEqual('1.0.0', version.parse())
+
+    def test_parse_odd_version(self):
+        """Assert parsing an odd version works."""
+        version = rpm.RpmVersion(version='release_1_0_0')
+        self.assertEqual('release_1_0_0', version.parse())
+
+    def test_parse_v_not_alone(self):
+        """Assert leading 'v' isn't stripped if it's not followed by a number."""
+        version = rpm.RpmVersion(version='version1.0.0')
+        self.assertEqual('version1.0.0', version.parse())
+
+    def test_prerelease_false(self):
+        """Assert prerelease is defined and returns False with non-prerelease versions."""
+        version = rpm.RpmVersion(version='v1.0.0')
+        self.assertFalse(version.prerelease())
+
+    def test_prerelease_prerelease_no_number(self):
+        """Assert pre-releases without a number are still valid pre-releases."""
+        for suffix in ('rc', 'alpha', 'beta', 'dev', 'pre'):
+            version = rpm.RpmVersion(version='v1.0.0' + suffix)
+            self.assertTrue(version.prerelease())
+
+    def test_prerelease_with_number(self):
+        """Assert versions with RC are prerelease versions."""
+        for suffix in ('rc1', 'alpha2', 'beta10', 'dev3', 'pre999'):
+            version = rpm.RpmVersion(version='v1.0.0' + suffix)
+            self.assertTrue(version.prerelease())
+
+    def test_prerelease_nonsense(self):
+        """Assert versions with junk following the version aren't prerelease versions."""
+        version = rpm.RpmVersion(version='v1.0.0junk1')
+        self.assertFalse(version.prerelease())
+
+    def test_postrelease_false(self):
+        """Assert postrelease is defined and returns False for non-postreleases."""
+        version = rpm.RpmVersion(version='v1.0.0')
+        self.assertFalse(version.postrelease())
+
+    def test_postrelease(self):
+        """Assert postrelease is currently unsupported."""
+        version = rpm.RpmVersion(version='v1.0.0post1')
+        self.assertFalse(version.postrelease())
+
+    def test_newer(self):
+        """Assert newer is functional."""
+        version = rpm.RpmVersion(version='v1.0.0')
+        newer_version = rpm.RpmVersion(version='v2.0.0')
+        self.assertFalse(version.newer(newer_version))
+        self.assertTrue(newer_version.newer(version))
+
+    def test_newer_with_strings(self):
+        """Assert newer handles string arguments,"""
+        version = rpm.RpmVersion(version='v1.0.0')
+        self.assertFalse(version.newer('v2.0.0'))
+
+    def test_newer_numerical(self):
+        """Assert newer is functional."""
+        version = rpm.RpmVersion(version='v1.1.0')
+        newer_version = rpm.RpmVersion(version='v1.11.0')
+        self.assertFalse(version.newer(newer_version))
+        self.assertTrue(newer_version.newer(version))
+
+    def test_lt(self):
+        """Assert RpmVersion supports < comparison."""
+        old_version = rpm.RpmVersion(version='v1.0.0')
+        new_version = rpm.RpmVersion(version='v1.1.0')
+        self.assertTrue(old_version < new_version)
+        self.assertFalse(new_version < old_version)
+
+    def test_lt_one_release_field(self):
+        """Assert versions with release fields are greater than those that don't have them."""
+        old_version = rpm.RpmVersion(version='v1.0.0')
+        new_version = rpm.RpmVersion(version='v1.0.0-1.fc26')
+        self.assertTrue(old_version < new_version)
+        self.assertFalse(new_version < old_version)
+
+    def test_lt_two_release_fields(self):
+        """Assert release fields are compared."""
+        old_version = rpm.RpmVersion(version='v1.0.0-1.fc26')
+        new_version = rpm.RpmVersion(version='v1.0.0-11.fc26')
+        self.assertTrue(old_version < new_version)
+        self.assertFalse(new_version < old_version)
+
+    def test_lt_rc_vs_pre(self):
+        """Assert rc prereleases are greater than pre prereleases of the same version."""
+        old_version = rpm.RpmVersion(version='1.0.0pre2')
+        new_version = rpm.RpmVersion(version='1.0.0rc1')
+        self.assertTrue(old_version < new_version)
+        self.assertFalse(new_version < old_version)
+
+    def test_lt_pre_vs_beta(self):
+        """Assert pre prereleases are greater than beta prereleases of the same version."""
+        old_version = rpm.RpmVersion(version='1.0.0pre2')
+        new_version = rpm.RpmVersion(version='1.0.0rc1')
+        self.assertTrue(old_version < new_version)
+        self.assertFalse(new_version < old_version)
+
+    def test_lt_beta_vs_alpha(self):
+        """Assert beta prereleases are greater than alpha prereleases of the same version."""
+        old_version = rpm.RpmVersion(version='1.0.0alpha2')
+        new_version = rpm.RpmVersion(version='1.0.0beta1')
+        self.assertTrue(old_version < new_version)
+        self.assertFalse(new_version < old_version)
+
+    def test_lt_beta_vs_newer_alpha(self):
+        """Assert alpha prereleases of newer versions are larger than older betas."""
+        old_version = rpm.RpmVersion(version='1.0.0beta1')
+        new_version = rpm.RpmVersion(version='1.0.1alpha2')
+        self.assertTrue(old_version < new_version)
+        self.assertFalse(new_version < old_version)
+
+    def test_lt_one_prerelease(self):
+        """Assert prereleases are less than non-prereleases."""
+        old_version = rpm.RpmVersion(version='v1.1.0rc1')
+        new_version = rpm.RpmVersion(version='v1.1.0')
+        self.assertTrue(old_version < new_version)
+        self.assertFalse(new_version < old_version)
+
+    def test_lt_both_prerelease(self):
+        """Assert prereleases sort numerically."""
+        old_version = rpm.RpmVersion(version='v1.1.0rc1')
+        new_version = rpm.RpmVersion(version='v1.1.0rc11')
+        self.assertTrue(old_version < new_version)
+        self.assertFalse(new_version < old_version)
+
+    def test_lt_both_prerelease_one_unversioned(self):
+        """Assert unversioned prereleases are less than versioned ones."""
+        old_version = rpm.RpmVersion(version='v1.1.0rc')
+        new_version = rpm.RpmVersion(version='v1.1.0rc1')
+        self.assertTrue(old_version < new_version)
+        self.assertFalse(new_version < old_version)
+
+    def test_le(self):
+        """Assert RpmVersion supports <= comparison."""
+        old_version = rpm.RpmVersion(version='v1.0.0')
+        equally_old_version = rpm.RpmVersion(version='v1.0.0')
+        new_version = rpm.RpmVersion(version='v1.1.0')
+        self.assertTrue(old_version <= new_version)
+        self.assertTrue(old_version <= equally_old_version)
+        self.assertFalse(new_version <= old_version)
+
+    def test_gt(self):
+        """Assert RpmVersion supports > comparison."""
+        old_version = rpm.RpmVersion(version='v1.0.0')
+        new_version = rpm.RpmVersion(version='v1.1.0')
+        self.assertTrue(new_version > old_version)
+        self.assertFalse(old_version > new_version)
+
+    def test_ge(self):
+        """Assert RpmVersion supports >= comparison."""
+        old_version = rpm.RpmVersion(version='v1.0.0')
+        equally_new_version = rpm.RpmVersion(version='v1.1.0')
+        new_version = rpm.RpmVersion(version='v1.1.0')
+        self.assertFalse(old_version >= new_version)
+        self.assertTrue(new_version >= equally_new_version)
+        self.assertTrue(new_version >= old_version)
+
+    def test_eq(self):
+        """Assert RpmVersion supports == comparison."""
+        old_version = rpm.RpmVersion(version='v1.0.0')
+        new_version = rpm.RpmVersion(version='v1.0.0')
+        self.assertTrue(new_version == old_version)
+
+    def test_eq_both_unnumbered_prereleases(self):
+        """Assert two prereleases of the same type without versions are equal."""
+        old_version = rpm.RpmVersion(version='1.0.0beta')
+        new_version = rpm.RpmVersion(version='1.0.0beta')
+        self.assertTrue(new_version == old_version)
+
+    def test_eq_one_v_prefix(self):
+        """Assert versions that are the same except one has a v prefix are equal."""
+        old_version = rpm.RpmVersion(version='v1.0.0-1.fc26')
+        new_version = rpm.RpmVersion(version='1.0.0-1.fc26')
+        self.assertTrue(new_version == old_version)


### PR DESCRIPTION
This is a v2 of https://github.com/release-monitoring/anitya/pull/448, but it should not change any user-facing behaviour and is strictly a refactor. It should make it easy to add additional version schemes later.

This is still a pretty large PR, but can reviewed commit-by-commit and each commit is reasonably sized and self-contained.