### PR TITLE
Stop depending on anitya/app.py in the backend __init__.py

### DIFF
--- a/anitya/lib/backends/__init__.py
+++ b/anitya/lib/backends/__init__.py
@@ -26,9 +26,10 @@ import socket
 import sre_constants
 import six.moves.urllib.request as urllib2
 
+import pkg_resources
 import requests
-import anitya
-import anitya.app
+
+from anitya.config import config as anitya_config
 from anitya.lib.exceptions import AnityaPluginException
 from anitya.lib.versions import RpmVersion
 import six
@@ -204,8 +205,8 @@ class BaseBackend(object):
         :return type: Request
         '''
         user_agent = 'Anitya %s at upstream-monitoring.org' % \
-            anitya.app.__version__
-        from_email = anitya.app.APP.config.get('ADMIN_EMAIL')
+            pkg_resources.get_distribution('anitya').version
+        from_email = anitya_config.get('ADMIN_EMAIL')
 
         if '*' in url:
             url = self.expand_subdirs(url)


### PR DESCRIPTION
This was causing a circular import since backend/__init__.py needed
app.py, but app.py needed utilities.py, which in turn needed
backend/__init__.py.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>