### PR TITLE
new backend: GitHub API

### DIFF
--- a/anitya/config.py
+++ b/anitya/config.py
@@ -85,6 +85,7 @@ DEFAULTS = dict(
         os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
         'client_secrets.json'
     ),
+    GITHUB_ACCESS_TOKEN=None,
     # Force the application to require HTTPS to save the cookie. This should only
     # be `False` in a development environment running on the local host!
     OIDC_ID_TOKEN_COOKIE_SECURE=True,

--- a/anitya/lib/backends/githubapi.py
+++ b/anitya/lib/backends/githubapi.py
@@ -10,6 +10,7 @@
 
 import github3
 
+import anitya
 from anitya.lib.backends import BaseBackend
 from anitya.lib.exceptions import AnityaPluginException
 
@@ -72,7 +73,14 @@ class GithubApiBackend(BaseBackend):
             raise AnityaPluginException(
                 'Project %s was incorrectly set-up' % project.name)
 
-        repo = github3.repository(owner, repo)
+        github_access_token = anitya.app.APP.config.get('GITHUB_ACCESS_TOKEN')
+
+        if github_access_token:
+            gh = github3.login(token=github_access_token)
+        else:
+            gh = github3
+
+        repo = gh.repository(owner, repo)
 
         if not repo:
             raise AnityaPluginException(

--- a/anitya/lib/backends/githubapi.py
+++ b/anitya/lib/backends/githubapi.py
@@ -1,12 +1,23 @@
 # -*- coding: utf-8 -*-
-
-"""
- (c) 2014 - Copyright Red Hat Inc
-
- Authors:
-   Michael Lutonsky <m@luto.at>
-
-"""
+#
+# Copyright © 2014  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions
+# of the GNU General Public License v.2, or (at your option) any later
+# version.  This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.  You
+# should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# Any Red Hat trademarks that are incorporated in the source
+# code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission
+# of Red Hat, Inc.
+#
 
 import github3
 

--- a/anitya/lib/backends/githubapi.py
+++ b/anitya/lib/backends/githubapi.py
@@ -74,7 +74,7 @@ class GithubApiBackend(BaseBackend):
             url = project.homepage
         else:
             raise AnityaPluginException(
-                'Project %s was incorrectly set-up' % project.name)
+                'Project %s does not have a version URL or homepage' % project.name)
 
         url = url.replace('https://github.com/', '')
 
@@ -82,7 +82,7 @@ class GithubApiBackend(BaseBackend):
             owner, repo = url.split('/')
         except:
             raise AnityaPluginException(
-                'Project %s was incorrectly set-up' % project.name)
+                'The URL of project %s does not look like a github one' % project.name)
 
         github_access_token = anitya.app.APP.config.get('GITHUB_ACCESS_TOKEN')
 
@@ -95,7 +95,7 @@ class GithubApiBackend(BaseBackend):
 
         if not repo:
             raise AnityaPluginException(
-                'Project %s does not exists on GitHub' % project.name)
+                'Project %s does not exist on GitHub' % project.name)
 
         versions = []
 

--- a/anitya/lib/backends/githubapi.py
+++ b/anitya/lib/backends/githubapi.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+
+"""
+ (c) 2014 - Copyright Red Hat Inc
+
+ Authors:
+   Michael Lutonsky <m@luto.at>
+
+"""
+
+import github3
+
+from anitya.lib.backends import BaseBackend
+from anitya.lib.exceptions import AnityaPluginException
+
+
+class GithubApiBackend(BaseBackend):
+    ''' The custom class for projects hosted on github.com. It uses the github
+    API instead of parsing the HTML returned by the web interface like github.py
+    '''
+
+    name = 'GitHub API'
+    examples = [
+        'https://github.com/fedora-infra/fedocal',
+        'https://github.com/fedora-infra/pkgdb2',
+    ]
+
+    @classmethod
+    def get_version(cls, project):
+        ''' Method called to retrieve the latest version of the projects
+        provided, project that relies on the backend of this plugin.
+
+        :arg Project project: a :class:`model.Project` object whose backend
+            corresponds to the current plugin.
+        :return: the latest version found upstream
+        :return type: str
+        :raise AnityaPluginException: a
+            :class:`anitya.lib.exceptions.AnityaPluginException` exception
+            when the version cannot be retrieved correctly
+
+        '''
+        return cls.get_ordered_versions(project)[-1]
+
+    @classmethod
+    def get_versions(cls, project):
+        ''' Method called to retrieve all the versions (that can be found)
+        of the projects provided, project that relies on the backend of
+        this plugin.
+
+        :arg Project project: a :class:`model.Project` object whose backend
+            corresponds to the current plugin.
+        :return: a list of all the possible releases found
+        :return type: list
+        :raise AnityaPluginException: a
+            :class:`anitya.lib.exceptions.AnityaPluginException` exception
+            when the versions cannot be retrieved correctly
+
+        '''
+        if project.version_url:
+            url = project.version_url
+        elif project.homepage.startswith('https://github.com'):
+            url = project.homepage
+        else:
+            raise AnityaPluginException(
+                'Project %s was incorrectly set-up' % project.name)
+
+        url = url.replace('https://github.com/', '')
+
+        try:
+            owner, repo = url.split('/')
+        except:
+            raise AnityaPluginException(
+                'Project %s was incorrectly set-up' % project.name)
+
+        repo = github3.repository(owner, repo)
+
+        if not repo:
+            raise AnityaPluginException(
+                'Project %s does not exists on GitHub' % project.name)
+
+        versions = []
+
+        for tag in repo.tags():
+            version = tag.name
+
+            if project.version_prefix is not None and \
+                    version.startswith(project.version_prefix):
+                version = version[len(project.version_prefix):]
+            elif version.startswith('v'):
+                version = version[1:]
+
+            versions.append(version)
+
+        return versions

--- a/anitya/templates/project_new.html
+++ b/anitya/templates/project_new.html
@@ -133,7 +133,7 @@
       $('#version_url_row').show();
       $('#insecure_row').show();
     };
-    if (str == 'GitHub'){
+    if (str == 'GitHub' || str == 'GitHub API'){
       $("label[for='version_url']").text('GitHub owner/project');
       $('#version_url_row').show();
     };

--- a/anitya/tests/lib/backends/test_githubapi.py
+++ b/anitya/tests/lib/backends/test_githubapi.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2014  Red Hat, Inc.
+# Copyright © 2017  Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions

--- a/anitya/tests/lib/backends/test_githubapi.py
+++ b/anitya/tests/lib/backends/test_githubapi.py
@@ -1,0 +1,157 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2014  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions
+# of the GNU General Public License v.2, or (at your option) any later
+# version.  This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.  You
+# should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# Any Red Hat trademarks that are incorporated in the source
+# code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission
+# of Red Hat, Inc.
+#
+
+'''
+anitya tests for the custom backend.
+'''
+
+import unittest
+
+import anitya.lib.backends.githubapi as backend
+import anitya.lib.model as model
+from anitya.lib.exceptions import AnityaPluginException
+from anitya.tests.base import Modeltests, create_distro, skip_jenkins
+
+
+BACKEND = 'GitHub API'
+
+
+class GithubApiBackendtests(Modeltests):
+    """ Github API backend tests. """
+
+    @skip_jenkins
+    def setUp(self):
+        """ Set up the environnment, ran before every tests. """
+        super(GithubApiBackendtests, self).setUp()
+
+        create_distro(self.session)
+        self.create_project()
+
+    def create_project(self):
+        """ Create some basic projects to work with. """
+        project = model.Project(
+            name='fedocal',
+            homepage='https://github.com/fedora-infra/fedocal',
+            version_url='fedora-infra/fedocal',
+            backend=BACKEND,
+        )
+        self.session.add(project)
+        self.session.commit()
+
+        project = model.Project(
+            name='foobar',
+            homepage='http://github.com/foo/bar',
+            version_url='foobar/bar',
+            backend=BACKEND,
+        )
+        self.session.add(project)
+        self.session.commit()
+
+        project = model.Project(
+            name='pkgdb2',
+            homepage='https://github.com/fedora-infra/pkgdb2',
+            backend=BACKEND,
+        )
+        self.session.add(project)
+        self.session.commit()
+
+    def test_get_version(self):
+        """ Test the get_version function of the github backend. """
+        pid = 1
+        project = model.Project.get(self.session, pid)
+        exp = '0.15.1'
+        obs = backend.GithubApiBackend.get_version(project)
+        self.assertEqual(obs, exp)
+
+        pid = 2
+        project = model.Project.get(self.session, pid)
+        self.assertRaises(
+            AnityaPluginException,
+            backend.GithubApiBackend.get_version,
+            project
+        )
+
+        pid = 3
+        project = model.Project.get(self.session, pid)
+        exp = '2.6.2'
+        obs = backend.GithubApiBackend.get_version(project)
+        self.assertEqual(obs, exp)
+
+    def test_get_versions(self):
+        """ Test the get_versions function of the github backend. """
+        pid = 1
+        project = model.Project.get(self.session, pid)
+        exp = [
+            u'0.1.0', u'0.1.1', u'0.1.2', u'0.2.0', u'0.3.0', u'0.3.1',
+            u'0.4.0', u'0.4.1', u'0.4.2', u'0.4.3', u'0.4.5', u'.0.4.6',
+            u'0.4.7', u'0.5.0', u'0.5.1', u'0.6.0', u'0.6.1', u'0.6.2',
+            u'0.6.3', u'0.7', u'0.7.1', u'0.8', u'0.9', u'0.9.1', u'0.9.2',
+            u'0.9.3', u'0.10', u'0.11', u'0.11.1', u'0.12', u'0.13',
+            u'0.13.1', u'0.13.2', u'0.13.3', u'0.14', u'0.15', u'0.15.1'
+        ]
+
+        obs = backend.GithubApiBackend.get_ordered_versions(project)
+        self.assertEqual(obs, exp)
+
+        pid = 2
+        project = model.Project.get(self.session, pid)
+        self.assertRaises(
+            AnityaPluginException,
+            backend.GithubApiBackend.get_versions,
+            project
+        )
+
+        pid = 3
+        project = model.Project.get(self.session, pid)
+        exp = [
+            u'0.1', u'0.2', u'0.2.1', u'0.3', u'0.4', u'0.5', u'0.6', u'0.7',
+            u'0.8', u'1.0', u'1.1', u'1.2', u'1.3', u'1.4', u'1.5', u'1.6',
+            u'1.7', u'1.8', u'1.8.1', u'1.8.2', u'1.9', u'1.9.1', u'1.9.2',
+            u'1.10', u'1.10.1', u'1.11', u'1.11.1', u'1.12', u'1.12.1', u'1.13',
+            u'1.13.1', u'1.13.2', u'1.13.3', u'1.14', u'1.14.1', u'1.14.2',
+            u'1.14.3', u'1.14.4', u'1.15', u'1.16', u'1.17', u'1.18', u'1.18.1',
+            u'1.18.2', u'1.18.3', u'1.18.4', u'1.18.5', u'1.18.6', u'1.19',
+            u'1.20', u'1.20.1', u'1.21', u'1.22', u'1.22.1', u'1.22.2', u'1.23',
+            u'1.23.99', u'1.23.991', u'1.23.992', u'1.23.993', u'1.23.994',
+            u'1.23.995', u'1.24', u'1.24.1', u'1.24.2', u'1.24.3', u'1.25',
+            u'1.25.1', u'1.26', u'1.27', u'1.28', u'1.28.1', u'1.28.2', u'1.29',
+            u'1.30', u'1.30.1', u'1.31', u'1.32', u'1.32.1', u'1.32.2',
+            u'1.33.0', u'1.33.1', u'1.33.2', u'1.33.3', u'2.0', u'2.0.1',
+            u'2.0.2', u'2.0.3', u'2.1', u'2.2', u'2.3', u'2.4', u'2.4.1',
+            u'2.4.2', u'2.4.3', u'2.5', u'2.6', u'2.6.2'
+        ]
+
+        obs = backend.GithubApiBackend.get_ordered_versions(project)
+        self.assertEqual(obs, exp)
+
+    def test_plexus_utils(self):
+        """ Regression test for issue #286 """
+        project = model.Project(
+            version_url='codehaus-plexus/plexus-archiver',
+            version_prefix='plexus-archiver-',
+        )
+        version = backend.GithubApiBackend().get_version(project)
+        self.assertEqual(u'3.4', version)
+
+
+if __name__ == '__main__':
+    SUITE = unittest.TestLoader().loadTestsFromTestCase(GithubApiBackendtests)
+    unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/anitya/tests/lib/test_plugins.py
+++ b/anitya/tests/lib/test_plugins.py
@@ -32,7 +32,7 @@ from anitya.tests.base import Modeltests
 EXPECTED_BACKENDS = [
     'BitBucket', 'CPAN (perl)', 'crates.io', 'Debian project', 'Drupal6',
     'Drupal7', 'Freshmeat',
-    'GNOME', 'GNU project', 'GitHub', 'Google code', 'Hackage',
+    'GNOME', 'GNU project', 'GitHub', 'GitHub API', 'Google code', 'Hackage',
     'Launchpad', 'Maven Central', 'PEAR', 'PECL', 'Packagist', 'PyPI',
     'Rubygems', 'Sourceforge', 'Stackage', 'custom', 'folder', 'npmjs',
     'pagure',

--- a/anitya/tests/request-data/anitya.tests.lib.backends.test_githubapi.GithubApiBackendtests.test_get_version
+++ b/anitya/tests/request-data/anitya.tests.lib.backends.test_githubapi.GithubApiBackendtests.test_get_version
@@ -1,0 +1,357 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.0.0a4]
+    method: GET
+    uri: https://api.github.com/repos/fedora-infra/fedocal
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1YTW/jNhD9K4autUPLym42AordvfTaHnLqxaAl2mIjkQJJ2XAE//c+kpIlGYg/
+        pGuAILEZvsfHIWc4M3XA0yD+8frtNXp9ngeCFiyIgy1LZULzYB5sqzxf90YVXXCxVZR0U+RBMBXE
+        dZDLHRcNup0HCrtAFIXfv0cv84DuqaFqXakcEzNjSh0T4gf16mnHTVZtKs1UIoVhwjwlsiAVaeA/
+        939GINyphsUyBxi4YCt5Q+TRYNNObk9TZor8QoRf20EuJm9lnssDWC5l31qInJHWko6Fi91IFiBr
+        Ik3GYD1s6WQNwbV5XJRD1cT+WfPU8mgciWLpw8IaHGTZK3CqiWKldITVRieKl4ZL8bjAARpsUu2o
+        4B90HBvQGiRW2uNSHApotsdlfBzuYTUpFd/T5GhNo1jC+B7GHkl5gQejOZbWZ//uWckeATdsTdPC
+        euSW5pqd5oGTYTDZDczhf/d6Qc/dU3Y+Wqz6e3Zgm9mGapbOEDGYSKma0bLMeeLOa7aVavaXcz6I
+        wpf38+pXvdYZfuCIPQmW5sZhfI6HUwINMe/sOJ7EgmuC340LJfBuusEujbwVJ65IG7DUpP/V3h3D
+        aDFeskODJZNygvUcGixc64rddYmv7NeRaNK6iaiKjY9s9zjHFV4Ph0qqNd8JxsZb7cxQkzbsbhQV
+        STaBsyWoif/kzpbuxou0YHBscrkZT4IHkDiGmuiM+vfFrCfpspSWYMCo2HaaSEtwZjRqyuk6gZbh
+        zIc3zeCgxytsCUjdWDGnYlfR3QTKMwPO2L65O/pxMxu54h0dBfhsoqX4ppoYtzoSq9E///DlCWbs
+        ODpGl1BcT1Ou7buXlbidFwW/9ahfoWvwg7s9ldPex0te+/129nFDqCWoSRdgffhuqEdbtInfrcL+
+        Ak0CP/4CtASk/qOkJrPxCOuUVLHRchs8qW2+cnp6eqozRl0GXDA1xUE9HDxUJRmyu9EK65YASUpB
+        jUupt1ZgihQ7lzQdb88zA9j8uY1W6eH90y5RJo6X5tB9uoLnTBspJsTMjqJPLKTh2yY1Ha93wFL/
+        1FwkbE7zfI7baXjCcV9RrdljQ07IJhjGw7EBlOW+eMgZru545Yp5gpr4yi9lZS6P08JLj8P6qGIo
+        MdI1NagOVsswWiyjxWr1Fr7G0bc4XP6LOVWZDua8LJbhIly9LX/EmPYc2TllpbMeDaZEi2j5Fj7H
+        0RI/dgqCZXOF8QlthE8q+LZwsE0BoLTOOtSvDhP3q/4LTJLjLl64y52r7S/fqxs4KMxkwUokDL65
+        ofkHPq1enleDxz+RlYCJQzRtDtQgHcVb2xtrUwZw/HM0mRSWl+q1d92uAsRQqeR/LDE6iI2qbFWI
+        sS5Y9AYP/J0PkTarOY/4qqzVECKocqVk0+sRcHFU8iUTjYRW7NJXhaAJAelNCGL8q92a32jKtrTK
+        zdpnzdhaQbVB72nYIvhqRblK5bJ6bptYsNZXK6rpO95s4H21otCP/aSNitRk0MrCxbq/FSWYOaAP
+        cw5Z8P1+1dBEkVV4+h9kfTgqoRYAAA==
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['public, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 24 Jun 2017 17:52:55 GMT']
+      etag: [W/"9019d227404174437e13a045e3140714"]
+      last-modified: ['Thu, 12 Jan 2017 08:19:43 GMT']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: [Accept, Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['EA4E:16B4:4EA0537:5AA5C71:594EA6F7']
+      x-ratelimit-limit: ['60']
+      x-ratelimit-remaining: ['33']
+      x-ratelimit-reset: ['1498328685']
+      x-runtime-rack: ['0.035493']
+      x-served-by: [15bc4ab707db6d6b474783868c7cc828]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.0.0a4]
+    method: GET
+    uri: https://api.github.com/repos/fedora-infra/fedocal/tags?per_page=100
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62b226duQ2F38XX020dKErKqxTFQAeyMZBMAsfTiw7y7rPkP3U72r4QGvrOBrzo
+        /YWgFg/5+x8Pv7XP8vDh4V/uVm/x4ZeHfz997e3Tp19/f/6EH398efn67cPjY/v6dPvn08vH3/tt
+        fPn8+Cxfv3x7VJlfntvfnn7T5/b6zWifHn/8/uOb4Et7/inBH7//X0H8AZ+fXh4+/PHw7WPD39gH
+        a3FOpmOfQ3SUsvdNSQb7WVIWP6afmvHh/t8PdYX89ngc6vv3X/6KNlijXYKmaJfgjpaClJaiBJcy
+        jxhyas5lrTRDDG3MHEWVHBugPQ51h9Zbo12CpmiX4B3amijJzCOUNoPnkktKXGfVNnIrsYp0nxtZ
+        oD0NtaM1BmuM9R2oEZ+Um/c6uw+dJgUqc1YXVlnoeRZukVimAdTjUBvUYgt1yRnm6pLbM7X6mTuz
+        Rtd0yAycW84RxdW5UX31MgK3QskA6nGoDWq+GReBS9AQ7CW4o408xCElG2WeuWZuLUuOgQNSVZL6
+        2LwG7gZoj0PtaG3zdb3ClljfyVdFBSBXYqw68fj7Isl156tKbzW60FIrrutK9Z/1A8ehNqhsbbUu
+        QUOwl+Cer6FwIt9jmb5VZqoU8ER16SX0ETnI6F1JmwHa41B3aI2tFt+MrdYluKMVWK3InD1eKmKX
+        myOt3ffZqIjIoDkytVwN0B6HukNrXGX5tWybZu17VktcCq3U2NQPQrFNzmfRDINQtA4dBemcS3MW
+        aE9D3aFd0Q17L74tQVO0S3DP2p5qyFHDmGV2OK3qWhhamk7nA/lEohRHUQO0x6E2tMnaG1yChmgv
+        wR1tTsVPmigCmkacHAm9gYzGhbKyam21IJEtbNdxqDu0xlmbrLP2EtzRIk8lwVhRbXjOYLmS1MbR
+        o7PlooUpgrfLFhOD41AbWrqt6IYF4RI0zNpL8A7tdINHH76G4Cn3UuHGRKpLqLpjxp5CSF1Wmf5Z
+        8zVPQ/0F7c3d6LYGFmZs3xTN4L4p7nQ5+ZQ0udcZAcEWrMFMnDEggRMNH0Pg2KtFv3Ac6i5xV0Uy
+        g7v+tZagGdv/CO5oFZagYmyIzmD0gFcLA6+Ejmxqa6ONQr4mN5LFPOY41B1a4wEtvbYhpmiX4I7W
+        956mcx1PVw/BdZ9mcYIywDU1GAcmdRGuzKAmHIe6Q2vcNZB113AJ7mhb1O4w3NLMPEnQI3gSz5mG
+        MKe2ml7KMsQA7XGoO7TGXQNZdw2X4I42LxegHAMF+KxSR44snmASWgrasVmYoWi3MAnHoe7QGvsv
+        svZfl+COlmdEn+RgDEqL3RHYAi2HgSbCYbcgs1NI06LXPQ61oY3WXcMlaFhrL8EdrYQqeLEwSOjI
+        TjecYwn40jEcB+p1oFfrwaIgHIe6Q2uctdE6ay/BHW1IaGQ7Y7CIFWPAXDG2IG3ChmqJ8LvsG9Y5
+        dRjU2uNQG9rwSsLQfF2Chll7Ce5oRywwWq6XzF5i7cUXH+tMhIVDnLW5JlNGthjZHofa0PrXB90Q
+        7SVoiPYSvEPr0dj2LAGTREZlIOeTcOvqU4s8i5QchJyF+Rqnoe7QGjsEb+0QLsEdLWFQUAOyk4RU
+        Z5IiGH6Rl5qbaq5Te0GvZlEQjkPdoTUuCN661l6CO9retCTG+qu7MkjXuYFUGg4pjAUZvlfMaopa
+        HB4ch/pftO7mbeeKb4JWBeFNcEfruSFngzaMpjhNIQCW5sLsKAfYmKN38DLZwiEch9rRGlbaxcGw
+        yf0ht0NFUzAHNuQDe3JsF6WkGlPElDa5UKfkNtChYcBo4A2OQ21Q1+TC6vkChSVnmKtLboeqdbJi
+        P7MuNpzvhH6WhkrtVDGyddg19IiNjsU1x3GoDWo0XeQC6yVoCPYS3NFmjL1r8rHkdR7DNB2uDaJi
+        iMAorMuB4WlL3gLtcag7tJaG6xWt5SL3TXBHW4h79ygE2JV32IImfUyiQW2mwmNg3TCcqoXhOg51
+        h9bScL2SsFzkvgnuaFNLBQa2oA9TDc2tpa2OKOKq4AKBwmp4e7WYGxyH2tHaVlnL+ezC+k6VFewV
+        cTAbY84So3od080uuObokzuGMW2QqyYu9jjUBtW4EBiXgSW3ZypWYJ1fl2AOiRkmptwBp54wtTW4
+        gawN2QXsxgz8wHGoDerV0xg6AtuuC9n6ftelDlYretx7J9x00GBCGSjMOOwaEXeJAX4hAbEB2uNQ
+        O1rbImBcW987keEcUhl5eYDUMm6RteC8swWsFzzG3bGTx9YmWTQFx6E2qJaNLJJryRnarCW3FwHc
+        FWGQhf+Z4Kn1dbQh6hSTw4m7uYLzAtx+EvliUQSOQ33//o8/AUPi6/z1MQAA
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['public, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 24 Jun 2017 17:52:55 GMT']
+      etag: [W/"17c65010ecb7419101df055170f72117"]
+      last-modified: ['Thu, 12 Jan 2017 08:19:43 GMT']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: [Accept, Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['EA4E:16B4:4EA054E:5AA5C87:594EA6F7']
+      x-ratelimit-limit: ['60']
+      x-ratelimit-remaining: ['32']
+      x-ratelimit-reset: ['1498328685']
+      x-runtime-rack: ['0.025682']
+      x-served-by: [eef8b8685a106934dcbb4b7c59fba0bf]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.0.0a4]
+    method: GET
+    uri: https://api.github.com/repos/foobar/bar
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWyk0tLk5MT1WyUvLLL1Fwyy/NS1HSUUrJTy7NTc0rSSzJzM+LLy3KAcpnlJQU
+        FFvp66eklqXm5BekFumlZ5ZklCbpJefn6pcZK9UCAP6TTUJNAAAA
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 24 Jun 2017 17:52:55 GMT']
+      server: [GitHub.com]
+      status: [404 Not Found]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['EA4E:16B4:4EA055F:5AA5CA0:594EA6F7']
+      x-ratelimit-limit: ['60']
+      x-ratelimit-remaining: ['31']
+      x-ratelimit-reset: ['1498328685']
+      x-runtime-rack: ['0.015781']
+      x-xss-protection: [1; mode=block]
+    status: {code: 404, message: Not Found}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.0.0a4]
+    method: GET
+    uri: https://api.github.com/repos/fedora-infra/pkgdb2
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1YTW/bOBD9K4Gua5uW3OZDQNEe9r49dC97MWiJkriRRIGkHCRC/vu+ESVZNuo4
+        oS97CBAkNsP3+DjDGc6wC2QaxA/r+ygKo0VQ80oEcdA85ukuChZB1pbldhjMRKo0X8o605xNM9RT
+        LXQQd0GpclkDO58GBqLfbMLb283dIuB7brnetrrExMLaxsSMuUETrXJpi3bXGqETVVtR21WiKtay
+        Af59/20DwlwPLMQcYOCErZEDkUODzbATTYWtyhMRbu0ecjI5U2WpnsByKvvSQmxCkiF7FlnnnixA
+        dkzZQsB62NIrGUIa+3FRPapj9GcrU+IxcIkW6YeFDTjIoiPw2jEtGtUTtjuTaNlYqeqPCzxCg03p
+        nNfyhfuxAW1AQtI+LqVHAS32OIwfhztYxxot9zx5JtNokQi5h7E9KU/wYLTPDUXsXzMrkQukFVue
+        VhSRGS+NeF0EvQyLyf3AAvH33ig4RHsqJs9i0b+bFITpzR7RAV/fqOwGJ/TmJ08eeS5u/kSw77gR
+        0JMp/Tgt/GbA9jY/isHD6sRywQ1n4YhGgCHlUTx7cxC2Y/g9hE6CqOY7ZEWrLuWH88KOSDo2/0pH
+        xgpeeQvuwSAplPK3XA8GiTSmFe86uec323MYNoZG3VY7l83eExDnaR0aGrkxMq+F8LbYRNCxMdHu
+        NK+Twp9yxHfMfeq9ynNviYQFxa5UO28O3HesJ+iYKbi7Tuz2GlXESPgjQi2yqyQSfiK0+gq/9vKI
+        YKLD/WXhYm99I551gwVLXuctEp8340QA79LtmvOXi3XH+Zg4MICOKiotd+11ierAQQrdNY/49d7w
+        jOJA2NcNb1cjb2x6Vnv0264qeenqPs82wI+O9JWUdA5Paen75QrjbZmE79ghn7pkPTD7WnPI1qO+
+        Of9Qonu7fsSz7o+G24IyEJZpuBa+Ygc466jmeF2tVl0heF/hVkJfEZUODRqukwLFm6++bsSjEqm4
+        7QvmjOSlKKBLxVNvW04EIHMu89Xo0HM/N+gAvYX14DlbJUthrKr9c+SBYc5bKyszmbynSTgfRkck
+        3Xcj60QseFkucCqtTCTOKdow8hiKPuFvFYeGfDTbxKZFKXBkva084jvmGrpUNKV6viqjzCgoMLWg
+        On/LLYr+aB1uluvNMrr/Fd7F+InCfzCndb3ANOd2GYbLdfQrDOPwIf76heY0rSlmNHfL9W0/5Tbe
+        3MfRmqYgPQ5nF5/wOHCmLx96Aur0ATKmOIB+HCDxb54sBkhS4hCeRMn71tqf3k1vwyCvUJVoUBfM
+        3zyoNVs5eY1W/4rErtCqum0x2pJ8wfwv0df7o1IgUW0NJ4QPi+CJWxSluHtnY2MBgZV+PttC1bQ6
+        N1sX1kFsdUuNH0aGRc187JBGZhOf5KM8tIyEpApnGnEt2SAhwhNPJbVWwxNPjfBHA9+IelAwao0i
+        1xKChzCzGRjA/8a9uZ2mIuNtabeuesbeKm4sHp2O3wY+36D6huWkd/58g/p8g6LC8H/yBlUL+4R3
+        mCkPIPjnbcSYytav/wF16AQ9mBYAAA==
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['public, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 24 Jun 2017 17:52:55 GMT']
+      etag: [W/"28c9829e720cccc4afa3a2a01f18834c"]
+      last-modified: ['Wed, 02 Nov 2016 11:19:54 GMT']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: [Accept, Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['EA4E:16B4:4EA0568:5AA5CA9:594EA6F7']
+      x-ratelimit-limit: ['60']
+      x-ratelimit-remaining: ['30']
+      x-ratelimit-reset: ['1498328685']
+      x-runtime-rack: ['0.022002']
+      x-served-by: [52189b7290fad804d77890ef34a1eeae]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.0.0a4]
+    method: GET
+    uri: https://api.github.com/repos/fedora-infra/pkgdb2/tags?per_page=100
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62d2Y5dx5FF/4XPdjHnQb9iNIwcLcIaCIruBxv6915Zh1Vw5T0Pib4BSIAogBGs
+        zTgx7oj8238+/VZ+HZ9++vS/+kXnT3/59O8vX2v55Ze//+vbL/zfn79///rHT58/l69fXv7x5fvP
+        /6ov7fdfP38bX3//4/Mc/fdv5a9ffpvfyuev//xHr+bzj9/++U3c9/LtGXE/fvu7OJT/+uX7p5/+
+        8+mPnwt/vt5qqbG2EJuPzbnmeqy2+WFSnaa6anxp/MMP9v/8gS6Nf3w+1vTnn3/5AGp6CbKwXgIF
+        gb0E7tCGGbUvKvlkXZxe92haaL65kFIaaY4UYipu2cyT0B5reoTWS0O7BIpCuwTu0KrWpzG2+OxD
+        T7H13Joy1s6ie+06ttqiLVM/D+2xpkdonTS0S6AotEvgDm2KtVZrWkmmhhG7i2U4b7J2JpikY9J1
+        xt7K89Aea3qE1kpDuwSKQrsE7tDqpLpNripXo43RDptbzdXZGls0ZXhnVGp9PA/tsaZHaI00tEug
+        KLRL4A6t0XNq41q3XmcVelE9z5KzzWXZq2raz97SCiRP+tpjTY/QLnckmB2klyVQFNol8AHaoLzq
+        dfTkh8U6e5m9hOTzjKMMXVJS0xXbBaA91fQArTCwwrDegFqKG8b07ms3M5esEo6gaK+cIy+o1bWW
+        clLLQT9pr8eadlCjLKhLnKCtLnG7pSpjIhhGk0ZQrvswVKy9VDfJbgspQtc5ziSRFZxq2kEVzmSX
+        OEFQl7gd1BS678r25IINMYac1bBqRGdiH860GqOeagiAeqxpB1U4hxXOYO/yV6KRTc1FV0LW2s2e
+        68ihN9dIYRNVAxmsjkogyTrWtIPqXoTz10ugoLVeAnd71TX51k0y02OtJttQ+vTOlR5M9cvRqu7K
+        EAhXx5oeoRXOX92LcP56CdyhrcPUHFvOLjSli58tK6+n8am00GdTUXen2jL4J4PWsaZHaIXzV/ci
+        nL9eAndoKWFLCJngVByZau7ONqOVNaFk01R2KppB+vU8tMeaHqEVzl+ddP56CdyhzdVSEKSGqQ6v
+        SunZRR/pbpVeXGnZJaeNGSuheNJqjzU9QCubagn3Ce66BHbWPOokZMXiZspUBb4OP4KPwVYfx+zB
+        hSzgCo417aDaV6coWG9dAgUD2CXwwV4jRauh7+JaMU73biJOFisFcF9mI91KJVeBUjafanqEVtjL
+        WmkvewncoS2Ya0jK6DE1SUFVWmX63MYVhVvw2owQ6MbM513BsaZHaIW9rJX2spfAHdqWZjWGlktK
+        xbvXxAu/gKF6F0brKpM46FkFyoRjTQ/QCrsDxEk6A8TtoCaaWLS0PX0CZjNGBa+8oTpgaMCoJpcQ
+        qRSod5+312NNO6jm1bwEvewlUBDYS+AOLfXAnCqrHAqjmTCsH6WmUOKkp2VdV4l2t9LpeWiPNT1A
+        KwysrL3edWHDJFmNPruSA4VXVl0N5VIco6VKy3AFNhLb+jyox5p2UBnSysJ6CRS010vgbq9ELd/I
+        skrUFUeqtV+eQEc6BZPOrAfgQi9RoEA41vQArTCwsvZ619p2NfXYVbXZVvxrzd53XYZKRC6/8oRG
+        wpCMQGlwrGkHVUnb6yVQ0F4vgbu9Gpe8VsnNEgbjxGpKdKPPrK1WzvqmAoPF6NTzruBY0wO0sva6
+        fhRJWBG3g+ojQ4Ks4BXQgSVV1aHY1JNeacLAlJutNdA2eB7UY00bqPk1kZdLBy55crBe8nZcKQCM
+        KZoA1YyDtOENjcKuCjkBDcNkU+A/whSoC441PeAqG7aycFVwydtxhS7gC3OCkGgaapKqVoHW20Ao
+        0zOGVtTw1gr412NNO66y1irqAhYxaEc0uKwjtoob0DFm3XL3k+HWTPQJUtC0tTptb4Ey61jThmgS
+        9gCXPDkPcMnbcYWhRbQfwRjfqVxNZohYAxFqjNDcbFQDVjWJJuGxpgdcZT2ANHvgkrfjyoQLTgYd
+        QQrWbAhTs7VpsrIhRVgD2tQ2GunX8xHrWNOOq6gHWPWioK3eeIAMJytm+C12OpuYbiW1KBhp8suZ
+        vbL0XXIZAqzCY00borLEAVnewB1toEcHPzO5YZkQtja8GWUONfUoNjJ3Yeqd6RAITAyPNW2IyrIG
+        ZEkDd5yBEAhOyTiobhnSxUqooMFCI6R61alX2MUNKqyAjR5r2hCVpQzIMgbuCAONqB883OyVSOlO
+        J9BCcjGxMSAMbg1hiw+1CwwFjjVtiMqyBWRHWHcTLAdN0HalWyp2Wstc0DTIg9XBEHBTwX2fDLVf
+        Gf1PjgWPNW2Iyo6vZBkCd/RW13sParQVg3K3jvxJ9RRqVVEN2n89FpqDScCPHmvaEJWtTWWJAbf9
+        1AzJgpk1fT/LB269L6P2ZGEJlz48NOwQmikCNKFwqmlDVDYnXdLksqe7jh/dvqhzoCed21wRn6FV
+        D9P1Girp6IwE/Ga7QKV/rGlDdDVv5Ponsk2pJW3P8AnztEdM06XYPAwpjo1WE9zrtIVef2LrxbKq
+        8bwfPdb0AVH1snJyKUQvaVI2eknbEc0GbmC2FKBlLIZKK3DYe46qdoeDhYOdaPwpgRr/WNOGqGSG
+        r14kM/xL2o7oNAFadWjNwa2GD0wNOli0oH6qOde+5oBMqZPAV3+saUNUMsNXr/tycjZ6m+FnTLF7
+        2iU2dFsgABkaURT5RudKe5r+fnUw2Z7/6sOppg1RyQxfvUhm+Je03Uaz06o3H4Jh12Il9T0zKcGf
+        KsXnXvGmDP5UkfjqTzVtiEpm+OqVXSxno3cZ/qh1VJOb92FVodHT4jfFqAx3jakJg1PyqVwEus/H
+        mjZEJTN8JcoBvqTtNqpUN97lAGypqDnoQ4cJO6W6nOIyW+rRZLXAAtuxpg1RWTqKepFlo7zJ23Gl
+        n0cJv4Z6iSRHBQ0ptZMCeEomSCg0SCOzKCVQix5r2nEVzaEkKycwvclKi/V2NE0o6t4DIr/szgwS
+        fQupOlq6e3SltMC3f6xpQ1SycpKd6d8P9FtUENGgm8COYnGNFrNzYxCkArcDFAxqRsYM9yQ6UKea
+        /htR8xIkB09v4oQi1Ju4/cNfAV+HHIn6PsPnm5DUtYq203r2HRvtM3jjBBzqsaYNVLnvHgzkQv4l
+        bIeTTokqThd4pkEXLHM0Z9n7aWa4BJkH4qTjuxeoRY81fYRTMCk1kjnpJWyHs1RVmqrcVRjspaSp
+        s1mBf3jWVCdlU8eoBp2o55P8Y00f4bzWlIRqe/Miukb1Jm4H1VR4JpH4znYvPPRInZTXqZWQLO6T
+        Rj55wLBFINYfa9pBFWyTLhQEo/2buB1URsyWuTKXVtioDvTzVjwak04UplpYpORYyOqePm+px5p2
+        UAXj/UJBsFX6Jm4Hlc+ekwlUT1WNQfskwUQn5af7TMWvgdbDkixWoCI91rSBKhmcBOtRAL1JScGK
+        YlNTI7VJc3QoglQwI/cRCwM99k6s1jmt3/rkwOlY00c4BatRI1mMXsJ262yVs1UBd8kEdERmoHbl
+        Tpz6mPShoPIro6yCfP48nMeaPsIp6kVFfehdwcT009OqZ4kvrW4ouxGzNK5/uanhlbepOKBQtBJY
+        6DvW9BFOUf8p6j2XsN06oZHCKKEDGh0juqAmfeZSMEzDr7Kd9Pk8lyoEeE/Hmj7CeTV4xFIn0e6T
+        eblvP3nGSMyYItNQ3/Lkkx+OzxzWLrwIjbXSKpncAHr+kz/WtIMq+tFfrQ2xEvS+UzLY1nFWs7LT
+        YT5HFhXITSuuVLug8tBNOxhlff1gT4alY007qKKfvmivZFnq3ecfuPUHdwSfybI5UZ+rSVyd4Phf
+        h1yiVj8K1qN3At70WNMGqmTqJDhkBtAbb6qzJ09yo2Cfg5BPicTRShsmc7zGyaTQnaMWFYj1x5r+
+        G079YkWXzd/lCX367/L2KMU8lH5ohTpmXSAyOW2DIzVt9FFsi9WMhqUGgVr0WNMDroIe9RUHwUzq
+        Xd6Oa4WOy5A5QtPL66AfB75MHHSgtU/s81KKBqWoU5/3qceaHnAVdKqvOAimVO/ydlxHKp20n62y
+        7GepcwYIupRPKmKv1g1u/7FhpgVKqGNND7gK8ndecRB0ru/ydlwrDEgWH4pvHERYp3wWbddyymPa
+        BjOSWMb6Ey1VAXs91bThaiSb++BwyZPzr5e8HdeWY7d09wYL0KyXhsj2gy+smnKbclZupLAdZWsR
+        yK2ONT3gKusHROelr39P9+kVuRVne9YEim3Slf8zLYE1xSUa9p+8p0/FnQ+JPfOVxZ1o2nGVy68W
+        CkgTtNWbDKutq6mNMoCbXk7PwRE16lWSK58GHqF6Lip33MDzHuBY04aorJ3KRqs7G4U/Pgq7uHzn
+        ZPxhELO4SRuMhcGn8AQlaCb9EsfSjjVtiIqulmOlopXVu7zdpzJyJt5zcpZxCTeSOEQ5Ddc6FFPU
+        HiI8NAovrSRu+Bxr2nEV/fZl4/9ddWUy5qi5R29qcZ0hP22rzKEpmoAm5zZo+xPDogBX4ljTR0TN
+        KkCEWlX65VWamDd9lbbbKOsObDYqbqGQ6rfA/VR4+5Sp3KT3ECMVToFlnSLQ/TvWtCEquqULpqJb
+        uu/ydlzbgK9LTCJB5VJizWzusEDuuD7LaZnI+j79/k55IBClTjU94Coap8BVNFL9kLfj2lfaz6oO
+        TWnWygrHOoA2GPoqdbUEufcJa5JE9XlcjzXtuIp6AMEt3WWrNx6gtMkUn+snntPz7JlUHlLAUku1
+        cY7B7Sl8LSdRBDzAsaYNUUEOPxgIcvh/SNttdGqCOye8bSM2kUtxZY4TMtxIVL2zXdY437FOUa4A
+        92Sf+ljThqgghx8MBMlSP6TtiCrX6Ekx5yOPYo0s0U2FZV6hoAy6LAGiX00zd4Gq/1jThqiXPH4E
+        Cpc8udh/ydtxZWBi1g6EpaEauY4eGaayCNlhn9P0Z0jFwY5GK/t5Sz3WtOMq6k0FdyPW39GNN1XJ
+        Qjbj4MGi7LL8qSfLO5Ezs6m2qT04s9JAmvU8oseaNkRFmWigIEpFe5e3W6oxK2HyM3DokJd9VuHf
+        yFMhTls2JwbjasUxmSEQpY41PeAq2v8HV9Feyg95O640/Afx3SQKVTopSo1cofsk3lSalPzcoPXs
+        SQyB/tSxpgdcZfNUUULaq73e91QcOxITE+Xf1Zwq9KxY44E7pdnltSHApMQvPO8HePnuTNOOq6hn
+        FeSkLUxvPOtggMQ0ipcnoKSWue5KdMd9SYZXpFdsRwfeobBNYFJ1rGlD1L7k1zPicvX/m0S5POBN
+        4u4HLEckWdfn6AHPJbAg6TO9/7T4QGz1UFsxX7XWSDz4dazpBt1lF7LoytrtQvfOdg13zlhB5QUa
+        p9NaPyVvHWyiZpYmOfDN8b7EuZkisDxxrOkGXUFWJd/wwmJJlLXdJXG3XUaqpFg0VngLsBU2JrmH
+        zMCK1JZHfzTl1zSs+geBeutY0w26stnBQlc2P3iTuKObQoJf5dhInSMTwhR9AeZWHPSgR8jEgLmW
+        YqAtcc73VNMNurI5wsJCtpv1JnFHF7qVbnHwphKTbd4IjfBYYF7z4KrCESfepSgwByR21Y413aAr
+        7nbF/cKNW2ARPXeuTzK+Wmc8YQx4XrF1mbcAedYW38vDa9ynEFj8P9a0QyuLqyyoN4gGOlk8VsWN
+        NM55sl5S0hiGRWDobiUWdgN5pSLNIBDGjjVtiAqTL4ww+eKHvN0JaD5xWK28+KFYW1XDcIiGiQx3
+        lEyGgEHHC44bF6r5K3myYXis6QFXWQcrTL4A17sibLCo2mhtY5ZdeajBXPVmSIA30K1yQFGXyF1v
+        ibfrjjXtuIp6ANmEYEnbLdVz1WcxLUxM7FnQMeAKVVO8Z81VGs2jyz4yiKXV/bylHmvaEJW1U9kk
+        4M5GjXHeMWvh0Vp4Asxb7LpMw700PCtecHBYgVnCFGjAHGvaEBUmXxhh8sUPeQ+WSgbF+dleo7Ec
+        +eG9BK6pMYDpsziu0yherSXdMgJFgT/VtOMq+u2Lki9eYdkRbZ4ZNmu/PAtePRttbLHQxeIZCo5V
+        0dzKClI2+4EC+dSxpj///J//A1o8QbDWggAA
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['public, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 24 Jun 2017 17:52:56 GMT']
+      etag: [W/"98f41bf6518b4d75b3ea05374bf572b3"]
+      last-modified: ['Wed, 02 Nov 2016 11:19:54 GMT']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: [Accept, Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['EA4E:16B4:4EA0575:5AA5CB6:594EA6F7']
+      x-ratelimit-limit: ['60']
+      x-ratelimit-remaining: ['29']
+      x-ratelimit-reset: ['1498328685']
+      x-runtime-rack: ['0.048004']
+      x-served-by: [10ea50bffaded85949561216def301f3]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/anitya/tests/request-data/anitya.tests.lib.backends.test_githubapi.GithubApiBackendtests.test_get_versions
+++ b/anitya/tests/request-data/anitya.tests.lib.backends.test_githubapi.GithubApiBackendtests.test_get_versions
@@ -1,0 +1,357 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.0.0a4]
+    method: GET
+    uri: https://api.github.com/repos/fedora-infra/fedocal
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1YTW/jNhD9K4autUPLym42AordvfTaHnLqxaAl2mIjkQJJ2XAE//c+kpIlGYg/
+        pGuAILEZvsfHIWc4M3XA0yD+8frtNXp9ngeCFiyIgy1LZULzYB5sqzxf90YVXXCxVZR0U+RBMBXE
+        dZDLHRcNup0HCrtAFIXfv0cv84DuqaFqXakcEzNjSh0T4gf16mnHTVZtKs1UIoVhwjwlsiAVaeA/
+        939GINyphsUyBxi4YCt5Q+TRYNNObk9TZor8QoRf20EuJm9lnssDWC5l31qInJHWko6Fi91IFiBr
+        Ik3GYD1s6WQNwbV5XJRD1cT+WfPU8mgciWLpw8IaHGTZK3CqiWKldITVRieKl4ZL8bjAARpsUu2o
+        4B90HBvQGiRW2uNSHApotsdlfBzuYTUpFd/T5GhNo1jC+B7GHkl5gQejOZbWZ//uWckeATdsTdPC
+        euSW5pqd5oGTYTDZDczhf/d6Qc/dU3Y+Wqz6e3Zgm9mGapbOEDGYSKma0bLMeeLOa7aVavaXcz6I
+        wpf38+pXvdYZfuCIPQmW5sZhfI6HUwINMe/sOJ7EgmuC340LJfBuusEujbwVJ65IG7DUpP/V3h3D
+        aDFeskODJZNygvUcGixc64rddYmv7NeRaNK6iaiKjY9s9zjHFV4Ph0qqNd8JxsZb7cxQkzbsbhQV
+        STaBsyWoif/kzpbuxou0YHBscrkZT4IHkDiGmuiM+vfFrCfpspSWYMCo2HaaSEtwZjRqyuk6gZbh
+        zIc3zeCgxytsCUjdWDGnYlfR3QTKMwPO2L65O/pxMxu54h0dBfhsoqX4ppoYtzoSq9E///DlCWbs
+        ODpGl1BcT1Ou7buXlbidFwW/9ahfoWvwg7s9ldPex0te+/129nFDqCWoSRdgffhuqEdbtInfrcL+
+        Ak0CP/4CtASk/qOkJrPxCOuUVLHRchs8qW2+cnp6eqozRl0GXDA1xUE9HDxUJRmyu9EK65YASUpB
+        jUupt1ZgihQ7lzQdb88zA9j8uY1W6eH90y5RJo6X5tB9uoLnTBspJsTMjqJPLKTh2yY1Ha93wFL/
+        1FwkbE7zfI7baXjCcV9RrdljQ07IJhjGw7EBlOW+eMgZru545Yp5gpr4yi9lZS6P08JLj8P6qGIo
+        MdI1NagOVsswWiyjxWr1Fr7G0bc4XP6LOVWZDua8LJbhIly9LX/EmPYc2TllpbMeDaZEi2j5Fj7H
+        0RI/dgqCZXOF8QlthE8q+LZwsE0BoLTOOtSvDhP3q/4LTJLjLl64y52r7S/fqxs4KMxkwUokDL65
+        ofkHPq1enleDxz+RlYCJQzRtDtQgHcVb2xtrUwZw/HM0mRSWl+q1d92uAsRQqeR/LDE6iI2qbFWI
+        sS5Y9AYP/J0PkTarOY/4qqzVECKocqVk0+sRcHFU8iUTjYRW7NJXhaAJAelNCGL8q92a32jKtrTK
+        zdpnzdhaQbVB72nYIvhqRblK5bJ6bptYsNZXK6rpO95s4H21otCP/aSNitRk0MrCxbq/FSWYOaAP
+        cw5Z8P1+1dBEkVV4+h9kfTgqoRYAAA==
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['public, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 24 Jun 2017 17:52:56 GMT']
+      etag: [W/"9019d227404174437e13a045e3140714"]
+      last-modified: ['Thu, 12 Jan 2017 08:19:43 GMT']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: [Accept, Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['CAA8:16BC:9F445AA:B7C31BF:594EA6F8']
+      x-ratelimit-limit: ['60']
+      x-ratelimit-remaining: ['28']
+      x-ratelimit-reset: ['1498328685']
+      x-runtime-rack: ['0.025641']
+      x-served-by: [d0b3c2c33a23690498aa8e70a435a259]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.0.0a4]
+    method: GET
+    uri: https://api.github.com/repos/fedora-infra/fedocal/tags?per_page=100
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62b226duQ2F38XX020dKErKqxTFQAeyMZBMAsfTiw7y7rPkP3U72r4QGvrOBrzo
+        /YWgFg/5+x8Pv7XP8vDh4V/uVm/x4ZeHfz997e3Tp19/f/6EH398efn67cPjY/v6dPvn08vH3/tt
+        fPn8+Cxfv3x7VJlfntvfnn7T5/b6zWifHn/8/uOb4Et7/inBH7//X0H8AZ+fXh4+/PHw7WPD39gH
+        a3FOpmOfQ3SUsvdNSQb7WVIWP6afmvHh/t8PdYX89ngc6vv3X/6KNlijXYKmaJfgjpaClJaiBJcy
+        jxhyas5lrTRDDG3MHEWVHBugPQ51h9Zbo12CpmiX4B3amijJzCOUNoPnkktKXGfVNnIrsYp0nxtZ
+        oD0NtaM1BmuM9R2oEZ+Um/c6uw+dJgUqc1YXVlnoeRZukVimAdTjUBvUYgt1yRnm6pLbM7X6mTuz
+        Rtd0yAycW84RxdW5UX31MgK3QskA6nGoDWq+GReBS9AQ7CW4o408xCElG2WeuWZuLUuOgQNSVZL6
+        2LwG7gZoj0PtaG3zdb3ClljfyVdFBSBXYqw68fj7Isl156tKbzW60FIrrutK9Z/1A8ehNqhsbbUu
+        QUOwl+Cer6FwIt9jmb5VZqoU8ER16SX0ETnI6F1JmwHa41B3aI2tFt+MrdYluKMVWK3InD1eKmKX
+        myOt3ffZqIjIoDkytVwN0B6HukNrXGX5tWybZu17VktcCq3U2NQPQrFNzmfRDINQtA4dBemcS3MW
+        aE9D3aFd0Q17L74tQVO0S3DP2p5qyFHDmGV2OK3qWhhamk7nA/lEohRHUQO0x6E2tMnaG1yChmgv
+        wR1tTsVPmigCmkacHAm9gYzGhbKyam21IJEtbNdxqDu0xlmbrLP2EtzRIk8lwVhRbXjOYLmS1MbR
+        o7PlooUpgrfLFhOD41AbWrqt6IYF4RI0zNpL8A7tdINHH76G4Cn3UuHGRKpLqLpjxp5CSF1Wmf5Z
+        8zVPQ/0F7c3d6LYGFmZs3xTN4L4p7nQ5+ZQ0udcZAcEWrMFMnDEggRMNH0Pg2KtFv3Ac6i5xV0Uy
+        g7v+tZagGdv/CO5oFZagYmyIzmD0gFcLA6+Ejmxqa6ONQr4mN5LFPOY41B1a4wEtvbYhpmiX4I7W
+        956mcx1PVw/BdZ9mcYIywDU1GAcmdRGuzKAmHIe6Q2vcNZB113AJ7mhb1O4w3NLMPEnQI3gSz5mG
+        MKe2ml7KMsQA7XGoO7TGXQNZdw2X4I42LxegHAMF+KxSR44snmASWgrasVmYoWi3MAnHoe7QGvsv
+        svZfl+COlmdEn+RgDEqL3RHYAi2HgSbCYbcgs1NI06LXPQ61oY3WXcMlaFhrL8EdrYQqeLEwSOjI
+        TjecYwn40jEcB+p1oFfrwaIgHIe6Q2uctdE6ay/BHW1IaGQ7Y7CIFWPAXDG2IG3ChmqJ8LvsG9Y5
+        dRjU2uNQG9rwSsLQfF2Chll7Ce5oRywwWq6XzF5i7cUXH+tMhIVDnLW5JlNGthjZHofa0PrXB90Q
+        7SVoiPYSvEPr0dj2LAGTREZlIOeTcOvqU4s8i5QchJyF+Rqnoe7QGjsEb+0QLsEdLWFQUAOyk4RU
+        Z5IiGH6Rl5qbaq5Te0GvZlEQjkPdoTUuCN661l6CO9retCTG+qu7MkjXuYFUGg4pjAUZvlfMaopa
+        HB4ch/pftO7mbeeKb4JWBeFNcEfruSFngzaMpjhNIQCW5sLsKAfYmKN38DLZwiEch9rRGlbaxcGw
+        yf0ht0NFUzAHNuQDe3JsF6WkGlPElDa5UKfkNtChYcBo4A2OQ21Q1+TC6vkChSVnmKtLboeqdbJi
+        P7MuNpzvhH6WhkrtVDGyddg19IiNjsU1x3GoDWo0XeQC6yVoCPYS3NFmjL1r8rHkdR7DNB2uDaJi
+        iMAorMuB4WlL3gLtcag7tJaG6xWt5SL3TXBHW4h79ygE2JV32IImfUyiQW2mwmNg3TCcqoXhOg51
+        h9bScL2SsFzkvgnuaFNLBQa2oA9TDc2tpa2OKOKq4AKBwmp4e7WYGxyH2tHaVlnL+ezC+k6VFewV
+        cTAbY84So3od080uuObokzuGMW2QqyYu9jjUBtW4EBiXgSW3ZypWYJ1fl2AOiRkmptwBp54wtTW4
+        gawN2QXsxgz8wHGoDerV0xg6AtuuC9n6ftelDlYretx7J9x00GBCGSjMOOwaEXeJAX4hAbEB2uNQ
+        O1rbImBcW987keEcUhl5eYDUMm6RteC8swWsFzzG3bGTx9YmWTQFx6E2qJaNLJJryRnarCW3FwHc
+        FWGQhf+Z4Kn1dbQh6hSTw4m7uYLzAtx+EvliUQSOQ33//o8/AUPi6/z1MQAA
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['public, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 24 Jun 2017 17:52:56 GMT']
+      etag: [W/"17c65010ecb7419101df055170f72117"]
+      last-modified: ['Thu, 12 Jan 2017 08:19:43 GMT']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: [Accept, Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['CAA8:16BC:9F445C5:B7C31DE:594EA6F8']
+      x-ratelimit-limit: ['60']
+      x-ratelimit-remaining: ['27']
+      x-ratelimit-reset: ['1498328685']
+      x-runtime-rack: ['0.030458']
+      x-served-by: [eef8b8685a106934dcbb4b7c59fba0bf]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.0.0a4]
+    method: GET
+    uri: https://api.github.com/repos/foobar/bar
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWyk0tLk5MT1WyUvLLL1Fwyy/NS1HSUUrJTy7NTc0rSSzJzM+LLy3KAcpnlJQU
+        FFvp66eklqXm5BekFumlZ5ZklCbpJefn6pcZK9UCAP6TTUJNAAAA
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 24 Jun 2017 17:52:57 GMT']
+      server: [GitHub.com]
+      status: [404 Not Found]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['CAA8:16BC:9F445EF:B7C3200:594EA6F8']
+      x-ratelimit-limit: ['60']
+      x-ratelimit-remaining: ['26']
+      x-ratelimit-reset: ['1498328685']
+      x-runtime-rack: ['0.011882']
+      x-xss-protection: [1; mode=block]
+    status: {code: 404, message: Not Found}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.0.0a4]
+    method: GET
+    uri: https://api.github.com/repos/fedora-infra/pkgdb2
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1YTW/bOBD9K4Gua5uW3OZDQNEe9r49dC97MWiJkriRRIGkHCRC/vu+ESVZNuo4
+        oS97CBAkNsP3+DjDGc6wC2QaxA/r+ygKo0VQ80oEcdA85ukuChZB1pbldhjMRKo0X8o605xNM9RT
+        LXQQd0GpclkDO58GBqLfbMLb283dIuB7brnetrrExMLaxsSMuUETrXJpi3bXGqETVVtR21WiKtay
+        Af59/20DwlwPLMQcYOCErZEDkUODzbATTYWtyhMRbu0ecjI5U2WpnsByKvvSQmxCkiF7FlnnnixA
+        dkzZQsB62NIrGUIa+3FRPapj9GcrU+IxcIkW6YeFDTjIoiPw2jEtGtUTtjuTaNlYqeqPCzxCg03p
+        nNfyhfuxAW1AQtI+LqVHAS32OIwfhztYxxot9zx5JtNokQi5h7E9KU/wYLTPDUXsXzMrkQukFVue
+        VhSRGS+NeF0EvQyLyf3AAvH33ig4RHsqJs9i0b+bFITpzR7RAV/fqOwGJ/TmJ08eeS5u/kSw77gR
+        0JMp/Tgt/GbA9jY/isHD6sRywQ1n4YhGgCHlUTx7cxC2Y/g9hE6CqOY7ZEWrLuWH88KOSDo2/0pH
+        xgpeeQvuwSAplPK3XA8GiTSmFe86uec323MYNoZG3VY7l83eExDnaR0aGrkxMq+F8LbYRNCxMdHu
+        NK+Twp9yxHfMfeq9ynNviYQFxa5UO28O3HesJ+iYKbi7Tuz2GlXESPgjQi2yqyQSfiK0+gq/9vKI
+        YKLD/WXhYm99I551gwVLXuctEp8340QA79LtmvOXi3XH+Zg4MICOKiotd+11ierAQQrdNY/49d7w
+        jOJA2NcNb1cjb2x6Vnv0264qeenqPs82wI+O9JWUdA5Paen75QrjbZmE79ghn7pkPTD7WnPI1qO+
+        Of9Qonu7fsSz7o+G24IyEJZpuBa+Ygc466jmeF2tVl0heF/hVkJfEZUODRqukwLFm6++bsSjEqm4
+        7QvmjOSlKKBLxVNvW04EIHMu89Xo0HM/N+gAvYX14DlbJUthrKr9c+SBYc5bKyszmbynSTgfRkck
+        3Xcj60QseFkucCqtTCTOKdow8hiKPuFvFYeGfDTbxKZFKXBkva084jvmGrpUNKV6viqjzCgoMLWg
+        On/LLYr+aB1uluvNMrr/Fd7F+InCfzCndb3ANOd2GYbLdfQrDOPwIf76heY0rSlmNHfL9W0/5Tbe
+        3MfRmqYgPQ5nF5/wOHCmLx96Aur0ATKmOIB+HCDxb54sBkhS4hCeRMn71tqf3k1vwyCvUJVoUBfM
+        3zyoNVs5eY1W/4rErtCqum0x2pJ8wfwv0df7o1IgUW0NJ4QPi+CJWxSluHtnY2MBgZV+PttC1bQ6
+        N1sX1kFsdUuNH0aGRc187JBGZhOf5KM8tIyEpApnGnEt2SAhwhNPJbVWwxNPjfBHA9+IelAwao0i
+        1xKChzCzGRjA/8a9uZ2mIuNtabeuesbeKm4sHp2O3wY+36D6huWkd/58g/p8g6LC8H/yBlUL+4R3
+        mCkPIPjnbcSYytav/wF16AQ9mBYAAA==
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['public, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 24 Jun 2017 17:52:57 GMT']
+      etag: [W/"28c9829e720cccc4afa3a2a01f18834c"]
+      last-modified: ['Wed, 02 Nov 2016 11:19:54 GMT']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: [Accept, Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['CAA8:16BC:9F4461A:B7C3236:594EA6F9']
+      x-ratelimit-limit: ['60']
+      x-ratelimit-remaining: ['25']
+      x-ratelimit-reset: ['1498328685']
+      x-runtime-rack: ['0.037595']
+      x-served-by: [62cdcc2d03a2f173f1c58590d1a90077]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.0.0a4]
+    method: GET
+    uri: https://api.github.com/repos/fedora-infra/pkgdb2/tags?per_page=100
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62d2Y5dx5FF/4XPdjHnQb9iNIwcLcIaCIruBxv6915Zh1Vw5T0Pib4BSIAogBGs
+        zTgx7oj8238+/VZ+HZ9++vS/+kXnT3/59O8vX2v55Ze//+vbL/zfn79///rHT58/l69fXv7x5fvP
+        /6ov7fdfP38bX3//4/Mc/fdv5a9ffpvfyuev//xHr+bzj9/++U3c9/LtGXE/fvu7OJT/+uX7p5/+
+        8+mPnwt/vt5qqbG2EJuPzbnmeqy2+WFSnaa6anxp/MMP9v/8gS6Nf3w+1vTnn3/5AGp6CbKwXgIF
+        gb0E7tCGGbUvKvlkXZxe92haaL65kFIaaY4UYipu2cyT0B5reoTWS0O7BIpCuwTu0KrWpzG2+OxD
+        T7H13Joy1s6ie+06ttqiLVM/D+2xpkdonTS0S6AotEvgDm2KtVZrWkmmhhG7i2U4b7J2JpikY9J1
+        xt7K89Aea3qE1kpDuwSKQrsE7tDqpLpNripXo43RDptbzdXZGls0ZXhnVGp9PA/tsaZHaI00tEug
+        KLRL4A6t0XNq41q3XmcVelE9z5KzzWXZq2raz97SCiRP+tpjTY/QLnckmB2klyVQFNol8AHaoLzq
+        dfTkh8U6e5m9hOTzjKMMXVJS0xXbBaA91fQArTCwwrDegFqKG8b07ms3M5esEo6gaK+cIy+o1bWW
+        clLLQT9pr8eadlCjLKhLnKCtLnG7pSpjIhhGk0ZQrvswVKy9VDfJbgspQtc5ziSRFZxq2kEVzmSX
+        OEFQl7gd1BS678r25IINMYac1bBqRGdiH860GqOeagiAeqxpB1U4hxXOYO/yV6KRTc1FV0LW2s2e
+        68ihN9dIYRNVAxmsjkogyTrWtIPqXoTz10ugoLVeAnd71TX51k0y02OtJttQ+vTOlR5M9cvRqu7K
+        EAhXx5oeoRXOX92LcP56CdyhrcPUHFvOLjSli58tK6+n8am00GdTUXen2jL4J4PWsaZHaIXzV/ci
+        nL9eAndoKWFLCJngVByZau7ONqOVNaFk01R2KppB+vU8tMeaHqEVzl+ddP56CdyhzdVSEKSGqQ6v
+        SunZRR/pbpVeXGnZJaeNGSuheNJqjzU9QCubagn3Ce66BHbWPOokZMXiZspUBb4OP4KPwVYfx+zB
+        hSzgCo417aDaV6coWG9dAgUD2CXwwV4jRauh7+JaMU73biJOFisFcF9mI91KJVeBUjafanqEVtjL
+        WmkvewncoS2Ya0jK6DE1SUFVWmX63MYVhVvw2owQ6MbM513BsaZHaIW9rJX2spfAHdqWZjWGlktK
+        xbvXxAu/gKF6F0brKpM46FkFyoRjTQ/QCrsDxEk6A8TtoCaaWLS0PX0CZjNGBa+8oTpgaMCoJpcQ
+        qRSod5+312NNO6jm1bwEvewlUBDYS+AOLfXAnCqrHAqjmTCsH6WmUOKkp2VdV4l2t9LpeWiPNT1A
+        KwysrL3edWHDJFmNPruSA4VXVl0N5VIco6VKy3AFNhLb+jyox5p2UBnSysJ6CRS010vgbq9ELd/I
+        skrUFUeqtV+eQEc6BZPOrAfgQi9RoEA41vQArTCwsvZ619p2NfXYVbXZVvxrzd53XYZKRC6/8oRG
+        wpCMQGlwrGkHVUnb6yVQ0F4vgbu9Gpe8VsnNEgbjxGpKdKPPrK1WzvqmAoPF6NTzruBY0wO0sva6
+        fhRJWBG3g+ojQ4Ks4BXQgSVV1aHY1JNeacLAlJutNdA2eB7UY00bqPk1kZdLBy55crBe8nZcKQCM
+        KZoA1YyDtOENjcKuCjkBDcNkU+A/whSoC441PeAqG7aycFVwydtxhS7gC3OCkGgaapKqVoHW20Ao
+        0zOGVtTw1gr412NNO66y1irqAhYxaEc0uKwjtoob0DFm3XL3k+HWTPQJUtC0tTptb4Ey61jThmgS
+        9gCXPDkPcMnbcYWhRbQfwRjfqVxNZohYAxFqjNDcbFQDVjWJJuGxpgdcZT2ANHvgkrfjyoQLTgYd
+        QQrWbAhTs7VpsrIhRVgD2tQ2GunX8xHrWNOOq6gHWPWioK3eeIAMJytm+C12OpuYbiW1KBhp8suZ
+        vbL0XXIZAqzCY00borLEAVnewB1toEcHPzO5YZkQtja8GWUONfUoNjJ3Yeqd6RAITAyPNW2IyrIG
+        ZEkDd5yBEAhOyTiobhnSxUqooMFCI6R61alX2MUNKqyAjR5r2hCVpQzIMgbuCAONqB883OyVSOlO
+        J9BCcjGxMSAMbg1hiw+1CwwFjjVtiMqyBWRHWHcTLAdN0HalWyp2Wstc0DTIg9XBEHBTwX2fDLVf
+        Gf1PjgWPNW2Iyo6vZBkCd/RW13sParQVg3K3jvxJ9RRqVVEN2n89FpqDScCPHmvaEJWtTWWJAbf9
+        1AzJgpk1fT/LB269L6P2ZGEJlz48NOwQmikCNKFwqmlDVDYnXdLksqe7jh/dvqhzoCed21wRn6FV
+        D9P1Girp6IwE/Ga7QKV/rGlDdDVv5Ponsk2pJW3P8AnztEdM06XYPAwpjo1WE9zrtIVef2LrxbKq
+        8bwfPdb0AVH1snJyKUQvaVI2eknbEc0GbmC2FKBlLIZKK3DYe46qdoeDhYOdaPwpgRr/WNOGqGSG
+        r14kM/xL2o7oNAFadWjNwa2GD0wNOli0oH6qOde+5oBMqZPAV3+saUNUMsNXr/tycjZ6m+FnTLF7
+        2iU2dFsgABkaURT5RudKe5r+fnUw2Z7/6sOppg1RyQxfvUhm+Je03Uaz06o3H4Jh12Il9T0zKcGf
+        KsXnXvGmDP5UkfjqTzVtiEpm+OqVXSxno3cZ/qh1VJOb92FVodHT4jfFqAx3jakJg1PyqVwEus/H
+        mjZEJTN8JcoBvqTtNqpUN97lAGypqDnoQ4cJO6W6nOIyW+rRZLXAAtuxpg1RWTqKepFlo7zJ23Gl
+        n0cJv4Z6iSRHBQ0ptZMCeEomSCg0SCOzKCVQix5r2nEVzaEkKycwvclKi/V2NE0o6t4DIr/szgwS
+        fQupOlq6e3SltMC3f6xpQ1SycpKd6d8P9FtUENGgm8COYnGNFrNzYxCkArcDFAxqRsYM9yQ6UKea
+        /htR8xIkB09v4oQi1Ju4/cNfAV+HHIn6PsPnm5DUtYq203r2HRvtM3jjBBzqsaYNVLnvHgzkQv4l
+        bIeTTokqThd4pkEXLHM0Z9n7aWa4BJkH4qTjuxeoRY81fYRTMCk1kjnpJWyHs1RVmqrcVRjspaSp
+        s1mBf3jWVCdlU8eoBp2o55P8Y00f4bzWlIRqe/Miukb1Jm4H1VR4JpH4znYvPPRInZTXqZWQLO6T
+        Rj55wLBFINYfa9pBFWyTLhQEo/2buB1URsyWuTKXVtioDvTzVjwak04UplpYpORYyOqePm+px5p2
+        UAXj/UJBsFX6Jm4Hlc+ekwlUT1WNQfskwUQn5af7TMWvgdbDkixWoCI91rSBKhmcBOtRAL1JScGK
+        YlNTI7VJc3QoglQwI/cRCwM99k6s1jmt3/rkwOlY00c4BatRI1mMXsJ262yVs1UBd8kEdERmoHbl
+        Tpz6mPShoPIro6yCfP48nMeaPsIp6kVFfehdwcT009OqZ4kvrW4ouxGzNK5/uanhlbepOKBQtBJY
+        6DvW9BFOUf8p6j2XsN06oZHCKKEDGh0juqAmfeZSMEzDr7Kd9Pk8lyoEeE/Hmj7CeTV4xFIn0e6T
+        eblvP3nGSMyYItNQ3/Lkkx+OzxzWLrwIjbXSKpncAHr+kz/WtIMq+tFfrQ2xEvS+UzLY1nFWs7LT
+        YT5HFhXITSuuVLug8tBNOxhlff1gT4alY007qKKfvmivZFnq3ecfuPUHdwSfybI5UZ+rSVyd4Phf
+        h1yiVj8K1qN3At70WNMGqmTqJDhkBtAbb6qzJ09yo2Cfg5BPicTRShsmc7zGyaTQnaMWFYj1x5r+
+        G079YkWXzd/lCX367/L2KMU8lH5ohTpmXSAyOW2DIzVt9FFsi9WMhqUGgVr0WNMDroIe9RUHwUzq
+        Xd6Oa4WOy5A5QtPL66AfB75MHHSgtU/s81KKBqWoU5/3qceaHnAVdKqvOAimVO/ydlxHKp20n62y
+        7GepcwYIupRPKmKv1g1u/7FhpgVKqGNND7gK8ndecRB0ru/ydlwrDEgWH4pvHERYp3wWbddyymPa
+        BjOSWMb6Ey1VAXs91bThaiSb++BwyZPzr5e8HdeWY7d09wYL0KyXhsj2gy+smnKbclZupLAdZWsR
+        yK2ONT3gKusHROelr39P9+kVuRVne9YEim3Slf8zLYE1xSUa9p+8p0/FnQ+JPfOVxZ1o2nGVy68W
+        CkgTtNWbDKutq6mNMoCbXk7PwRE16lWSK58GHqF6Lip33MDzHuBY04aorJ3KRqs7G4U/Pgq7uHzn
+        ZPxhELO4SRuMhcGn8AQlaCb9EsfSjjVtiIqulmOlopXVu7zdpzJyJt5zcpZxCTeSOEQ5Ddc6FFPU
+        HiI8NAovrSRu+Bxr2nEV/fZl4/9ddWUy5qi5R29qcZ0hP22rzKEpmoAm5zZo+xPDogBX4ljTR0TN
+        KkCEWlX65VWamDd9lbbbKOsObDYqbqGQ6rfA/VR4+5Sp3KT3ECMVToFlnSLQ/TvWtCEquqULpqJb
+        uu/ydlzbgK9LTCJB5VJizWzusEDuuD7LaZnI+j79/k55IBClTjU94Coap8BVNFL9kLfj2lfaz6oO
+        TWnWygrHOoA2GPoqdbUEufcJa5JE9XlcjzXtuIp6AMEt3WWrNx6gtMkUn+snntPz7JlUHlLAUku1
+        cY7B7Sl8LSdRBDzAsaYNUUEOPxgIcvh/SNttdGqCOye8bSM2kUtxZY4TMtxIVL2zXdY437FOUa4A
+        92Sf+ljThqgghx8MBMlSP6TtiCrX6Ekx5yOPYo0s0U2FZV6hoAy6LAGiX00zd4Gq/1jThqiXPH4E
+        Cpc8udh/ydtxZWBi1g6EpaEauY4eGaayCNlhn9P0Z0jFwY5GK/t5Sz3WtOMq6k0FdyPW39GNN1XJ
+        Qjbj4MGi7LL8qSfLO5Ezs6m2qT04s9JAmvU8oseaNkRFmWigIEpFe5e3W6oxK2HyM3DokJd9VuHf
+        yFMhTls2JwbjasUxmSEQpY41PeAq2v8HV9Feyg95O640/Afx3SQKVTopSo1cofsk3lSalPzcoPXs
+        SQyB/tSxpgdcZfNUUULaq73e91QcOxITE+Xf1Zwq9KxY44E7pdnltSHApMQvPO8HePnuTNOOq6hn
+        FeSkLUxvPOtggMQ0ipcnoKSWue5KdMd9SYZXpFdsRwfeobBNYFJ1rGlD1L7k1zPicvX/m0S5POBN
+        4u4HLEckWdfn6AHPJbAg6TO9/7T4QGz1UFsxX7XWSDz4dazpBt1lF7LoytrtQvfOdg13zlhB5QUa
+        p9NaPyVvHWyiZpYmOfDN8b7EuZkisDxxrOkGXUFWJd/wwmJJlLXdJXG3XUaqpFg0VngLsBU2JrmH
+        zMCK1JZHfzTl1zSs+geBeutY0w26stnBQlc2P3iTuKObQoJf5dhInSMTwhR9AeZWHPSgR8jEgLmW
+        YqAtcc73VNMNurI5wsJCtpv1JnFHF7qVbnHwphKTbd4IjfBYYF7z4KrCESfepSgwByR21Y413aAr
+        7nbF/cKNW2ARPXeuTzK+Wmc8YQx4XrF1mbcAedYW38vDa9ynEFj8P9a0QyuLqyyoN4gGOlk8VsWN
+        NM55sl5S0hiGRWDobiUWdgN5pSLNIBDGjjVtiAqTL4ww+eKHvN0JaD5xWK28+KFYW1XDcIiGiQx3
+        lEyGgEHHC44bF6r5K3myYXis6QFXWQcrTL4A17sibLCo2mhtY5ZdeajBXPVmSIA30K1yQFGXyF1v
+        ibfrjjXtuIp6ANmEYEnbLdVz1WcxLUxM7FnQMeAKVVO8Z81VGs2jyz4yiKXV/bylHmvaEJW1U9kk
+        4M5GjXHeMWvh0Vp4Asxb7LpMw700PCtecHBYgVnCFGjAHGvaEBUmXxhh8sUPeQ+WSgbF+dleo7Ec
+        +eG9BK6pMYDpsziu0yherSXdMgJFgT/VtOMq+u2Lki9eYdkRbZ4ZNmu/PAtePRttbLHQxeIZCo5V
+        0dzKClI2+4EC+dSxpj///J//A1o8QbDWggAA
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['public, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 24 Jun 2017 17:52:57 GMT']
+      etag: [W/"98f41bf6518b4d75b3ea05374bf572b3"]
+      last-modified: ['Wed, 02 Nov 2016 11:19:54 GMT']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: [Accept, Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['CAA8:16BC:9F44645:B7C3268:594EA6F9']
+      x-ratelimit-limit: ['60']
+      x-ratelimit-remaining: ['24']
+      x-ratelimit-reset: ['1498328685']
+      x-runtime-rack: ['0.030548']
+      x-served-by: [a6882e5cd2513376cb9481dbcd83f3a2]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/anitya/tests/request-data/anitya.tests.lib.backends.test_githubapi.GithubApiBackendtests.test_plexus_utils
+++ b/anitya/tests/request-data/anitya.tests.lib.backends.test_githubapi.GithubApiBackendtests.test_plexus_utils
@@ -1,0 +1,143 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.0.0a4]
+    method: GET
+    uri: https://api.github.com/repos/codehaus-plexus/plexus-archiver
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2bTY+jNhiA/wvXJgPkc4JUbc+99DK99BI5xAl0CEbYZDqL5r/3tYHgkNh82Kv2
+        sNJqdzaxH78YbOzn9ZROfHSCxW63WOz815mTogt2AidL8D8FnaM8jOIrzp2ZcyqSZF9/G5IjjhB8
+        XxVzH0uTjxRqBaWTkHOcArBTBYC8Xd9br73l2ps56IoYyvdFnkDhiLGMBq5bfUj9l3PMouJQUJyH
+        JGU4ZS8hubiF29T/dv11CchzXmM424EPOrgsrklVdcBR9zGwiF2STiBV+6LWY/kTSRLyAaxu9AOa
+        c2+VeRcLUJyep4OgcukSFmHoSri8L94pMWWTQhMVS5f/s4+PHEXhFuX4OCW8uioEx5+Mr9LNcUYE
+        szjQMI8zFpN0Uph3AACS/IzS+DuaDAQABQ4PcFJAoiIA8BUe1EmEqmbpZnl8ReEn76YchxhG4nE/
+        ndpBAJR9Znyw/yH1GL8jMcN7dLzwcXtCCcVfM0dEwqCw+GAGI3TEGHkyPxzx7aY7QQpTC3/683cn
+        YHkBeO24Ff3bHYdP2uDAnu4fhIIxCiDomHf8aYXHOaULf9fDKoRxjw4kR4z0TSLDAr4DltBVLZ8/
+        Swyji5ULESAARoTY6WkBAmBMaYEHPerDOkTwqNuMq7S4HKrJcchoGtZERYLYEaXxOcXYSg/fYKXb
+        zOeHHKVhZAffsEq3+kk8HehsJXTOAdwhIQcrPHgHuwJWujRC1ZuN7W1Fy+mcdQfP8cla6Jx1g7Pc
+        0vMhwuawGxpetAweFStxNyy3rHs8Qem5QGc79BuMv3NgZXFG33sXUcPGYksDNF8x5vGhsDe5tjwe
+        ebV+gfnETpe3uBYuFkf6VdfAjpEWW6JrLpe4b4kyjFyj7oaPRTx/zrtN8P/3r7CGh89Zpdu+G6qX
+        UN2Kjd6v30JN3HJb9bbGyiPUsNzylwyxiM+U0GSGcmzjImqUWx4QrAxfXl7KCCOxO7jg3NLMUJEA
+        We8/bcRdNixYzV0QEzuQEw/7CDuShKCjlb6/wQBc3W4bsVck+XnJYMlsJWABksmXOMGUkdTOHN/S
+        5DZSwuJTHA7Zog0bvnfA8huN0xDPEOwq4KlncRjDOICdMb/bsNDGdnquIsFlgTGpdmgJhiFh5a7k
+        uGKVbrXxPuIsIZ/WZjsJxyeHHMPW7rhHDPaCC89fzz1/vti++Ztg8Ros/b+gTJEd78ps5x4U2755
+        r8F6F6x2vExW0EjCQJHNfLHiGF5EYGAar8cD/ASCR+1Vuvs5Lm4AQGnUAn5rqwc9SqquHibwYHdG
+        5PgYrt138XAEXEJELjiDNVTtuaAXOrE3jiom3U5weQ/E36Hqyt+CrJNWTSEpUrh//mrmfCAG+wNY
+        jkifNWstaPR3cGQ8DET31bzSbLr5J1lO/sYho/Jn7ZxW7855wY/4PW5tAK/Jl4VNtWrr3bS/g3dD
+        nOek1nvVdp9kOK0DaALdVBIAKD5UkQo4AXzVXFZ1kUd8QkXC9tW+BS7rgigTolL2Pz8NZK/w/Gkg
+        fxrIR5v2PzSQsH7lM1xZJQ6Wq43nrQfmK95zQnF6JcmxO6Py+aKbqmhLw7c8k7DZblcwr+pSFAtl
+        ikJUNshP3EWj1653RUdlJaQOmpyQeGCY5CIkmFEaQuLYy0DIUDl70Xn59KwEuc+jrsQam3eQqopV
+        MjQ/RGc+tGtnrN9Fc5ergLjqRMOfcMliCWOaYJAae8w9mucWtPjBaQU1ZXRGQYMyTiZo2LbyCJom
+        RqcQNKyp2QMN0kLiQEOfljPQAA3TBRqySaZAgx2bJNCguCKcnh/oAU9ODfRwp2UFeqDTEwIasFku
+        QAOengbQQI0yABqunEzgb7Jx8l8Dlkgtd7D37wcLFJBHOHkNtKviudexQ+ajuEtvhPkQldoTtLHj
+        1/At6X1NC2ZmXwsW+QEjqa/BT/H5Gpwdla9pYJrF1wANBL6GaujuNWRL2l7Two8w9prmTGS9Bmvo
+        6TVkvaL3595i7u3efD8AA++9PlP04OeFogf/7q2DpSjTUfSbubeEP28LDxR+sPJ6FL063D4731uz
+        R8z31qc6J6+uDV0i6XixNeV23X9dg+95YtefyHWeUqoORTx3682BORtyvWbd2fXFQLkOZ2yrc2wB
+        1Lhz6/CN5NYhIapQ63AMkJIiD6GDagm3eF1766GHhilJEfcAQxRcUxbuCBdwq9VuCc3oBNxSKeBE
+        ZQMBJ8Wi129SwVHy7dYxk9Vbh2Ai3m4oI+12o9iTbi3SVLndSGOF263ieN12q2pHtkmRKFSb9TO9
+        tyZHCLd6vhpwmldDH+zbVIzRtk0JMnZtSrIt06ZsYLRnU5KmWjYl0IJjU7KnGTYlztCvKbkmdk0J
+        HevWlCAzs6bFTvZqWuo0q6ZFTndqSqyZUVNip/s0JdLIpimpZi5NiTUzaX3YCR5Niex6rpEWTck1
+        dWhKcCPijE7JKumW/JmSb2bPNFhzd6aETzFnSpgdb6bET7NmSpyBM1MyDY2ZkmvJlyn5P8KWKRsz
+        cWVKqKEpU3J7PRkcZV2++Vv4FedgtXzmycQ5VW8jXBrXaUpPthAnYndwKLbHk6mC7bNkPfV6HFlP
+        ba0hU9VV+LGlv3p++hSObT6cPoXP/ltDtoJjYoPOn7aKjFfRODK4JI0kSzH7gN8YbU61cpacJ6xP
+        xW6+/gUrPozQez8AAA==
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['public, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 24 Jun 2017 17:52:58 GMT']
+      etag: [W/"109fc7b2582f7fc8f5f5a10d4d4822bf"]
+      last-modified: ['Sun, 07 May 2017 08:59:49 GMT']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: [Accept, Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['EA76:16BA:9A444FF:B1F3B83:594EA6F9']
+      x-ratelimit-limit: ['60']
+      x-ratelimit-remaining: ['23']
+      x-ratelimit-reset: ['1498328685']
+      x-runtime-rack: ['0.040333']
+      x-served-by: [d256f86292c6dde5d09d15d926ec67a3]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.0.0a4]
+    method: GET
+    uri: https://api.github.com/repos/codehaus-plexus/plexus-archiver/tags?per_page=100
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA72a304sNwyH32Wvz9lN4iR2eJWqqpzELkhQEH+qqke8ez0MPRdTujMXUcQFsKD5
+        lvlw/Iszv/w4/cEPcro5Pd3LX28v3/m53d79Kc/f4RxP305/3z1Vvr//7e353n7n9vX16eXmcuGn
+        u/Pvd6+3b/XcHh8uz/L0+HJpj11u2S6xXumyueDl81Lb1z9Br/w8CvR5qf8B2Rt+uHs93fw4vdyy
+        /U3o1SGTb1RLAyoIqdsXXDgW7xNDTuqxBbsZA27CSn+5HKa+v3+7oghmKVpAUxQtoK0iQC6ojMip
+        S3KhdUIIDkhI0LFG4dhU21hFh6nXFS3/OFOqaAFNUbSAtoqkp9YxV2IqrkoW8Nn3hJw9u5Zrzyw1
+        +jpW0WHqdUX+7GdJWlFTNK2orSjUnip7pymYEMeVSipVvBYMxNFWv+IlhsG1dJi6I2qaplm1tPzj
+        bRVRUA+xA2KWYJ+kOHuFsJFGcOQBqtoP0thaOky9rsidp/WkFTWlllbUVhS0FrSV0hEk+S451wbY
+        sWoslUTUKsthzmNFHabuiZrWmdx5Wm9aUVtRYjXTtMSoLDkB5sIC9hJ46Y1D7NoEkdxYUYepe6Km
+        dSf30QgnVdRXSx+qRmoQHZFStpaUon2klEOzVS82iT0VjTpW1GHqNVHh7Cd5+iRN0PRJ2pYTg7rS
+        s7OcwK4rUbP07SzmpRK86UILFlWrjLV0mLpjaVqHsrs3rUX9ZG1dOdsyRaFe2bZNyampcW0pKS4k
+        PlvgW7a6Dce6OkzddTWpSX3cv0ld6idr64pTSZiRYg8gGWtzTjBKzNCrj9Hb92B7qzLW1WHqrqt5
+        69+0RvXh6qtO1atL0fmEzWpKrFk5Qsmaq3QfIS6Ni8G+GuvqMHXPlb2tCUOJ5e7NCRSfpG1FWTRf
+        1jrvpIVac8fepUjtBcB3ixkRvG+B+lhLh6nXLZVZY4lwXlFTEsWK2oqqWUGxdHa2sbXlj8i2ukA2
+        84uVarBSAtv+hsGR4jB1R9SsalpW/jmSDPQfRcnVyvZRIxOV2GulbHuongJga+hLCrYLHlxL9Sj1
+        uiKadZoRzitqiqYVtRVleU9C5QxCiJWAnHeFvVeuaBWVoNtoogOPXfQOU/dETZofLaImnWr8i9qK
+        KlltueNUq5LLWgoo1e6olaQU7eQpSESVwXnvMHVP1LRoTvOS+YraimIpJqVG0eKZm2Y7ycguZY+W
+        /6zSAlRMngeHvcPUPVHTcjnNmh8tFfVVKg+uNRY7rw01kJdk0yI7eirZRkkgQDZQX37cBos6TN0R
+        NStG0KwYsYC2tVQdFW/1k6yCbFpEudvhrbN1MDgtFtJ9DwIRBo/4DlOvK8J5kXxFTYkRK2orylqQ
+        BgsMoWBy0abmqI4UnIRmgbxAsZDRvV8cD3ww4jB1R9SsWloGZ3MkfVFLNhINseQY7AzXDt5zo2jJ
+        vGjWkF3zwQI5oj0cMVbRYep1RXleJF9RUzStqG0tee0+YHF20s5R1WqHbSRh6ZxDxxLtuLcts6PB
+        kfwwdU/UtEie50XyFbUVBZrZNw/2JEQSkNhKpGQxzx6XAMg+g4l0jIPnEIepe6KmRfI8L5KvqK2o
+        Zk+pZGKbt1ou7zFyy620JDWxHckHsfOoVO0AcezSd5i6I2pWd1oePZiz7H3RnWLq2qXbKRN11NZy
+        oBgkx9x02T1Vc1XtBH7w0dNh6vv7r/8AxInMuP4qAAA=
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['public, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 24 Jun 2017 17:52:58 GMT']
+      etag: [W/"14c375b9c09891d7768cf7ad728cbeee"]
+      last-modified: ['Sun, 07 May 2017 08:59:49 GMT']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: [Accept, Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['EA76:16BA:9A4452C:B1F3BB0:594EA6FA']
+      x-ratelimit-limit: ['60']
+      x-ratelimit-remaining: ['22']
+      x-ratelimit-reset: ['1498328685']
+      x-runtime-rack: ['0.034266']
+      x-served-by: [6694d697f15dfc31f0ffaf8cdb1d5a86]
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/anitya/tests/test_config.py
+++ b/anitya/tests/test_config.py
@@ -50,6 +50,7 @@ oidc_scopes = [
     "https://release-monitoring.org/oidc/downstream",
     "https://release-monitoring.org/oidc/upsidedownstream",
 ]
+github_access_token = "foobar"
 
 [anitya_log_config]
     version = 1
@@ -151,6 +152,7 @@ class LoadTests(unittest.TestCase):
             },
             'SMTP_SERVER': 'smtp.example.com',
             'EMAIL_ERRORS': False,
+            'GITHUB_ACCESS_TOKEN': 'foobar',
             'BLACKLISTED_USERS': ['http://sometroublemaker.id.fedoraproject.org'],
             'OIDC_CLIENT_SECRETS': '/etc/anitya/client_secrets.json',
             'OIDC_ID_TOKEN_COOKIE_SECURE': True,

--- a/requirements/el7-requirements.txt
+++ b/requirements/el7-requirements.txt
@@ -18,3 +18,4 @@ sqlalchemy == 0.9.8
 straight.plugin==1.4.0-post-1
 pytoml == 0.1.11
 wtforms == 2.0
+github3.py==1.0.0a4

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -16,3 +16,4 @@ sqlalchemy >= 0.9
 straight.plugin==1.4.0-post-1
 pytoml
 wtforms
+github3.py==1.0.0a4


### PR DESCRIPTION
Anitya currently uses the GitHub releases HTML page to determine the versions for a project. While this works, it is likely to break with interface changes in the future. Parsing the HTML pages via regex is also probably less efficient than using the API.

This PR implements a simple backend, which reports a projects tags as versions.

Todo:
- [x] support authentication for much higher rate limits
- [ ] use [conditional requests](https://developer.github.com/v3/#conditional-requests) wherever possible to minimize the import on rate limits
- [ ] gracefully handle rate limits
- [ ] merge GitHub and GitHub API backends
  - [ ] fallback to HTML scraping if `github3` is not installed, or rate limit is hit

Please let me know what you think about this :)