### PR TITLE
Remove unused dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN dnf update -y libnghttp2 && \
         python-wtforms \
         python-openid \
         python-dateutil \
-        python-markupsafe \
         python-bunch \
         python-straight-plugin \
         python-setuptools \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN dnf update -y libnghttp2 && \
         python-flask-openid \
         python-wtforms \
         python-openid \
-        python-docutils \
         python-dateutil \
         python-markupsafe \
         python-bunch \

--- a/files/anitya.spec
+++ b/files/anitya.spec
@@ -19,7 +19,6 @@ BuildRequires:  python-flask-wtf
 BuildRequires:  python-flask-openid
 BuildRequires:  python-wtforms
 BuildRequires:  python-openid
-BuildRequires:  python-docutils
 BuildRequires:  python-dateutil
 BuildRequires:  python-markupsafe
 BuildRequires:  python-bunch
@@ -42,7 +41,6 @@ Requires:  python-flask-wtf
 Requires:  python-flask-openid
 Requires:  python-wtforms
 Requires:  python-openid
-Requires:  python-docutils
 Requires:  python-dateutil
 Requires:  python-markupsafe
 Requires:  python-bunch

--- a/files/anitya.spec
+++ b/files/anitya.spec
@@ -20,7 +20,6 @@ BuildRequires:  python-flask-openid
 BuildRequires:  python-wtforms
 BuildRequires:  python-openid
 BuildRequires:  python-dateutil
-BuildRequires:  python-markupsafe
 BuildRequires:  python-bunch
 BuildRequires:  python-straight-plugin
 BuildRequires:  python-setuptools
@@ -42,7 +41,6 @@ Requires:  python-flask-openid
 Requires:  python-wtforms
 Requires:  python-openid
 Requires:  python-dateutil
-Requires:  python-markupsafe
 Requires:  python-bunch
 Requires:  python-straight-plugin
 Requires:  python-setuptools

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,6 @@
 alembic
 bunch
 dateutils
-docutils
 fedmsg
 flask
 flask-openid

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -10,7 +10,6 @@ flask-oidc >= 1.1.1
 flask-restful
 flask-wtf
 jinja2 >= 2.4
-markupsafe
 python-openid; python_version < '3.0'
 python3-openid; python_version >= '3.0'
 sqlalchemy >= 0.9


### PR DESCRIPTION
When we stopped building the RST files to docs and started using Sphinx, we no longer have dependencies on markupsafe or docutils. This removes them.