### PR TITLE
allow the vagrant box to be provisioned with empty database

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,11 @@ You may then access Anitya on your host at::
 
     http://127.0.0.1:5000
 
+By default anitya imports the production database so you've got something
+to work off of. If instead you prefer an empty database, add the following
+to the ansible provisioner inside your `Vagrantfile`::
+
+    ansible.extra_vars = { import_production_database: false }
 
 virtualenv
 ``````````

--- a/ansible/roles/anitya-dev/defaults/main.yml
+++ b/ansible/roles/anitya-dev/defaults/main.yml
@@ -1,0 +1,1 @@
+import_production_database: true

--- a/ansible/roles/anitya-dev/tasks/db.yml
+++ b/ansible/roles/anitya-dev/tasks/db.yml
@@ -41,6 +41,7 @@
 - shell: xzcat /tmp/anitya.dump.xz | runuser -l postgres -c 'psql anitya' && touch /home/vagrant/.db-imported
   args:
       creates: /home/vagrant/.db-imported
+  when: import_production_database
 
 - name: Create /home/vagrant/alembic.ini
   become_user: "{{ ansible_env.SUDO_USER }}"
@@ -63,4 +64,15 @@
   command: ~/.virtualenvs/anitya/bin/alembic upgrade head
   args:
       chdir: /home/vagrant/
+  when: import_production_database
 
+- name: Create database schema
+  become_user: "{{ ansible_env.SUDO_USER }}"
+  shell: >
+      source ~/.virtualenvs/anitya/bin/activate && python createdb.py && touch ~/.schema-created
+  args:
+    creates: /home/vagrant/.schema-created
+    chdir: /home/vagrant/devel
+  environment:
+    ANITYA_WEB_CONFIG: /home/vagrant/anitya.toml
+  when: not import_production_database


### PR DESCRIPTION
Sometimes a clean slate is better for local development. By default imports the production database so you've got something to work off of. With this change, it's possible to just creates the empty database schema.

Note that I'm not that deep into anitya yet. Creating an empty DB allows the service to start and also renders the main web views. I haven't tested anything more until now.