### PR TITLE
Remove the explicit dependency on Flask to avoid setuptools bug

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,7 +2,6 @@ alembic
 bunch
 dateutils
 fedmsg
-flask
 flask-openid
 # Need the fixes for https://github.com/puiterwijk/flask-oidc/issues/12
 #                and https://github.com/puiterwijk/flask-oidc/issues/24


### PR DESCRIPTION
At the moment you cannot ``python setup.py install`` Anitya (and this is
causing our [documentation to not build](https://readthedocs.org/projects/anitya/builds/5287816/)) because we're hitting a
setuptools bug[0] which is causing "Flask-WTF" to be matched for the
"Flask" requirement. Without the explicit requirement, the Flask plugins
we use (including Flask-WTF) will pull Flask in.

[0] https://github.com/pypa/setuptools/issues/196

Signed-off-by: Jeremy Cline <jeremy@jcline.org>