### PR TITLE
PEP-8 the remainder of Anitya

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,9 +1,14 @@
 from __future__ import with_statement
-import sys
+
+from logging.config import fileConfig
 from os.path import dirname
+import sys
+
 from alembic import context
 from sqlalchemy import engine_from_config, pool
-from logging.config import fileConfig
+
+from anitya.lib.model import BASE
+
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -16,13 +21,13 @@ fileConfig(config.config_file_name)
 # add your model's MetaData object here
 # for 'autogenerate' support
 sys.path.append(dirname(dirname(__file__)))
-from anitya.lib.model import BASE
 target_metadata = BASE.metadata
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:
 # my_important_option = config.get_main_option("my_important_option")
 # ... etc.
+
 
 def run_migrations_offline():
     """Run migrations in 'offline' mode.
@@ -41,6 +46,7 @@ def run_migrations_offline():
 
     with context.begin_transaction():
         context.run_migrations()
+
 
 def run_migrations_online():
     """Run migrations in 'online' mode.
@@ -66,8 +72,8 @@ def run_migrations_online():
     finally:
         connection.close()
 
+
 if context.is_offline_mode():
     run_migrations_offline()
 else:
     run_migrations_online()
-

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -3,16 +3,17 @@
 Revision ID: ${up_revision}
 Revises: ${down_revision}
 Create Date: ${create_date}
-
 """
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
 
 # revision identifiers, used by Alembic.
 revision = ${repr(up_revision)}
 down_revision = ${repr(down_revision)}
 
-from alembic import op
-import sqlalchemy as sa
-${imports if imports else ""}
 
 def upgrade():
     ${upgrades if upgrades else "pass"}

--- a/alembic/versions/2925648d8cc3_add_a_version_prefix_field.py
+++ b/alembic/versions/2925648d8cc3_add_a_version_prefix_field.py
@@ -6,12 +6,12 @@ Create Date: 2015-10-22 09:49:10.757572
 
 """
 
+from alembic import op
+import sqlalchemy as sa
+
 # revision identifiers, used by Alembic.
 revision = '2925648d8cc3'
 down_revision = '571bd07533a9'
-
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/alembic/versions/571bd07533a9_add_insecure_column_to_projects_table.py
+++ b/alembic/versions/571bd07533a9_add_insecure_column_to_projects_table.py
@@ -6,12 +6,12 @@ Create Date: 2015-03-23 17:18:11.421783
 
 """
 
+from alembic import op
+import sqlalchemy as sa
+
 # revision identifiers, used by Alembic.
 revision = '571bd07533a9'
 down_revision = None
-
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/alembic/versions/921c612ba0da_model_upstream_ecosystems.py
+++ b/alembic/versions/921c612ba0da_model_upstream_ecosystems.py
@@ -6,18 +6,22 @@ Create Date: 2016-08-09 18:44:53.119461
 
 """
 
+from alembic import op
+import sqlalchemy as sa
+
 # revision identifiers, used by Alembic.
 revision = '921c612ba0da'
 down_revision = '2925648d8cc3'
 
-from alembic import op
-import sqlalchemy as sa
-
 
 def upgrade():
-    op.add_column('projects', sa.Column('ecosystem_name', sa.String(length=200), nullable=True))
-    op.create_unique_constraint('UNIQ_PROJECT_NAME_PER_ECOSYSTEM', 'projects', ['name', 'ecosystem_name'])
-    op.create_foreign_key('FK_ECOSYSTEM_FOR_PROJECT', 'projects', 'ecosystems', ['ecosystem_name'], ['name'], onupdate='cascade', ondelete='set null')
+    op.add_column(
+        'projects', sa.Column('ecosystem_name', sa.String(length=200), nullable=True))
+    op.create_unique_constraint(
+        'UNIQ_PROJECT_NAME_PER_ECOSYSTEM', 'projects', ['name', 'ecosystem_name'])
+    op.create_foreign_key(
+        'FK_ECOSYSTEM_FOR_PROJECT', 'projects', 'ecosystems', ['ecosystem_name'],
+        ['name'], onupdate='cascade', ondelete='set null')
 
 
 def downgrade():

--- a/alembic/versions/9c29da0af3af_populate_ecosystem_data.py
+++ b/alembic/versions/9c29da0af3af_populate_ecosystem_data.py
@@ -6,12 +6,11 @@ Create Date: 2017-01-11 22:23:58.497998
 
 """
 
+from alembic import op
+
 # revision identifiers, used by Alembic.
 revision = '9c29da0af3af'
 down_revision = '921c612ba0da'
-
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/anitya/tests/base.py
+++ b/anitya/tests/base.py
@@ -32,8 +32,8 @@ import mock
 import anitya.lib
 import anitya.lib.model as model
 
-#DB_PATH = 'sqlite:///:memory:'
-## A file database is required to check the integrity, don't ask
+# DB_PATH = 'sqlite:///:memory:'
+# A file database is required to check the integrity, don't ask
 DB_PATH = 'sqlite:////tmp/anitya_test.sqlite'
 FAITOUT_URL = 'http://faitout.fedorainfracloud.org/'
 
@@ -53,11 +53,6 @@ def skip_jenkins(function):
     @wraps(function)
     def decorated_function(*args, **kwargs):
         """ Decorated function, actually does the work. """
-        ## We used to skip all these tests in jenkins, but now with vcrpy, we
-        ## don't need to.  We can replay the recorded request/response pairs
-        ## for each test from disk.
-        #if os.environ.get('BUILD_ID'):
-        #    raise unittest.SkipTest('Skip backend test on jenkins')
         return function(*args, **kwargs)
 
     return decorated_function

--- a/anitya/tests/lib/backends/test_bitbucket.py
+++ b/anitya/tests/lib/backends/test_bitbucket.py
@@ -73,7 +73,6 @@ class BitBucketBackendtests(Modeltests):
         self.session.add(project)
         self.session.commit()
 
-
     def test_get_version(self):
         """ Test the get_version function of the BitBucket backend. """
         pid = 1

--- a/anitya/tests/lib/backends/test_cpan.py
+++ b/anitya/tests/lib/backends/test_cpan.py
@@ -23,7 +23,6 @@
 anitya tests for the custom backend.
 '''
 
-import json
 import unittest
 
 import anitya.lib.backends.cpan as backend
@@ -64,7 +63,6 @@ class CpanBackendtests(Modeltests):
         self.session.add(project)
         self.session.commit()
 
-
     def test_cpan_get_version(self):
         """ Test the get_version function of the custom backend. """
         pid = 1
@@ -80,7 +78,6 @@ class CpanBackendtests(Modeltests):
             backend.CpanBackend.get_version,
             project
         )
-
 
     def test_cpan_get_versions(self):
         """ Test the get_versions function of the custom backend. """

--- a/anitya/tests/lib/backends/test_debian.py
+++ b/anitya/tests/lib/backends/test_debian.py
@@ -25,8 +25,6 @@ anitya tests for the debian backend.
 
 import unittest
 
-import mock
-
 from anitya.lib.exceptions import AnityaPluginException
 from anitya.lib.backends import get_versions_by_regex_for_text
 from anitya.tests.base import Modeltests, create_distro, skip_jenkins
@@ -74,7 +72,6 @@ class DebianBackendtests(Modeltests):
         )
         self.session.add(project)
         self.session.commit()
-
 
     def test_get_version(self):
         """ Test the get_version function of the debian backend. """

--- a/anitya/tests/lib/backends/test_drupal6.py
+++ b/anitya/tests/lib/backends/test_drupal6.py
@@ -23,7 +23,6 @@
 anitya tests for the custom backend.
 '''
 
-import json
 import unittest
 
 import anitya.lib.backends.drupal6 as backend
@@ -71,7 +70,6 @@ class Drupal6Backendtests(Modeltests):
         )
         self.session.add(project)
         self.session.commit()
-
 
     def test_get_version(self):
         """ Test the get_version function of the debian backend. """

--- a/anitya/tests/lib/backends/test_drupal7.py
+++ b/anitya/tests/lib/backends/test_drupal7.py
@@ -23,7 +23,6 @@
 anitya tests for the custom backend.
 '''
 
-import json
 import unittest
 
 import anitya.lib.backends.drupal7 as backend
@@ -71,7 +70,6 @@ class Drupal7Backendtests(Modeltests):
         )
         self.session.add(project)
         self.session.commit()
-
 
     def test_get_version(self):
         """ Test the get_version function of the debian backend. """

--- a/anitya/tests/lib/backends/test_freshmeat.py
+++ b/anitya/tests/lib/backends/test_freshmeat.py
@@ -23,7 +23,6 @@
 anitya tests for the custom backend.
 '''
 
-import json
 import unittest
 
 import anitya.lib.backends.freshmeat as backend

--- a/anitya/tests/lib/backends/test_github.py
+++ b/anitya/tests/lib/backends/test_github.py
@@ -73,7 +73,6 @@ class GithubBackendtests(Modeltests):
         self.session.add(project)
         self.session.commit()
 
-
     def test_get_version(self):
         """ Test the get_version function of the github backend. """
         pid = 1

--- a/anitya/tests/lib/backends/test_gnome.py
+++ b/anitya/tests/lib/backends/test_gnome.py
@@ -155,7 +155,6 @@ class GnomeBackendtests(Modeltests):
             u'3.16.1', u'3.16.2', u'3.17.1', u'3.17.2',
         ]
         obs = backend.GnomeBackend.get_ordered_versions(project)
-        #print [str(o) for o in obs]
         self.assertEqual(obs, exp)
 
         pid = 2
@@ -205,7 +204,6 @@ class GnomeBackendtests(Modeltests):
             u'3.16.0', u'3.16.1', u'3.16.2',
         ]
         obs = backend.GnomeBackend.get_ordered_versions(project)
-        #print [str(o) for o in obs]
         self.assertEqual(obs, exp)
 
 

--- a/anitya/tests/lib/backends/test_gnu.py
+++ b/anitya/tests/lib/backends/test_gnu.py
@@ -23,7 +23,6 @@
 anitya tests for the custom backend.
 '''
 
-import json
 import unittest
 
 import anitya.lib.backends.gnu as backend

--- a/anitya/tests/lib/backends/test_google.py
+++ b/anitya/tests/lib/backends/test_google.py
@@ -23,7 +23,6 @@
 anitya tests for the custom backend.
 '''
 
-import json
 import unittest
 
 import anitya.lib.backends.google as backend
@@ -64,7 +63,6 @@ class GoogleBackendtests(Modeltests):
         self.session.add(project)
         self.session.commit()
 
-
     def test_cpan_get_version(self):
         """ Test the get_version function of the custom backend. """
         pid = 1
@@ -80,7 +78,6 @@ class GoogleBackendtests(Modeltests):
             backend.GoogleBackend.get_version,
             project
         )
-
 
     def test_cpan_get_versions(self):
         """ Test the get_versions function of the custom backend. """

--- a/anitya/tests/lib/backends/test_hackage.py
+++ b/anitya/tests/lib/backends/test_hackage.py
@@ -23,7 +23,6 @@
 anitya tests for the custom backend.
 '''
 
-import json
 import unittest
 
 import anitya.lib.backends.hackage as backend
@@ -64,7 +63,6 @@ class HackageBackendtests(Modeltests):
         self.session.add(project)
         self.session.commit()
 
-
     def test_get_version(self):
         """ Test the get_version function of the custom backend. """
         pid = 1
@@ -80,7 +78,6 @@ class HackageBackendtests(Modeltests):
             backend.HackageBackend.get_version,
             project
         )
-
 
     def test_get_versions(self):
         """ Test the get_versions function of the custom backend. """

--- a/anitya/tests/lib/backends/test_launchpad.py
+++ b/anitya/tests/lib/backends/test_launchpad.py
@@ -23,7 +23,6 @@
 anitya tests for the custom backend.
 '''
 
-import json
 import unittest
 
 import anitya.lib.backends.launchpad as backend
@@ -64,7 +63,6 @@ class LaunchpadBackendtests(Modeltests):
         self.session.add(project)
         self.session.commit()
 
-
     def test_get_version(self):
         """ Test the get_version function of the custom backend. """
         pid = 1
@@ -80,7 +78,6 @@ class LaunchpadBackendtests(Modeltests):
             backend.LaunchpadBackend.get_version,
             project
         )
-
 
     def test_get_versions(self):
         """ Test the get_versions function of the custom backend. """

--- a/anitya/tests/lib/backends/test_maven.py
+++ b/anitya/tests/lib/backends/test_maven.py
@@ -87,7 +87,7 @@ class MavenBackendTest(Modeltests):
     def test_maven_get_version_by_url(self):
         self.assert_plexus_version(
             name='plexus-maven-plugin',
-            homepage='http://repo1.maven.org/maven2/'\
+            homepage='http://repo1.maven.org/maven2/'
                      'org/codehaus/plexus/plexus-maven-plugin/',
         )
 

--- a/anitya/tests/lib/backends/test_pagure.py
+++ b/anitya/tests/lib/backends/test_pagure.py
@@ -23,7 +23,6 @@
 anitya tests for the pagure backend.
 '''
 
-import json
 import unittest
 
 import anitya.lib.backends.pagure as backend

--- a/anitya/tests/lib/backends/test_pear.py
+++ b/anitya/tests/lib/backends/test_pear.py
@@ -23,7 +23,6 @@
 anitya tests for the custom backend.
 '''
 
-import json
 import unittest
 
 import anitya.lib.backends.pear as backend
@@ -64,7 +63,6 @@ class PearBackendtests(Modeltests):
         self.session.add(project)
         self.session.commit()
 
-
     def test_get_version(self):
         """ Test the get_version function of the custom backend. """
         pid = 1
@@ -80,7 +78,6 @@ class PearBackendtests(Modeltests):
             backend.PearBackend.get_version,
             project
         )
-
 
     def test_get_versions(self):
         """ Test the get_versions function of the custom backend. """

--- a/anitya/tests/lib/backends/test_pecl.py
+++ b/anitya/tests/lib/backends/test_pecl.py
@@ -23,7 +23,6 @@
 anitya tests for the custom backend.
 '''
 
-import json
 import unittest
 
 import anitya.lib.backends.pecl as backend
@@ -64,7 +63,6 @@ class PeclBackendtests(Modeltests):
         self.session.add(project)
         self.session.commit()
 
-
     def test_get_version(self):
         """ Test the get_version function of the custom backend. """
         pid = 1
@@ -80,7 +78,6 @@ class PeclBackendtests(Modeltests):
             backend.PeclBackend.get_version,
             project
         )
-
 
     def test_get_versions(self):
         """ Test the get_versions function of the custom backend. """

--- a/anitya/tests/lib/backends/test_pypi.py
+++ b/anitya/tests/lib/backends/test_pypi.py
@@ -23,7 +23,6 @@
 anitya tests for the pypi backend.
 '''
 
-import json
 import unittest
 
 import anitya.lib.backends.pypi as backend

--- a/anitya/tests/lib/backends/test_rubygems.py
+++ b/anitya/tests/lib/backends/test_rubygems.py
@@ -63,7 +63,6 @@ class RubygemsBackendtests(Modeltests):
         self.session.add(project)
         self.session.commit()
 
-
     def test_get_version(self):
         """ Test the get_version function of the rubygems backend. """
         pid = 1
@@ -79,7 +78,6 @@ class RubygemsBackendtests(Modeltests):
             backend.RubygemsBackend.get_version,
             project
         )
-
 
     def test_get_versions(self):
         """ Test the get_versions function of the rubygems backend. """

--- a/anitya/tests/lib/backends/test_sourceforge.py
+++ b/anitya/tests/lib/backends/test_sourceforge.py
@@ -71,7 +71,6 @@ class SourceforgeBackendtests(Modeltests):
         self.session.add(project)
         self.session.commit()
 
-
     def test_get_version(self):
         """ Test the get_version function of the sourceforge backend. """
         pid = 1

--- a/anitya/tests/lib/backends/test_stackage.py
+++ b/anitya/tests/lib/backends/test_stackage.py
@@ -23,7 +23,6 @@
 anitya tests for the custom backend.
 '''
 
-import json
 import unittest
 
 import anitya.lib.backends.stackage as backend
@@ -64,7 +63,6 @@ class HackageBackendtests(Modeltests):
         self.session.add(project)
         self.session.commit()
 
-
     def test_get_version(self):
         """ Test the get_version function of the Stackage backend. """
         pid = 1
@@ -80,7 +78,6 @@ class HackageBackendtests(Modeltests):
             backend.StackageBackend.get_version,
             project
         )
-
 
     def test_get_versions(self):
         """ Test the get_versions function of the Stackage backend. """

--- a/anitya/tests/lib/test_plugins.py
+++ b/anitya/tests/lib/test_plugins.py
@@ -23,11 +23,9 @@
 anitya tests of the plugins.
 '''
 
-import datetime
 import unittest
 
 from anitya.lib import plugins
-from anitya.lib import model
 from anitya.lib.versions import Version
 from anitya.tests.base import Modeltests
 
@@ -75,7 +73,7 @@ class Pluginstests(Modeltests):
 
         ecosystem_plugins = all_plugins["ecosystems"]
         ecosystems = dict((plugin.name, plugin.default_backend)
-                              for plugin in ecosystem_plugins)
+                          for plugin in ecosystem_plugins)
         self.assertEqual(ecosystems, EXPECTED_ECOSYSTEMS)
 
     def test_load_plugins(self):

--- a/anitya/tests/test_distro.py
+++ b/anitya/tests/test_distro.py
@@ -24,8 +24,6 @@ anitya tests for the Distro object.
 '''
 
 import unittest
-import sys
-import os
 
 import anitya.lib.model as model
 from anitya.tests.base import Modeltests, create_distro

--- a/anitya/tests/test_flask.py
+++ b/anitya/tests/test_flask.py
@@ -310,10 +310,11 @@ class FlaskTest(Modeltests):
                 </a>"""
         self.assertTrue(expected in output.data)
 
-        expected = b"""
-                <a href="https://fedorahosted.org/r2spec/" target="_blank" rel="noopener noreferrer">
-                  https://fedorahosted.org/r2spec/
-                </a>"""
+        expected = (
+            b'\n                <a href="https://fedorahosted.org/r2spec/" target="_blank"'
+            b' rel="noopener noreferrer">\n                  '
+            b'https://fedorahosted.org/r2spec/\n                </a>'
+        )
         self.assertTrue(expected in output.data)
 
         expected = b"""

--- a/anitya/tests/test_flask_admin.py
+++ b/anitya/tests/test_flask_admin.py
@@ -24,12 +24,7 @@ anitya tests for the flask application.
 '''
 
 import datetime
-import json
 import unittest
-import sys
-import os
-
-import flask
 
 import anitya
 from anitya.lib import model
@@ -496,7 +491,7 @@ class FlaskAdminTest(Modeltests):
                 sess['email'] = 'pingou@pingoured.fr'
 
             output = c.post('/flags/{0}/set/closed'.format(flag.id),
-                           follow_redirects=True)
+                            follow_redirects=True)
 
             # Non-admin ID will complain, insufficient creds
             self.assertEqual(output.status_code, 401)
@@ -516,7 +511,7 @@ class FlaskAdminTest(Modeltests):
                 sess['email'] = 'pingou@pingoured.fr'
 
             output = c.post('/flags/{0}/set/closed'.format(flag.id),
-                           follow_redirects=True)
+                            follow_redirects=True)
             self.assertEqual(output.status_code, 200)
 
             # Now the flag state should *not* have toggled because while we did
@@ -551,7 +546,7 @@ class FlaskAdminTest(Modeltests):
                 sess['email'] = 'pingou@pingoured.fr'
 
             output = c.post('/flags/{0}/set/open'.format(flag.id),
-                           follow_redirects=True)
+                            follow_redirects=True)
 
             # Get a new CSRF Token
             output = c.get('/distro/add')
@@ -579,7 +574,7 @@ class FlaskAdminTest(Modeltests):
                 sess['email'] = 'pingou@pingoured.fr'
 
             output = c.post('/flags/{0}/set/nonsense'.format(flag.id),
-                           follow_redirects=True)
+                            follow_redirects=True)
             self.assertEqual(output.status_code, 422)
 
         # Make sure that passing garbage doesn't change anything.

--- a/anitya/tests/test_flask_api.py
+++ b/anitya/tests/test_flask_api.py
@@ -25,14 +25,13 @@ anitya tests for the flask API.
 
 import json
 import unittest
-import sys
-import os
 
 import anitya
 import anitya.lib.model as model
 from anitya.lib.backends import REGEX
 from anitya.tests.base import (Modeltests, create_distro, create_project,
                                create_package, create_ecosystem_projects)
+
 
 # Py3 compatibility: UTF-8 decoding and JSON decoding may be separate steps
 def _read_json(output):
@@ -278,9 +277,6 @@ class AnityaWebAPItests(Modeltests):
             "output": "notok"
         }
 
-        # This test will break for every update of geany, so we need to
-        # keep the output easy on hand.
-        #print output.data
         self.assertEqual(data, exp)
 
         # Modify it back:
@@ -312,9 +308,6 @@ class AnityaWebAPItests(Modeltests):
             ],
         }
 
-        # This test will break for every update of geany, so we need to
-        # keep the output easy on hand.
-        #print output.data
         self.assertEqual(data, exp)
 
     def test_api_get_project(self):
@@ -460,6 +453,7 @@ class AnityaWebAPItests(Modeltests):
         }
 
         self.assertEqual(data, exp)
+
 
 if __name__ == '__main__':
     SUITE = unittest.TestLoader().loadTestsFromTestCase(AnityaWebAPItests)

--- a/anitya/tests/test_flask_api_v2.py
+++ b/anitya/tests/test_flask_api_v2.py
@@ -31,14 +31,16 @@ import oauthlib.oauth2
 import requests_oauthlib
 
 import mock
-import unittest2 as unittest # Ensure we always have TestCase.addCleanup
+import unittest2 as unittest  # Ensure we always have TestCase.addCleanup
 
 import anitya
 from .base import (Modeltests, create_project)
 
+
 # Py3 compatibility: UTF-8 decoding and JSON decoding may be separate steps
 def _read_json(output):
     return json.loads(output.get_data(as_text=True))
+
 
 class _APItestsMixin(object):
     """Helper mixin to set up API testing environment"""
@@ -261,7 +263,6 @@ class AuthenticationRequiredTests(_APItestsMixin, Modeltests):
             }
         self.assertEqual(data, exp)
 
-
     def test_project_monitoring_request(self):
         self.maxDiff = None
         output = self.app.post('/api/v2/projects/')
@@ -327,6 +328,7 @@ class MockAuthenticationTests(_AuthenticatedAPItestsMixin, Modeltests):
 
     def setUp(self):
         super(MockAuthenticationTests, self).setUp()
+
         # Replace anitya.authentication._validate_api_token
         def _bypass_token_validation(validated, raw_api, *args, **kwds):
             return raw_api(*args, **kwds)
@@ -341,6 +343,7 @@ class MockAuthenticationTests(_AuthenticatedAPItestsMixin, Modeltests):
         }
 
         test_case = self
+
         class MockOIDC:
             # In the live API, `access_token` is optional, but here we expect
             # to receive it
@@ -412,7 +415,6 @@ class LiveAuthenticationTests(_AuthenticatedAPItestsMixin, Modeltests):
         oidc_credentials["client_token"] = token
 
         with open(CREDENTIALS_FILE, "w") as f:
-            refresh_token_id = token["refresh_token"][:]
             json.dump(oidc_credentials, f)
         return token["access_token"]
 

--- a/createdb.py
+++ b/createdb.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 
 from anitya.app import APP
 import anitya.lib

--- a/files/anitya_cron.py
+++ b/files/anitya_cron.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 
 import sys
 import logging
@@ -46,7 +46,6 @@ def projects_by_feed(session):
             LOG.debug("Project %s is already up to date." % project.name)
         else:
             yield project
-
 
 
 def update_project(project_id):

--- a/files/migrate_wiki.py
+++ b/files/migrate_wiki.py
@@ -2,8 +2,9 @@
 # -*- coding: utf-8 -*-
 """ Migrate all the projects present on the wiki into Cnucnu Web """
 
-## Requires:
-## project name -- Fedora package name
+# Requires:
+# project name -- Fedora package name
+#
 # python-bugzilla -- python-bugzilla
 # PyYAML -- PyYAML
 # pycurl -- python-pycurl
@@ -12,12 +13,10 @@
 import os
 import pprint
 
-import cnucnu
 from cnucnu.package_list import PackageList
 import anitya.app
 import anitya.lib
 import anitya.lib.plugins
-from anitya.lib import model
 
 import anitya.lib.backends.sourceforge
 import anitya.lib.backends.gnu
@@ -143,14 +142,6 @@ def migrate_wiki(agent):
             url = CONVERT_URL[url] % (name or pkg.name)
         else:
             url = clean_url(url)
-
-        # Code for this lives here:
-        # http://ambre.pingoured.fr/cgit/cnucnu.git/tree/cnucnu/__init__.py?h=devel#n39
-        #if name:
-        #    name = cnucnu.clear_name(name, url)
-        #    # Only keep the name if it is
-        #    #if pkg.name.lower().startswith(name.lower()):
-        #        #name = None
 
         project = anitya.lib.model.Project.get_or_create(
             SESSION,

--- a/runserver.py
+++ b/runserver.py
@@ -3,8 +3,9 @@
 """ The flask application """
 
 import argparse
-import sys
 import os
+
+from anitya.app import APP
 
 
 parser = argparse.ArgumentParser(
@@ -45,6 +46,5 @@ if args.config:
     os.environ['ANITYA_WEB_CONFIG'] = config
 
 
-from anitya.app import APP
 APP.debug = True
 APP.run(port=int(args.port), host=args.host)

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ Setup script
 from setuptools import setup, find_packages
 import re
 
+
 def get_project_version():
     """Read the declared version of the project from the source code"""
     version_file = "anitya/app.py"
@@ -17,6 +18,7 @@ def get_project_version():
         err_msg = "No line matching  %r found in %r"
         raise ValueError(err_msg % (version_pattern, version_file))
     return match.groups()[0].decode("utf-8")
+
 
 def get_requirements(requirements_file='requirements/requirements.txt'):
     """Get the contents of a file listing the requirements.

--- a/tox.ini
+++ b/tox.ini
@@ -60,4 +60,4 @@ commands =
 [flake8]
 show-source = True
 max-line-length = 100
-exclude = .git,.tox,dist,*egg,doc,files,alembic,tests,createdb.py,runserver.py,setup.py
+exclude = .git,.tox,dist,*egg,build


### PR DESCRIPTION
This fixes all the PEP-8 problems as reported by flake8 on the tests,
alembic migrations and other Python files. It also adjusts the Tox
configuration to enforce PEP-8 on all these files.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>