### PR TITLE
Refactor the Flask application to use an app factory

### DIFF
--- a/anitya.wsgi
+++ b/anitya.wsgi
@@ -3,4 +3,6 @@ import sys, os
 sys.path.insert (0,'/opt/anitya/src')
 os.chdir('/opt/anitya/src')
 
-from anitya.app import APP as application
+from anitya.app import create
+
+application = create()

--- a/anitya/admin.py
+++ b/anitya/admin.py
@@ -12,13 +12,23 @@ import anitya
 import anitya.forms
 import anitya.lib.model
 
-from anitya.app import APP, SESSION, login_required, is_admin
+from anitya.ui import login_required, ui_blueprint
+from anitya.lib.model import Session as SESSION
 
 
 _log = logging.getLogger(__name__)
 
 
-@APP.route('/distro/add', methods=['GET', 'POST'])
+def is_admin(user=None):
+    ''' Check if the provided user, or the user logged in are recognized
+    as being admins.
+    '''
+    if not user and flask.g.auth.logged_in:
+        user = flask.g.auth.openid
+    return user in flask.current_app.config.get('ANITYA_WEB_ADMINS', [])
+
+
+@ui_blueprint.route('/distro/add', methods=['GET', 'POST'])
 @login_required
 def add_distro():
 
@@ -51,7 +61,7 @@ def add_distro():
             flask.flash(
                 'Could not add this distro, already exists?', 'error')
         return flask.redirect(
-            flask.url_for('distros')
+            flask.url_for('anitya_ui.distros')
         )
 
     return flask.render_template(
@@ -60,7 +70,7 @@ def add_distro():
         form=form)
 
 
-@APP.route('/distro/<distro_name>/edit', methods=['GET', 'POST'])
+@ui_blueprint.route('/distro/<distro_name>/edit', methods=['GET', 'POST'])
 @login_required
 def edit_distro(distro_name):
 
@@ -95,7 +105,7 @@ def edit_distro(distro_name):
             message = 'Distribution edited'
             flask.flash(message)
         return flask.redirect(
-            flask.url_for('distros')
+            flask.url_for('anitya_ui.distros')
         )
 
     return flask.render_template(
@@ -105,7 +115,7 @@ def edit_distro(distro_name):
         form=form)
 
 
-@APP.route('/distro/<distro_name>/delete', methods=['GET', 'POST'])
+@ui_blueprint.route('/distro/<distro_name>/delete', methods=['GET', 'POST'])
 @login_required
 def delete_distro(distro_name):
     """ Delete a distro """
@@ -133,7 +143,7 @@ def delete_distro(distro_name):
         SESSION.delete(distro)
         SESSION.commit()
         flask.flash('Distro %s has been removed' % distro_name)
-        return flask.redirect(flask.url_for('distros'))
+        return flask.redirect(flask.url_for('anitya_ui.distros'))
 
     return flask.render_template(
         'distro_delete.html',
@@ -142,7 +152,7 @@ def delete_distro(distro_name):
         form=form)
 
 
-@APP.route('/project/<project_id>/delete', methods=['GET', 'POST'])
+@ui_blueprint.route('/project/<project_id>/delete', methods=['GET', 'POST'])
 @login_required
 def delete_project(project_id):
 
@@ -176,10 +186,10 @@ def delete_project(project_id):
             SESSION.delete(project)
             SESSION.commit()
             flask.flash('Project %s has been removed' % project_name)
-            return flask.redirect(flask.url_for('projects'))
+            return flask.redirect(flask.url_for('anitya_ui.projects'))
         else:
             return flask.redirect(
-                flask.url_for('project', project_id=project.id))
+                flask.url_for('anitya_ui.project', project_id=project.id))
 
     return flask.render_template(
         'project_delete.html',
@@ -188,7 +198,7 @@ def delete_project(project_id):
         form=form)
 
 
-@APP.route(
+@ui_blueprint.route(
     '/project/<project_id>/delete/<distro_name>/<pkg_name>',
     methods=['GET', 'POST'])
 @login_required
@@ -231,7 +241,7 @@ def delete_project_mapping(project_id, distro_name, pkg_name):
 
             flask.flash('Mapping for %s has been removed' % project.name)
         return flask.redirect(
-            flask.url_for('project', project_id=project.id))
+            flask.url_for('anitya_ui.project', project_id=project.id))
 
     return flask.render_template(
         'regex_delete.html',
@@ -241,7 +251,7 @@ def delete_project_mapping(project_id, distro_name, pkg_name):
         form=form)
 
 
-@APP.route(
+@ui_blueprint.route(
     '/project/<project_id>/delete/<version>', methods=['GET', 'POST'])
 @login_required
 def delete_project_version(project_id, version):
@@ -291,7 +301,7 @@ def delete_project_version(project_id, version):
 
             flask.flash('Version for %s has been removed' % version)
         return flask.redirect(
-            flask.url_for('project', project_id=project.id))
+            flask.url_for('anitya_ui.project', project_id=project.id))
 
     return flask.render_template(
         'version_delete.html',
@@ -301,7 +311,7 @@ def delete_project_version(project_id, version):
         form=form)
 
 
-@APP.route('/logs')
+@ui_blueprint.route('/logs')
 @login_required
 def browse_logs():
 
@@ -380,7 +390,7 @@ def browse_logs():
     )
 
 
-@APP.route('/flags')
+@ui_blueprint.route('/flags')
 @login_required
 def browse_flags():
 
@@ -466,7 +476,7 @@ def browse_flags():
     )
 
 
-@APP.route('/flags/<flag_id>/set/<state>', methods=['POST'])
+@ui_blueprint.route('/flags/<flag_id>/set/<state>', methods=['POST'])
 @login_required
 def set_flag_state(flag_id, state):
 
@@ -496,5 +506,5 @@ def set_flag_state(flag_id, state):
             flask.flash(str(err), 'errors')
 
     return flask.redirect(
-        flask.url_for('browse_flags')
+        flask.url_for('anitya_ui.browse_flags')
     )

--- a/anitya/api.py
+++ b/anitya/api.py
@@ -22,15 +22,18 @@ This module provides Anitya's HTTP API.
 
 import flask
 
-from anitya.app import APP, SESSION
 from anitya.lib import utilities
+from anitya.lib.model import Session as SESSION
 import anitya
 import anitya.lib.plugins
 import anitya.lib.model
 
 
-@APP.route('/api/')
-@APP.route('/api')
+api_blueprint = flask.Blueprint('anitya_apiv1', __name__)
+
+
+@api_blueprint.route('/api/')
+@api_blueprint.route('/api')
 def api():
     """
     Retrieve the HTML information page.
@@ -42,8 +45,8 @@ def api():
     return flask.redirect(new_url)
 
 
-@APP.route('/api/version/')
-@APP.route('/api/version')
+@api_blueprint.route('/api/version/')
+@api_blueprint.route('/api/version')
 def api_version():
     '''
     Display the api version information.
@@ -66,8 +69,8 @@ def api_version():
     return flask.jsonify({'version': anitya.__api_version__})
 
 
-@APP.route('/api/projects/')
-@APP.route('/api/projects')
+@api_blueprint.route('/api/projects/')
+@api_blueprint.route('/api/projects')
 def api_projects():
     '''
     Lists all the projects registered in Anitya.
@@ -166,8 +169,8 @@ def api_projects():
     return jsonout
 
 
-@APP.route('/api/packages/wiki/')
-@APP.route('/api/packages/wiki')
+@api_blueprint.route('/api/packages/wiki/')
+@api_blueprint.route('/api/packages/wiki')
 def api_packages_wiki_list():
     '''
     List all packages in mediawiki format.
@@ -208,8 +211,8 @@ def api_packages_wiki_list():
     )
 
 
-@APP.route('/api/projects/names/')
-@APP.route('/api/projects/names')
+@api_blueprint.route('/api/projects/names/')
+@api_blueprint.route('/api/projects/names')
 def api_projects_names():
     '''
     Lists the names of all the projects registered in anitya.
@@ -277,8 +280,8 @@ def api_projects_names():
     return jsonout
 
 
-@APP.route('/api/distro/names/')
-@APP.route('/api/distro/names')
+@api_blueprint.route('/api/distro/names/')
+@api_blueprint.route('/api/distro/names')
 def api_distro_names():
     '''
     Lists the names of all the distributions registered in anitya.
@@ -338,7 +341,7 @@ def api_distro_names():
     return jsonout
 
 
-@APP.route('/api/version/get', methods=['POST'])
+@api_blueprint.route('/api/version/get', methods=['POST'])
 def api_get_version():
     '''
     Forces anitya to retrieve the latest version available from a project
@@ -413,8 +416,8 @@ def api_get_version():
     return jsonout
 
 
-@APP.route('/api/project/<int:project_id>/', methods=['GET'])
-@APP.route('/api/project/<int:project_id>', methods=['GET'])
+@api_blueprint.route('/api/project/<int:project_id>/', methods=['GET'])
+@api_blueprint.route('/api/project/<int:project_id>', methods=['GET'])
 def api_get_project(project_id):
     '''
     Retrieves a specific project using its identifier in anitya.
@@ -468,8 +471,8 @@ def api_get_project(project_id):
     return jsonout
 
 
-@APP.route('/api/project/<distro>/<path:package_name>/', methods=['GET'])
-@APP.route('/api/project/<distro>/<path:package_name>', methods=['GET'])
+@api_blueprint.route('/api/project/<distro>/<path:package_name>/', methods=['GET'])
+@api_blueprint.route('/api/project/<distro>/<path:package_name>', methods=['GET'])
 def api_get_project_distro(distro, package_name):
     '''
     Retrieves a project in a distribution via the name of the distribution
@@ -534,8 +537,8 @@ def api_get_project_distro(distro, package_name):
     return jsonout
 
 
-@APP.route('/api/by_ecosystem/<ecosystem>/<project_name>/', methods=['GET'])
-@APP.route('/api/by_ecosystem/<ecosystem>/<project_name>', methods=['GET'])
+@api_blueprint.route('/api/by_ecosystem/<ecosystem>/<project_name>/', methods=['GET'])
+@api_blueprint.route('/api/by_ecosystem/<ecosystem>/<project_name>', methods=['GET'])
 def api_get_project_ecosystem(ecosystem, project_name):
     '''
     Retrieves a project in an ecosystem via the name of the ecosystem

--- a/anitya/api_v2.py
+++ b/anitya/api_v2.py
@@ -11,9 +11,9 @@ from flask import jsonify
 from flask_restful import Resource, reqparse
 
 from anitya import authentication
-from anitya.app import APP, SESSION
 from anitya.lib import utilities, model
 from anitya.lib.exceptions import ProjectExists
+from anitya.lib.model import Session as SESSION
 
 _BASE_ARG_PARSER = reqparse.RequestParser(trim=True, bundle_errors=True)
 _BASE_ARG_PARSER.add_argument('access_token', type=str)
@@ -255,6 +255,3 @@ class ProjectsResource(Resource):
             response = jsonify(e.to_dict())
             response.status_code = 409
             return response
-
-
-APP.api.add_resource(ProjectsResource, '/api/v2/projects/')

--- a/anitya/api_v2.py
+++ b/anitya/api_v2.py
@@ -246,7 +246,7 @@ class ProjectsResource(Resource):
         try:
             project = utilities.create_project(
                 SESSION,
-                user_id=APP.oidc.user_getfield('email', access_token),
+                user_id=authentication.oidc.user_getfield('email', access_token),
                 **args
             )
             SESSION.commit()

--- a/anitya/app.py
+++ b/anitya/app.py
@@ -10,7 +10,6 @@ User-facing Flask routes should be placed in the ``anitya.ui`` module and API
 routes should be placed in ``anitya.api_v2``.
 """
 
-import functools
 import logging
 import logging.config
 import logging.handlers
@@ -69,7 +68,6 @@ def create(config=None):
     app.oid.loginhandler(ui.yahoo_login)
     app.oid.loginhandler(ui.google_login)
 
-
     if app.config.get('EMAIL_ERRORS'):
         # If email logging is configured, set up the anitya logger with an email
         # handler for any ERROR-level logs.
@@ -79,35 +77,10 @@ def create(config=None):
             mail_admin=app.config.get('ADMIN_EMAIL')
         ))
 
-
     return app
 
 
 APP = create()
-
-
-@APP.template_filter('format_examples')
-def format_examples(examples):
-    ''' Return the plugins examples as HTML links. '''
-    output = ''
-    if examples:
-        for cnt, example in enumerate(examples):
-            if cnt > 0:
-                output += " <br /> "
-            output += "<a href='%(url)s'>%(url)s</a> " % ({'url': example})
-
-    return output
-
-
-@APP.template_filter('context_class')
-def context_class(category):
-    ''' Return bootstrap context class for a given category. '''
-    values = {
-        'message': 'default',
-        'error': 'danger',
-        'info': 'info',
-    }
-    return values.get(category, 'warning')
 
 
 @APP.before_request

--- a/anitya/app.py
+++ b/anitya/app.py
@@ -22,7 +22,7 @@ from flask_restful import Api
 from anitya.config import config as anitya_config
 from anitya.lib import utilities
 from anitya.lib.model import Session as SESSION, initialize as initialize_db
-from . import ui, admin
+from . import ui, admin, api
 import anitya.lib
 import anitya.authentication
 import anitya.mail_logging
@@ -61,6 +61,7 @@ def create(config=None):
 
     # Register all the view blueprints
     app.register_blueprint(ui.ui_blueprint)
+    app.register_blueprint(api.api_blueprint)
 
     # Mark login handlers
     app.oid.loginhandler(ui.login)

--- a/anitya/app.py
+++ b/anitya/app.py
@@ -145,6 +145,3 @@ def after_openid_login(resp):
         return flask.redirect(next_url)
     else:
         return flask.redirect(default)
-
-
-APP = create()

--- a/anitya/app.py
+++ b/anitya/app.py
@@ -21,7 +21,7 @@ from flask_restful import Api
 from anitya.config import config as anitya_config
 from anitya.lib import utilities
 from anitya.lib.model import Session as SESSION, initialize as initialize_db
-from . import ui, admin, api, authentication  # noqa: F401
+from . import ui, admin, api, api_v2, authentication  # noqa: F401
 import anitya.lib
 import anitya.mail_logging
 
@@ -54,7 +54,10 @@ def create(config=None):
 
     # Set up the Flask extensions
     authentication.configure_openid(app)
+
+    # Register the v2 API resources
     app.api = Api(app)
+    app.api.add_resource(api_v2.ProjectsResource, '/api/v2/projects/')
 
     # Register all the view blueprints
     app.register_blueprint(ui.ui_blueprint)
@@ -145,8 +148,3 @@ def after_openid_login(resp):
 
 
 APP = create()
-
-
-# Finalize the import of other controllers
-from . import api  # NOQA
-from . import api_v2  # NOQA

--- a/anitya/templates/distro_add.html
+++ b/anitya/templates/distro_add.html
@@ -9,7 +9,7 @@
   <h1>Add a new disribution</h1>
 </div>
 
-<form method="POST" action="{{ url_for('add_distro') }}" >
+<form method="POST" action="{{ url_for('anitya_ui.add_distro') }}" >
   <div class="row">
     <div class="col-md-6">
       <div class="list-group">
@@ -28,7 +28,7 @@
     <span class="glyphicon glyphicon-plus"></span>
     Add distribution
   </button>
-  <a href="{{ url_for('distros') }}">
+  <a href="{{ url_for('anitya_ui.distros') }}">
     <button type="button" class="btn btn-danger" tabindex=3>
       <span class="glyphicon glyphicon-ban-circle"></span>
       Cancel

--- a/anitya/templates/distro_delete.html
+++ b/anitya/templates/distro_delete.html
@@ -9,12 +9,12 @@
   <h1>Delete disribution: {{ distro.name }}</h1>
 </div>
 
-<form method="POST" action="{{ url_for('delete_distro', distro_name=distro.name) }}" >
+<form method="POST" action="{{ url_for('anitya_ui.delete_distro', distro_name=distro.name) }}" >
   <button type="submit" class="btn btn-success">
     <span class="glyphicon glyphicon-plus"></span>
     Submit
   </button>
-  <a href="{{ url_for('distros') }}">
+  <a href="{{ url_for('anitya_ui.distros') }}">
     <button type="button" class="btn btn-danger">
       <span class="glyphicon glyphicon-ban-circle"></span>
       Cancel

--- a/anitya/templates/distro_edit.html
+++ b/anitya/templates/distro_edit.html
@@ -9,7 +9,7 @@
   <h1>Edit disribution: {{ distro.name }}</h1>
 </div>
 
-<form method="POST" action="{{ url_for('edit_distro', distro_name=distro.name) }}" >
+<form method="POST" action="{{ url_for('anitya_ui.edit_distro', distro_name=distro.name) }}" >
   <div class="row">
     <div class="col-md-6">
       <div class="list-group">
@@ -28,7 +28,7 @@
     <span class="glyphicon glyphicon-plus"></span>
     Submit
   </button>
-  <a href="{{ url_for('distros') }}">
+  <a href="{{ url_for('anitya_ui.distros') }}">
     <button type="button" class="btn btn-danger" tabindex=3>
       <span class="glyphicon glyphicon-ban-circle"></span>
       Cancel

--- a/anitya/templates/distros.html
+++ b/anitya/templates/distros.html
@@ -14,7 +14,7 @@
     <ul class="pagination pagination-sm">
         <li>
             {% if page > 1%}
-              <a href="{{ url_for('distros') }}?page={{page - 1}}">
+              <a href="{{ url_for('anitya_ui.distros') }}?page={{page - 1}}">
                 «
               </a>
             {% else %}
@@ -26,7 +26,7 @@
         </li>
         <li>
             {% if page < total_page %}
-              <a href="{{ url_for('distros') }}?page={{page + 1}}">
+              <a href="{{ url_for('anitya_ui.distros') }}?page={{page + 1}}">
                 »
               </a>
             {% else %}
@@ -44,7 +44,7 @@
   </p>
   {% if is_admin %}
   <p>
-  <a href="{{ url_for('add_distro') }}">
+  <a href="{{ url_for('anitya_ui.add_distro') }}">
     <button type="submit" class="btn btn-success">
       <span class="glyphicon glyphicon-edit"></span>
       Add a new distribution
@@ -56,18 +56,18 @@
   {% for distro in distros %}
     <span class="list-group-item">
       <h4 class="list-group-item-heading">
-        <a href="{{ url_for('distro', distroname=distro.name) }}">
+        <a href="{{ url_for('anitya_ui.distro', distroname=distro.name) }}">
           {{distro.name}}
         </a>
       </h4>
       {% if is_admin %}
-      <a href="{{ url_for('edit_distro', distro_name=distro.name) }}">
+      <a href="{{ url_for('anitya_ui.edit_distro', distro_name=distro.name) }}">
         <button type="submit" class="btn btn-info">
           <span class="glyphicon glyphicon-edit"></span>
           Edit
         </button>
       </a>
-      <a href="{{ url_for('delete_distro', distro_name=distro.name) }}">
+      <a href="{{ url_for('anitya_ui.delete_distro', distro_name=distro.name) }}">
         <button type="submit" class="btn btn-warning btn-sm pull-right">
           <span class="glyphicon glyphicon-remove"></span>
             Delete

--- a/anitya/templates/flags.html
+++ b/anitya/templates/flags.html
@@ -15,14 +15,14 @@
   <h1>Flags</h1>
   {% if refresh %}
   <p>This page should refresh automatically every 5 seconds</p>
-  <a href="{{ url_for('browse_flags', page=page) }}">
+  <a href="{{ url_for('anitya_ui.browse_flags', page=page) }}">
     <button type="submit" class="btn btn-danger" id="checknow">
       <span class="glyphicon glyphicon-remove-sign"></span>
       Remove auto-refresh
     </button>
   </a>
   {% else %}
-  <a href="{{ url_for('browse_flags', page=page, refresh=True) }}">
+  <a href="{{ url_for('anitya_ui.browse_flags', page=page, refresh=True) }}">
     <button type="submit" class="btn btn-success" id="checknow">
       <span class="glyphicon glyphicon-refresh"></span>
       Activate auto-refresh
@@ -37,7 +37,7 @@
     <ul class="pagination pagination-sm">
         <li>
             {% if page > 1%}
-              <a href="{{ url_for('browse_flags', page=page-1, project=project,
+              <a href="{{ url_for('anitya_ui.browse_flags', page=page-1, project=project,
                 user=user, from_date=from_date) }}">
                 «
               </a>
@@ -50,7 +50,7 @@
         </li>
         <li>
             {% if page < total_page %}
-              <a href="{{ url_for('browse_flags', page=page+1, project=project,
+              <a href="{{ url_for('anitya_ui.browse_flags', page=page+1, project=project,
                 user=user, from_date=from_date) }}">
                 »
               </a>
@@ -63,7 +63,7 @@
   </div>
 
   <div class="col-xs-10">
-    <form action="{{url_for('browse_flags') }}" class="form-inline"
+    <form action="{{url_for('anitya_ui.browse_flags') }}" class="form-inline"
           role="form" action="GET" id="flags_form">
       <div class="form-group col-xs-6 col-sm-2">
         <select name="state" class="form-control">
@@ -108,14 +108,14 @@
     <tr>
         <td>
           {% if flag.state == 'open' %}
-          <form method="POST" action="{{ url_for('set_flag_state', flag_id=flag.id, state='closed') }}">
+          <form method="POST" action="{{ url_for('anitya_ui.set_flag_state', flag_id=flag.id, state='closed') }}">
             <button type="submit" class="btn btn-warning btn-sm pull-right inline"
                   id="flag_btn">
               <span class="glyphicon glyphicon-eye-close"></span>
               Close
             </button>
           {% else %}
-          <form method="POST" action="{{ url_for('set_flag_state', flag_id=flag.id, state='open') }}">
+          <form method="POST" action="{{ url_for('anitya_ui.set_flag_state', flag_id=flag.id, state='open') }}">
             <button type="submit" class="btn btn-success btn-sm pull-right inline"
                   id="flag_btn">
               <span class="glyphicon glyphicon-eye-open"></span>
@@ -132,7 +132,7 @@
         </td>
         <td>
           {% if flag.project -%}
-          <a href="{{ url_for('project', project_id=flag.project.id) }}">{{ flag.project.name }}</a>
+          <a href="{{ url_for('anitya_ui.project', project_id=flag.project.id) }}">{{ flag.project.name }}</a>
           {%- endif %}
         </td>
         <td> {{ flag.user }} </td>

--- a/anitya/templates/index.html
+++ b/anitya/templates/index.html
@@ -29,9 +29,9 @@
       <h2><span class="glyphicon glyphicon-search"></span> Search</h2>
       <p>Currently {{ total }} projects are being monitored by Anitya.
       Your project of interest might be there, or not. To check it
-      <a href="{{ url_for('projects') }}">browse the list of all projects</a>
+      <a href="{{ url_for('anitya_ui.projects') }}">browse the list of all projects</a>
       or simply search for them!</p>
-      <form action="{{ url_for('projects_search') }}" role="form" class="form-inline">
+      <form action="{{ url_for('anitya_ui.projects_search') }}" role="form" class="form-inline">
         <div class="form-group">
           <input id="searchbox" type="text" name="pattern" placeholder="Project name" class="form-control input-sm"/>
           <button type="submit" class="btn btn-sm btn-default">Search</button>

--- a/anitya/templates/login.html
+++ b/anitya/templates/login.html
@@ -10,7 +10,7 @@
     {% if config.get('ANITYA_WEB_ALLOW_GENERIC_OPENID') %}
     <span class="list-group-item">
         <h4 class="list-group-item-heading">OpenId Login</h4>
-          <form role="form" action="{{url_for('login')}}" method="post">
+          <form role="form" action="{{url_for('anitya_ui.login')}}" method="post">
             <input name="openid" placeholder="https://id.openid.server">
             <span class="pull-right">
                 <button type="submit" class="btn btn-success">

--- a/anitya/templates/logs.html
+++ b/anitya/templates/logs.html
@@ -15,14 +15,14 @@
   <h1>Logs</h1>
   {% if refresh %}
   <p>This page should refresh automatically every 5 seconds</p>
-  <a href="{{ url_for('browse_logs') }}?page={{page}}">
+  <a href="{{ url_for('anitya_ui.browse_logs') }}?page={{page}}">
     <button type="submit" class="btn btn-danger" id="checknow">
       <span class="glyphicon glyphicon-remove-sign"></span>
       Remove auto-refresh
     </button>
   </a>
   {% else %}
-  <a href="{{ url_for('browse_logs') }}?page={{page}}&refresh=True">
+  <a href="{{ url_for('anitya_ui.browse_logs') }}?page={{page}}&refresh=True">
     <button type="submit" class="btn btn-success" id="checknow">
       <span class="glyphicon glyphicon-refresh"></span>
       Activate auto-refresh
@@ -37,7 +37,7 @@
     <ul class="pagination pagination-sm">
         <li>
             {% if page > 1%}
-              <a href="{{ url_for('browse_logs', page=page-1, project=project,
+              <a href="{{ url_for('anitya_ui.browse_logs', page=page-1, project=project,
                 user=user, from_date=from_date) }}">
                 «
               </a>
@@ -50,7 +50,7 @@
         </li>
         <li>
             {% if page < total_page %}
-              <a href="{{ url_for('browse_logs', page=page+1, project=project,
+              <a href="{{ url_for('anitya_ui.browse_logs', page=page+1, project=project,
                 user=user, from_date=from_date) }}">
                 »
               </a>
@@ -63,7 +63,7 @@
   </div>
 
   <div class="col-xs-10">
-    <form action="{{url_for('browse_logs') }}" class="form-inline"
+    <form action="{{url_for('anitya_ui.browse_logs') }}" class="form-inline"
           role="form" action="GET" id="logs_form">
       <div class="form-group col-xs-6 col-sm-3">
         <input type="text" name="project" placeholder="Project name"

--- a/anitya/templates/mapping.html
+++ b/anitya/templates/mapping.html
@@ -78,7 +78,7 @@
     $('#distro').autocomplete({
         source: function( request, response ) {
             $.getJSON(
-              "{{ url_for('api_distro_names') }}", {
+              "{{ url_for('anitya_apiv1.api_distro_names') }}", {
                 pattern: request.term
               },
               function( data ) {

--- a/anitya/templates/mapping.html
+++ b/anitya/templates/mapping.html
@@ -12,10 +12,10 @@
 <div class="row">
 
     {% if package %}
-    <form method="POST" action="{{ url_for('edit_project_mapping',
+    <form method="POST" action="{{ url_for('anitya_ui.edit_project_mapping',
         project_id=project.id, pkg_id=package.id) }}" >
     {% else %}
-    <form method="POST" action="{{ url_for('map_project', project_id=project.id) }}" >
+    <form method="POST" action="{{ url_for('anitya_ui.map_project', project_id=project.id) }}" >
     {% endif %}
       {{ form.csrf_token }}
       <table id="input_table">
@@ -44,7 +44,7 @@
         {% endif %}
       </button>
 
-      <a href="{{ url_for('project', project_id=project.id) }}">
+      <a href="{{ url_for('anitya_ui.project', project_id=project.id) }}">
         <button type="button" class="btn btn-danger">
           <span class="glyphicon glyphicon-ban-circle"></span>
           Cancel
@@ -78,7 +78,7 @@
     $('#distro').autocomplete({
         source: function( request, response ) {
             $.getJSON(
-              "{{ url_for('.api_distro_names') }}", {
+              "{{ url_for('api_distro_names') }}", {
                 pattern: request.term
               },
               function( data ) {

--- a/anitya/templates/master.html
+++ b/anitya/templates/master.html
@@ -194,7 +194,7 @@
       <div class="container">
         <p class="text-muted credit">
         Anitya ({{ version }}):
-        <a href="{{ url_for('api') }}">API</a>
+        <a href="{{ url_for('anitya_apiv1.api') }}">API</a>
         --
         <a href="https://github.com/fedora-infra/anitya">sources</a>
         --
@@ -228,7 +228,7 @@
         $('#searchbox').autocomplete({
           source: function( request, response ) {
             $.getJSON(
-              "{{ url_for('api_projects_names') }}", {
+              "{{ url_for('anitya_apiv1.api_projects_names') }}", {
                 pattern: request.term + '*'
               },
               function( data ) {

--- a/anitya/templates/master.html
+++ b/anitya/templates/master.html
@@ -7,19 +7,19 @@
     <meta name="description" content="Monitoring project releases" />
     <meta name="author" content="Pierre-Yves Chibon" />
 
-    <link rel="shortcut icon" href="{{ url_for('static', filename='ico/favicon.ico') }}">
+    <link rel="shortcut icon" href="{{ url_for('anitya_ui.static', filename='ico/favicon.ico') }}">
 
     <!-- Page Title -->
     <title>{% block title %}{% endblock %}</title>
 
-    <link href="{{ url_for('static', filename='bootstrap/css/bootstrap.css') }}" rel="stylesheet" />
-    <link href="{{ url_for('static', filename='css/text.css') }}" rel="stylesheet" />
-    <link href="{{ url_for('static', filename='css/navbar.css') }}" rel="stylesheet" />
-    <link href="{{ url_for('static', filename='css/footer.css') }}" rel="stylesheet" />
-    <link href="{{ url_for('static', filename='css/cnucnu.css') }}" rel="stylesheet" />
-    <link href="{{ url_for('static', filename='css/jquery-ui.min.css') }}" rel="stylesheet" />
-    <link href="{{ url_for('static', filename='css/jquery-ui.theme.min.css') }}" rel="stylesheet" />
-    <link href="{{ url_for('static', filename='bootstrap-datetimepicker.min.css') }}" rel="stylesheet" />
+    <link href="{{ url_for('anitya_ui.static', filename='bootstrap/css/bootstrap.css') }}" rel="stylesheet" />
+    <link href="{{ url_for('anitya_ui.static', filename='css/text.css') }}" rel="stylesheet" />
+    <link href="{{ url_for('anitya_ui.static', filename='css/navbar.css') }}" rel="stylesheet" />
+    <link href="{{ url_for('anitya_ui.static', filename='css/footer.css') }}" rel="stylesheet" />
+    <link href="{{ url_for('anitya_ui.static', filename='css/cnucnu.css') }}" rel="stylesheet" />
+    <link href="{{ url_for('anitya_ui.static', filename='css/jquery-ui.min.css') }}" rel="stylesheet" />
+    <link href="{{ url_for('anitya_ui.static', filename='css/jquery-ui.theme.min.css') }}" rel="stylesheet" />
+    <link href="{{ url_for('anitya_ui.static', filename='bootstrap-datetimepicker.min.css') }}" rel="stylesheet" />
 
     {% block header %}{% endblock %}
 
@@ -39,7 +39,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="{{url_for('index')}}">
+          <a class="navbar-brand" href="{{url_for('anitya_ui.index')}}">
             release-monitoring.org
           </a>
         </div>
@@ -47,7 +47,7 @@
         <div class="navbar-collapse collapse">
           <ul class="nav navbar-nav">
               <li>
-                  <a href="{{ url_for('static', filename='docs/index.html') }}">Documentation</a>
+                  <a href="{{ url_for('anitya_ui.static', filename='docs/index.html') }}">Documentation</a>
               </li>
             {%- if current == 'projects' -%}
             <li class="active">
@@ -59,29 +59,29 @@
               </a>
               <ul class="dropdown-menu">
                   <li>
-                      <a href="{{url_for('projects')}}">All</a>
+                      <a href="{{url_for('anitya_ui.projects')}}">All</a>
                   </li>
                   <li class="divider"></li>
                   <li>
-                    <a href="{{url_for('projects_updated')}}">Updated</a>
+                    <a href="{{url_for('anitya_ui.projects_updated')}}">Updated</a>
                   </li>
                   <li>
-                    <a href="{{url_for('projects_updated', status='odd')}}">
+                    <a href="{{url_for('anitya_ui.projects_updated', status='odd')}}">
                       Odd version found
                     </a>
                   </li>
                   <li>
-                    <a href="{{url_for('projects_updated', status='new')}}">
+                    <a href="{{url_for('anitya_ui.projects_updated', status='new')}}">
                       Not updated
                     </a>
                   </li>
                   <li>
-                    <a href="{{url_for('projects_updated', status='failed')}}">
+                    <a href="{{url_for('anitya_ui.projects_updated', status='failed')}}">
                       Failed to update
                     </a>
                   </li>
                   <li>
-                    <a href="{{url_for('projects_updated', status='never_updated')}}">
+                    <a href="{{url_for('anitya_ui.projects_updated', status='never_updated')}}">
                       Never updated
                     </a>
                   </li>
@@ -93,7 +93,7 @@
             {%- else -%}
             <li>
             {%- endif -%}
-              <a href="{{url_for('distros')}}">
+              <a href="{{url_for('anitya_ui.distros')}}">
                   distros
               </a>
             </li>
@@ -104,7 +104,7 @@
             {%- else -%}
             <li>
             {%- endif -%}
-              <a href="{{url_for('new_project')}}">
+              <a href="{{url_for('anitya_ui.new_project')}}">
                   add project
               </a>
             </li>
@@ -114,7 +114,7 @@
             {%- else -%}
             <li>
             {%- endif -%}
-              <a href="{{url_for('browse_logs')}}">
+              <a href="{{url_for('anitya_ui.browse_logs')}}">
                   logs
               </a>
             </li>
@@ -124,12 +124,12 @@
               {%- else -%}
                <li>
               {%- endif -%}
-               <a href="{{url_for('browse_flags')}}">
+               <a href="{{url_for('anitya_ui.browse_flags')}}">
                   flags</a>
                </li>
             {%- endif -%}
             <li>
-              <a href="{{url_for('logout')}}?next={{request.url}}">logout</a>
+              <a href="{{url_for('anitya_ui.logout')}}?next={{request.url}}">logout</a>
             </li>
             {%- else -%}
             <li>
@@ -139,23 +139,23 @@
                 <ul class="dropdown-menu">
                   {%- if config['ANITYA_WEB_FEDORA_OPENID'] and
                         config['ANITYA_WEB_ALLOW_FAS_OPENID'] -%}
-                  <li><a href="{{url_for('fedora_login')}}">Fedora</a></li>
+                  <li><a href="{{url_for('anitya_ui.fedora_login')}}">Fedora</a></li>
                   <li class="divider"></li>
                   {%- endif -%}
                   {%- if config['ANITYA_WEB_ALLOW_GOOGLE_OPENID'] -%}
-                  <li><a href="{{url_for('google_login')}}">Google</a></li>
+                  <li><a href="{{url_for('anitya_ui.google_login')}}">Google</a></li>
                   {%- endif -%}
                   {%- if config['ANITYA_WEB_ALLOW_YAHOO_OPENID'] -%}
-                  <li><a href="{{url_for('yahoo_login')}}">Yahoo</a></li>
+                  <li><a href="{{url_for('anitya_ui.yahoo_login')}}">Yahoo</a></li>
                   {%- endif -%}
                   {%- if config['ANITYA_WEB_ALLOW_GENERIC_OPENID'] -%}
-                  <li><a href="{{url_for('login')}}">Other OpenID</a></li>
+                  <li><a href="{{url_for('anitya_ui.login')}}">Other OpenID</a></li>
                   {%- endif -%}
                 </ul>
             </li>
             {%- endif -%}
             <li>
-              <form action="{{ url_for('projects_search') }}" role="form" class="form-inline">
+              <form action="{{ url_for('anitya_ui.projects_search') }}" role="form" class="form-inline">
                 <div class="form-group">
                   <input id="searchbox" class="form-control input-sm" type="text" name="pattern" placeholder="Project name"/>
                   <button type="submit" class="btn btn-sm btn-default">Search</button>
@@ -211,17 +211,17 @@
 
     <!-- Placed at the end of the document so the pages load faster -->
     <script type="text/javascript"
-        src="{{ url_for('static', filename='js/jquery-1.10.2.min.js')}}"></script>
+        src="{{ url_for('anitya_ui.static', filename='js/jquery-1.10.2.min.js')}}"></script>
     <script type="text/javascript"
-        src="{{ url_for('static', filename='js/jquery-ui.min.1.11.3.js')}}"></script>
+        src="{{ url_for('anitya_ui.static', filename='js/jquery-ui.min.1.11.3.js')}}"></script>
     <script type="text/javascript"
-        src="{{ url_for('static', filename='js/bootstrap.min.js') }}">
+        src="{{ url_for('anitya_ui.static', filename='js/bootstrap.min.js') }}">
     </script>
     <script type="text/javascript"
-        src="{{ url_for('static', filename='js/moment.js') }}">
+        src="{{ url_for('anitya_ui.static', filename='js/moment.js') }}">
     </script>
     <script type="text/javascript"
-        src="{{ url_for('static', filename='bootstrap-datetimepicker.js') }}">
+        src="{{ url_for('anitya_ui.static', filename='bootstrap-datetimepicker.js') }}">
     </script>
     <script type="text/javascript">
       $(function() {

--- a/anitya/templates/project.html
+++ b/anitya/templates/project.html
@@ -220,7 +220,7 @@
     }
     $(btn).hide(); $(btn + "-spinner").show();
     var _id = "{{ project.id }}";
-    var _url = "{{ url_for('api_get_version') }}";
+    var _url = "{{ url_for('anitya_apiv1.api_get_version') }}";
     data = {id: _id};
     if (test) {
         data.test = test;

--- a/anitya/templates/project.html
+++ b/anitya/templates/project.html
@@ -14,14 +14,14 @@
     <div class="panel panel-default">
       <div class="panel-heading">
           <div class="list-group-item-text">
-        <a href="{{ url_for('edit_project', project_id=project.id) }}">
+        <a href="{{ url_for('anitya_ui.edit_project', project_id=project.id) }}">
             <button type="submit" class="btn btn-info btn-sm pull-right inline"
                 id="edit_btn" tabindex=1>
               <span class="glyphicon glyphicon-edit"></span>
               Edit
             </button>
         </a>
-        <a href="{{ url_for('flag_project', project_id=project.id) }}">
+        <a href="{{ url_for('anitya_ui.flag_project', project_id=project.id) }}">
           <button title="Ask for an admin intervention (delete version/project, fix mapping...)."
                  type="submit" class="btn btn-warning btn-sm pull-right inline"
                  id="flag_btn" tabindex=2>
@@ -45,7 +45,7 @@
                     <li property="doap:release" typeof="doap:Version">
                       <span property="doap:revision">{{ version }}</span>
                       {% if is_admin %}
-                      <a href="{{ url_for('delete_project_version',
+                      <a href="{{ url_for('anitya_ui.delete_project_version',
                                     project_id=project.id,
                                     version=version) }}"
                          title="Delete this version">[x]</a>
@@ -66,7 +66,7 @@
                 <span class="glyphicon glyphicon-refresh"></span>
                 Test check
               </button>
-              <img src="{{url_for('static', filename='img/spinner.gif')}}"
+              <img src="{{url_for('anitya_ui.static', filename='img/spinner.gif')}}"
                 id="testcheck-spinner" class="pull-right"
                 style="display: none; padding-top: 12px; padding-right: 25px;"/>
               <button type="submit" class="btn btn-success btn-sm pull-right"
@@ -74,7 +74,7 @@
                 <span class="glyphicon glyphicon-refresh"></span>
                 Full check
               </button>
-              <img src="{{url_for('static', filename='img/spinner.gif')}}"
+              <img src="{{url_for('anitya_ui.static', filename='img/spinner.gif')}}"
                 id="checknow-spinner" class="pull-right"
                 style="display: none; padding-top: 12px; padding-right: 25px;"/>
               {% endif %}
@@ -102,7 +102,7 @@
         <div class="list-group-item">
           <h4 class="list-group-item-heading">Whoah..</h4>
           <div class="list-group-item-text">
-            <a href="{{url_for('delete_project', project_id=project.id) }}">
+            <a href="{{url_for('anitya_ui.delete_project', project_id=project.id) }}">
               <button type="submit" class="btn btn-danger btn-sm pull-right">
                 <span class="glyphicon glyphicon-remove"></span>
                 Delete
@@ -140,7 +140,7 @@
                   <td>{{ package.package_name }}</td>
                   <td>
                     <a href="{{
-                      url_for('edit_project_mapping',
+                      url_for('anitya_ui.edit_project_mapping',
                               project_id=project.id,
                               pkg_id=package.id) }}">
                       <button type="submit" class="btn btn-info btn-sm pull-right">
@@ -152,7 +152,7 @@
                   {% if is_admin %}
                   <td>
                     <a href="{{
-                      url_for('delete_project_mapping',
+                      url_for('anitya_ui.delete_project_mapping',
                               project_id=project.id,
                               distro_name=package.distro,
                               pkg_name=package.package_name) }}">
@@ -174,7 +174,7 @@
         {% if g.auth.logged_in %}
         <div class="list-group-item">
           <div class="list-group-item-text">
-            <p><a href="{{ url_for('map_project', project_id=project.id) }}">
+            <p><a href="{{ url_for('anitya_ui.map_project', project_id=project.id) }}">
             <button type="submit" class="btn btn-info btn-sm pull-right" tabindex=6>
               <span class="glyphicon glyphicon-map-marker"></span>
               Add new distribution mapping
@@ -257,7 +257,7 @@
         return false;
     }
     if (event.which == 69 && !$("#searchbox").is(':focus')) { //e
-      window.location.replace("{{ url_for('edit_project', project_id=project.id) }}");
+      window.location.replace("{{ url_for('anitya_ui.edit_project', project_id=project.id) }}");
     }
     {% if g.auth.logged_in and (not project.versions or is_admin) %}
     if (event.which == 67 && !$("#searchbox").is(':focus')) { //c

--- a/anitya/templates/project_delete.html
+++ b/anitya/templates/project_delete.html
@@ -18,7 +18,7 @@
         </h3>
       </div>
 
-      <form method="POST" action="{{ url_for('delete_project',
+      <form method="POST" action="{{ url_for('anitya_ui.delete_project',
                                              project_id=project.id) }}" >
         <table class="table table-condensed">
           <tr>
@@ -52,13 +52,13 @@
           {% if g.auth.logged_in %}
           {{ form.csrf_token }}
           <p class="pull-right">
-            <a href="{{ url_for('delete_project', project_id=project.id) }}">
+            <a href="{{ url_for('anitya_ui.delete_project', project_id=project.id) }}">
               <button type="submit" name="confirm" value="Yes" class="btn btn-warning">
                 <span class="glyphicon glyphicon-remove"></span>
                 Delete project
               </button>
             </a>
-            <a href="{{ url_for('project', project_id=project.id) }}">
+            <a href="{{ url_for('anitya_ui.project', project_id=project.id) }}">
               <button type="submit" class="btn btn-danger">
                 <span class="glyphicon glyphicon-ban-circle"></span>
                 Cancel

--- a/anitya/templates/project_flag.html
+++ b/anitya/templates/project_flag.html
@@ -8,7 +8,7 @@
 <div class="page-header">
   <h1>Flag project</h1>
 </div>
-<form method="POST" action="{{ url_for('flag_project', project_id=project.id) }}" >
+<form method="POST" action="{{ url_for('anitya_ui.flag_project', project_id=project.id) }}" >
   <div class="row">
     <div class="col-md-12">
       <p> Flag a project for admin review. Use this form to request that the project
@@ -29,7 +29,7 @@
     <span class="glyphicon glyphicon-plus"></span>
     Submit
   </button>
-  <a href="{{ url_for('project', project_id=project.id) }}">
+  <a href="{{ url_for('anitya_ui.project', project_id=project.id) }}">
     <button type="button" class="btn btn-danger" tabindex=3>
       <span class="glyphicon glyphicon-ban-circle"></span>
       Cancel

--- a/anitya/templates/project_new.html
+++ b/anitya/templates/project_new.html
@@ -218,7 +218,7 @@
         var _name = $('#name').val().trim();
         show_hide();
         if (_name) {
-          var _url = "{{ url_for('api_projects') }}?pattern=" + _name;
+          var _url = "{{ url_for('anitya_apiv1.api_projects') }}?pattern=" + _name;
           show_similar_projects(_url, 'name');
         } else {
           $('#info_field').hide();
@@ -227,7 +227,7 @@
     $('#homepage').focusout(function(){
       var _homepage = $('#homepage').val().trim();
       if (_homepage) {
-        var _url = "{{ url_for('api_projects') }}?homepage=" + _homepage;
+        var _url = "{{ url_for('anitya_apiv1.api_projects') }}?homepage=" + _homepage;
         show_similar_projects(_url, 'homepage');
       } else {
         $('#info_field').hide();
@@ -250,7 +250,7 @@
     $('#distro').autocomplete({
         source: function( request, response ) {
             $.getJSON(
-              "{{ url_for('api_distro_names') }}", {
+              "{{ url_for('anitya_apiv1.api_distro_names') }}", {
                 pattern: request.term
               },
               function( data ) {

--- a/anitya/templates/project_new.html
+++ b/anitya/templates/project_new.html
@@ -9,9 +9,9 @@
   <h1>{{ context }} project</h1>
 </div>
 {% if context == 'Add' -%}
-<form method="POST" action="{{ url_for('new_project') }}" >
+<form method="POST" action="{{ url_for('anitya_ui.new_project') }}" >
 {%- elif context == 'Edit' -%}
-<form method="POST" action="{{ url_for('edit_project', project_id=project.id) }}" >
+<form method="POST" action="{{ url_for('anitya_ui.edit_project', project_id=project.id) }}" >
 {%- endif %}
   <div class="row">
     <div class="col-md-6">
@@ -72,9 +72,9 @@
     Submit
   </button>
   {%- if context == 'Add' -%}
-  <a href="{{ url_for('projects') }}">
+  <a href="{{ url_for('anitya_ui.projects') }}">
   {%- elif context == 'Edit' -%}
-  <a href="{{ url_for('project', project_id=project.id) }}">
+  <a href="{{ url_for('anitya_ui.project', project_id=project.id) }}">
   {%- endif -%}
     <button type="button" class="btn btn-danger" tabindex=11>
       <span class="glyphicon glyphicon-ban-circle"></span>
@@ -238,9 +238,9 @@
   $('body').bind('keyup', function(event) {
     if (event.which == 27) { // esc
       {% if context == 'Add' %}
-      window.location.replace("{{ url_for('projects') }}");
+      window.location.replace("{{ url_for('anitya_ui.projects') }}");
       {% elif context == 'Edit' %}
-      window.location.replace("{{ url_for('project', project_id=project.id) }}");
+      window.location.replace("{{ url_for('anitya_ui.project', project_id=project.id) }}");
       {% endif %}
     }
   });
@@ -250,7 +250,7 @@
     $('#distro').autocomplete({
         source: function( request, response ) {
             $.getJSON(
-              "{{ url_for('.api_distro_names') }}", {
+              "{{ url_for('api_distro_names') }}", {
                 pattern: request.term
               },
               function( data ) {

--- a/anitya/templates/projects.html
+++ b/anitya/templates/projects.html
@@ -9,9 +9,9 @@
 </div>
 
 {% if distroname %}
-{% set page_url = url_for('distro', distroname=distroname) %}
+{% set page_url = url_for('anitya_ui.distro', distroname=distroname) %}
 {% else %}
-{% set page_url = url_for('projects') %}
+{% set page_url = url_for('anitya_ui.projects') %}
 {% endif %}
 
 <div class="row show-grid">
@@ -45,9 +45,9 @@
 
   <div class="col-sm-6">
     {% if distroname %}
-    <form action="{{ url_for('distro_projects_search', distroname=distroname)}}" role="form" class="form-inline">
+    <form action="{{ url_for('anitya_ui.distro_projects_search', distroname=distroname)}}" role="form" class="form-inline">
     {% else %}
-    <form action="{{ url_for('projects_search') }}" role="form" class="form-inline">
+    <form action="{{ url_for('anitya_ui.projects_search') }}" role="form" class="form-inline">
     {% endif %}
       <div class="form-group">
         <input type="text" name="pattern" placeholder="Project name" class="form-control input-sm"/>
@@ -69,7 +69,7 @@
         {% for project in projects %}
             <tr>
               <td>
-                <a href="{{ url_for('project', project_id=project.id) }}">
+                <a href="{{ url_for('anitya_ui.project', project_id=project.id) }}">
                 {{project.name}}
                 </a>
               </td>

--- a/anitya/templates/regex_delete.html
+++ b/anitya/templates/regex_delete.html
@@ -9,7 +9,7 @@
 <div class="row">
 
     <form method="POST" action="{{
-        url_for('delete_project_mapping',
+        url_for('anitya_ui.delete_project_mapping',
                 project_id=project.id,
                 distro_name=package.distro,
                 pkg_name=package.package_name) }}" >
@@ -34,7 +34,7 @@
         Delete mapping
       </button>
 
-      <a href="{{ url_for('project', project_id=project.id) }}">
+      <a href="{{ url_for('anitya_ui.project', project_id=project.id) }}">
         <button type="button" class="btn btn-danger">
           <span class="glyphicon glyphicon-ban-circle"></span>
           Cancel

--- a/anitya/templates/search.html
+++ b/anitya/templates/search.html
@@ -14,7 +14,7 @@
     <ul class="pagination pagination-sm">
         <li>
             {% if page > 1%}
-              <a href="{{ url_for('projects_search', page=page-1, pattern=pattern) }}">
+              <a href="{{ url_for('anitya_ui.projects_search', page=page-1, pattern=pattern) }}">
                 «
               </a>
             {% else %}
@@ -26,7 +26,7 @@
         </li>
         <li>
             {% if page < total_page %}
-              <a href="{{ url_for('projects_search', page=page+1, pattern=pattern) }}">
+              <a href="{{ url_for('anitya_ui.projects_search', page=page+1, pattern=pattern) }}">
                 »
               </a>
             {% else %}
@@ -39,10 +39,10 @@
 
   <div class="col-sm-6">
     {% if distroname %}
-    <form action="{{ url_for('distro_projects_search', distroname=distroname)
+    <form action="{{ url_for('anitya_ui.distro_projects_search', distroname=distroname)
      }}" role="form">
     {% else %}
-    <form action="{{ url_for('projects_search') }}" role="form" class="form-inline">
+    <form action="{{ url_for('anitya_ui.projects_search') }}" role="form" class="form-inline">
     {% endif %}
       <div class="form-group">
         <input type="text" name="pattern" placeholder="Project name"
@@ -65,7 +65,7 @@
             {% for project in projects %}
               <tr>
                 <td>
-                  <a href="{{ url_for('project', project_id=project.id) }}">
+                  <a href="{{ url_for('anitya_ui.project', project_id=project.id) }}">
                     {{project.name}}
                   </a>
                 </td>
@@ -93,7 +93,7 @@
     <blockquote>
         Oups this is embarrassing, it seems that no projects are being
         monitored currently.
-        <p><a href="{{ url_for('new_project', name=pattern) }}">Click Here</a> to add this project instead. </p>
+        <p><a href="{{ url_for('anitya_ui.new_project', name=pattern) }}">Click Here</a> to add this project instead. </p>
     </blockquote>
     {% endif %}
     </div>

--- a/anitya/templates/updates.html
+++ b/anitya/templates/updates.html
@@ -25,7 +25,7 @@
         <li>
             {% if page > 1%}
               <a href="{{
-                url_for('projects_updated',
+                url_for('anitya_ui.projects_updated',
                         status=status, name=name, log=log, page=page-1) }}">
                 «
               </a>
@@ -39,7 +39,7 @@
         <li>
             {% if page < total_page %}
               <a href="{{
-                url_for('projects_updated',
+                url_for('anitya_ui.projects_updated',
                         status=status, name=name, log=log, page=page+1) }}">
                 »
               </a>
@@ -52,7 +52,7 @@
   </div>
 
   <div class="col-sm-8">
-    <form action="{{url_for('projects_updated', status=status) }}"
+    <form action="{{url_for('anitya_ui.projects_updated', status=status) }}"
           role="form" action="GET" class="form-inline">
       <div class="form-group">
         <input type="text" name="name" placeholder="Project name" class="form-control input-sm"/>
@@ -75,7 +75,7 @@
         {% for project in projects %}
             <tr>
               <td>
-                <a href="{{ url_for('project', project_id=project.id) }}">
+                <a href="{{ url_for('anitya_ui.project', project_id=project.id) }}">
                 {{project.name}}
                 </a>
               </td>

--- a/anitya/templates/version_delete.html
+++ b/anitya/templates/version_delete.html
@@ -9,7 +9,7 @@
 <div class="row">
 
     <form method="POST" action="{{
-        url_for('delete_project_version',
+        url_for('anitya_ui.delete_project_version',
                 project_id=project.id,
                 version=version) }}" >
       {{ form.csrf_token }}
@@ -33,7 +33,7 @@
         Delete version
       </button>
 
-      <a href="{{ url_for('project', project_id=project.id) }}">
+      <a href="{{ url_for('anitya_ui.project', project_id=project.id) }}">
         <button type="button" class="btn btn-danger">
           <span class="glyphicon glyphicon-ban-circle"></span>
           Cancel

--- a/anitya/tests/lib/backends/test_init.py
+++ b/anitya/tests/lib/backends/test_init.py
@@ -28,6 +28,7 @@ import unittest
 
 import mock
 
+from anitya.config import config
 from anitya.lib import backends
 from anitya.lib.exceptions import AnityaPluginException
 import anitya
@@ -40,7 +41,7 @@ class BaseBackendTests(unittest.TestCase):
         self.headers = {
             'User-Agent': 'Anitya {0} at upstream-monitoring.org'.format(
                 anitya.app.__version__),
-            'From': anitya.app.APP.config.get('ADMIN_EMAIL'),
+            'From': config.get('ADMIN_EMAIL'),
         }
 
     @mock.patch('anitya.lib.backends.http_session')

--- a/anitya/tests/test_app.py
+++ b/anitya/tests/test_app.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of the Anitya project.
+# Copyright (C) 2017  Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+"""Tests for the :mod:`anitya.app` module."""
+
+import logging
+import unittest
+
+from sqlalchemy.exc import UnboundExecutionError
+
+from anitya import app
+from anitya.config import config as anitya_config
+from anitya.lib.model import Session
+
+
+class CreateTests(unittest.TestCase):
+    """Tests for the :func:`anitya.app.create` function."""
+
+    def setUp(self):
+        # Make sure each test starts with a clean session
+        Session.remove()
+        Session.configure(bind=None)
+
+    def test_default_config(self):
+        """Assert when no configuration is provided, :data:`anitya.config.config` is used."""
+        application = app.create()
+        for key in anitya_config:
+            self.assertEqual(anitya_config[key], application.config[key])
+
+    def test_email_config(self):
+        """Assert a SMTPHandler is added to the anitya logger when ``EMAIL_ERRORS=True``."""
+        config = {
+            'DB_URL': 'sqlite://',
+            'EMAIL_ERRORS': True,
+            'SMTP_SERVER': 'smtp.example.com',
+            'ADMIN_EMAIL': 'admin@example.com',
+        }
+        anitya_logger = logging.getLogger('anitya')
+        anitya_logger.handlers = []
+
+        app.create(config)
+
+        self.assertEqual(1, len(anitya_logger.handlers))
+        self.assertEqual('smtp.example.com', anitya_logger.handlers[0].mailhost)
+        self.assertEqual(['admin@example.com'], anitya_logger.handlers[0].toaddrs)
+
+    def test_db_config(self):
+        """Assert creating the application configures the scoped session."""
+        # Assert the scoped session is not bound.
+        self.assertRaises(UnboundExecutionError, Session.get_bind)
+        Session.remove()
+
+        app.create({'DB_URL': 'sqlite://'})
+        self.assertEqual('sqlite://', str(Session().get_bind().url))

--- a/anitya/tests/test_flask.py
+++ b/anitya/tests/test_flask.py
@@ -28,18 +28,17 @@ import unittest
 import mock
 
 from anitya.lib import model
-from anitya.tests.base import DatabaseTestCase, create_distro, create_project
-import anitya
+from anitya.tests.base import AnityaTestCase, DatabaseTestCase, create_distro, create_project
 
 
-class ShutdownSessionTests(unittest.TestCase):
+class ShutdownSessionTests(AnityaTestCase):
     """Tests for the :func:`anitya.app.shutdown_session` function."""
 
     def test_session_removed_post_request(self):
         """Assert that the session is cleaned up after a request."""
         session = model.Session()
         self.assertTrue(session is model.Session())
-        app = anitya.app.APP.test_client()
+        app = self.flask_app.test_client()
         app.get('/about', follow_redirects=False)
         self.assertFalse(session is model.Session())
 
@@ -51,8 +50,8 @@ class NewProjectTests(DatabaseTestCase):
         """Set up the Flask testing environnment"""
         super(NewProjectTests, self).setUp()
 
-        anitya.app.APP.config['TESTING'] = True
-        self.app = anitya.app.APP.test_client()
+        self.flask_app.config['TESTING'] = True
+        self.app = self.flask_app.test_client()
 
     def test_new_project_unauthenticated(self):
         """Assert that authentication is required to create a project"""
@@ -65,7 +64,7 @@ class NewProjectTests(DatabaseTestCase):
 
     def test_new_project(self):
         """Assert an authenticated user can create a new project"""
-        with anitya.app.APP.test_client() as c:
+        with self.flask_app.test_client() as c:
             with c.session_transaction() as sess:
                 sess['openid'] = 'openid_url'
                 sess['fullname'] = 'Pierre-Yves C.'
@@ -100,7 +99,7 @@ class NewProjectTests(DatabaseTestCase):
 
     def test_new_project_no_csrf(self):
         """Assert a missing CSRF token results in an HTTP 400"""
-        with anitya.app.APP.test_client() as c:
+        with self.flask_app.test_client() as c:
             with c.session_transaction() as sess:
                 sess['openid'] = 'openid_url'
                 sess['fullname'] = 'Pierre-Yves C.'
@@ -125,7 +124,7 @@ class NewProjectTests(DatabaseTestCase):
 
     def test_new_project_duplicate(self):
         """Assert duplicate projects result in a HTTP 409"""
-        with anitya.app.APP.test_client() as c:
+        with self.flask_app.test_client() as c:
             with c.session_transaction() as sess:
                 sess['openid'] = 'openid_url'
                 sess['fullname'] = 'Pierre-Yves C.'
@@ -165,7 +164,7 @@ class NewProjectTests(DatabaseTestCase):
 
     def test_new_project_invalid_homepage(self):
         """Assert a HTTP 400 results in projects with invalid homepages"""
-        with anitya.app.APP.test_client() as c:
+        with self.flask_app.test_client() as c:
             with c.session_transaction() as sess:
                 sess['openid'] = 'openid_url'
                 sess['fullname'] = 'Pierre-Yves C.'
@@ -192,7 +191,7 @@ class NewProjectTests(DatabaseTestCase):
     @mock.patch('anitya.lib.utilities.check_project_release')
     def test_new_project_with_check_release(self, patched):
         output = self.app.get('/project/new', follow_redirects=True)
-        with anitya.app.APP.test_client() as c:
+        with self.flask_app.test_client() as c:
             with c.session_transaction() as sess:
                 sess['openid'] = 'openid_url'
                 sess['fullname'] = 'Pierre-Yves C.'
@@ -235,8 +234,8 @@ class FlaskTest(DatabaseTestCase):
         """ Set up the environnment, ran before every tests. """
         super(FlaskTest, self).setUp()
 
-        anitya.app.APP.config['TESTING'] = True
-        self.app = anitya.app.APP.test_client()
+        self.flask_app.config['TESTING'] = True
+        self.app = self.flask_app.test_client()
 
     def test_index(self):
         """ Test the index function. """
@@ -451,7 +450,7 @@ class FlaskTest(DatabaseTestCase):
         self.assertEqual(projects[2].name, 'subsurface')
         self.assertEqual(projects[2].id, 2)
 
-        with anitya.app.APP.test_client() as c:
+        with self.flask_app.test_client() as c:
             with c.session_transaction() as sess:
                 sess['openid'] = 'openid_url'
                 sess['fullname'] = 'Pierre-Yves C.'
@@ -567,7 +566,7 @@ class FlaskTest(DatabaseTestCase):
         self.assertEqual(projects[2].id, 2)
         self.assertEqual(len(projects[2].packages), 0)
 
-        with anitya.app.APP.test_client() as c:
+        with self.flask_app.test_client() as c:
             with c.session_transaction() as sess:
                 sess['openid'] = 'openid_url'
                 sess['fullname'] = 'Pierre-Yves C.'
@@ -663,7 +662,7 @@ class FlaskTest(DatabaseTestCase):
         self.assertEqual(projects[2].id, 2)
         self.assertEqual(len(projects[2].packages), 0)
 
-        with anitya.app.APP.test_client() as c:
+        with self.flask_app.test_client() as c:
             with c.session_transaction() as sess:
                 sess['openid'] = 'openid_url'
                 sess['fullname'] = 'Pierre-Yves C.'

--- a/anitya/tests/test_flask_admin.py
+++ b/anitya/tests/test_flask_admin.py
@@ -26,7 +26,6 @@ anitya tests for the flask application.
 import datetime
 import unittest
 
-import anitya
 from anitya.lib import model
 from anitya.tests.base import (DatabaseTestCase, create_distro, create_project,
                                create_package, create_flagged_project)
@@ -39,9 +38,9 @@ class FlaskAdminTest(DatabaseTestCase):
         """ Set up the environnment, ran before every tests. """
         super(FlaskAdminTest, self).setUp()
 
-        anitya.app.APP.config['TESTING'] = True
-        anitya.app.APP.config['ANITYA_WEB_ADMINS'] = ['http://pingou.id.fedoraproject.org/']
-        self.app = anitya.app.APP.test_client()
+        self.flask_app.config['TESTING'] = True
+        self.flask_app.config['ANITYA_WEB_ADMINS'] = ['http://pingou.id.fedoraproject.org/']
+        self.app = self.flask_app.test_client()
 
     def test_add_distro(self):
         """ Test the add_distro function. """
@@ -52,7 +51,7 @@ class FlaskAdminTest(DatabaseTestCase):
             b'<li class="list-group-item list-group-item-warning">'
             b'Login required</li></ul>' in output.data)
 
-        with anitya.app.APP.test_client() as c:
+        with self.flask_app.test_client() as c:
             with c.session_transaction() as sess:
                 sess['openid'] = 'openid_url'
                 sess['fullname'] = 'Pierre-Yves C.'
@@ -62,7 +61,7 @@ class FlaskAdminTest(DatabaseTestCase):
             output = c.get('/distro/add', follow_redirects=True)
             self.assertEqual(output.status_code, 401)
 
-        with anitya.app.APP.test_client() as c:
+        with self.flask_app.test_client() as c:
             with c.session_transaction() as sess:
                 sess['openid'] = 'http://pingou.id.fedoraproject.org/'
                 sess['fullname'] = 'Pierre-Yves C.'
@@ -125,7 +124,7 @@ class FlaskAdminTest(DatabaseTestCase):
             b'<li class="list-group-item list-group-item-warning">'
             b'Login required</li></ul>' in output.data)
 
-        with anitya.app.APP.test_client() as c:
+        with self.flask_app.test_client() as c:
             with c.session_transaction() as sess:
                 sess['openid'] = 'openid_url'
                 sess['fullname'] = 'Pierre-Yves C.'
@@ -138,7 +137,7 @@ class FlaskAdminTest(DatabaseTestCase):
             output = c.get('/distro/Debian/edit', follow_redirects=True)
             self.assertEqual(output.status_code, 401)
 
-        with anitya.app.APP.test_client() as c:
+        with self.flask_app.test_client() as c:
             with c.session_transaction() as sess:
                 sess['openid'] = 'http://pingou.id.fedoraproject.org/'
                 sess['fullname'] = 'Pierre-Yves C.'
@@ -191,7 +190,7 @@ class FlaskAdminTest(DatabaseTestCase):
             b'<li class="list-group-item list-group-item-warning">'
             b'Login required</li></ul>' in output.data)
 
-        with anitya.app.APP.test_client() as c:
+        with self.flask_app.test_client() as c:
             with c.session_transaction() as sess:
                 sess['openid'] = 'openid_url'
                 sess['fullname'] = 'Pierre-Yves C.'
@@ -211,7 +210,7 @@ class FlaskAdminTest(DatabaseTestCase):
         self.assertEqual(output.data.count(b'<a href="/project/2'), 1)
         self.assertEqual(output.data.count(b'<a href="/project/3'), 1)
 
-        with anitya.app.APP.test_client() as c:
+        with self.flask_app.test_client() as c:
             with c.session_transaction() as sess:
                 sess['openid'] = 'http://pingou.id.fedoraproject.org/'
                 sess['fullname'] = 'Pierre-Yves C.'
@@ -280,7 +279,7 @@ class FlaskAdminTest(DatabaseTestCase):
             b'<li class="list-group-item list-group-item-warning">'
             b'Login required</li></ul>' in output.data)
 
-        with anitya.app.APP.test_client() as c:
+        with self.flask_app.test_client() as c:
             with c.session_transaction() as sess:
                 sess['openid'] = 'openid_url'
                 sess['fullname'] = 'Pierre-Yves C.'
@@ -308,7 +307,7 @@ class FlaskAdminTest(DatabaseTestCase):
         self.assertTrue(b'<h1>Project: geany</h1>' in output.data)
         self.assertTrue(b'<td>Fedora</td>' in output.data)
 
-        with anitya.app.APP.test_client() as c:
+        with self.flask_app.test_client() as c:
             with c.session_transaction() as sess:
                 sess['openid'] = 'http://pingou.id.fedoraproject.org/'
                 sess['fullname'] = 'Pierre-Yves C.'
@@ -374,7 +373,7 @@ class FlaskAdminTest(DatabaseTestCase):
             b'<li class="list-group-item list-group-item-warning">'
             b'Login required</li></ul>' in output.data)
 
-        with anitya.app.APP.test_client() as c:
+        with self.flask_app.test_client() as c:
             with c.session_transaction() as sess:
                 sess['openid'] = 'openid_url'
                 sess['fullname'] = 'Pierre-Yves C.'
@@ -384,7 +383,7 @@ class FlaskAdminTest(DatabaseTestCase):
             output = c.get('/logs', follow_redirects=True)
             self.assertEqual(output.status_code, 200)
 
-        with anitya.app.APP.test_client() as c:
+        with self.flask_app.test_client() as c:
             with c.session_transaction() as sess:
                 sess['openid'] = 'http://pingou.id.fedoraproject.org/'
                 sess['fullname'] = 'Pierre-Yves C.'
@@ -425,7 +424,7 @@ class FlaskAdminTest(DatabaseTestCase):
             b'<li class="list-group-item list-group-item-warning">'
             b'Login required</li></ul>' in output.data)
 
-        with anitya.app.APP.test_client() as c:
+        with self.flask_app.test_client() as c:
             with c.session_transaction() as sess:
                 sess['openid'] = 'openid_url'
                 sess['fullname'] = 'Pierre-Yves C.'
@@ -435,7 +434,7 @@ class FlaskAdminTest(DatabaseTestCase):
             output = c.get('/flags', follow_redirects=True)
             self.assertEqual(output.status_code, 401)
 
-        with anitya.app.APP.test_client() as c:
+        with self.flask_app.test_client() as c:
             with c.session_transaction() as sess:
                 sess['openid'] = 'http://pingou.id.fedoraproject.org/'
                 sess['fullname'] = 'Pierre-Yves C.'
@@ -478,7 +477,7 @@ class FlaskAdminTest(DatabaseTestCase):
         self.assertEqual(len(project.flags), 1)
         self.assertEqual(project.flags[0].state, 'open')
 
-        with anitya.app.APP.test_client() as c:
+        with self.flask_app.test_client() as c:
             with c.session_transaction() as sess:
                 sess['openid'] = 'some_invalid_openid_url'
                 sess['fullname'] = 'Pierre-Yves C.'
@@ -498,7 +497,7 @@ class FlaskAdminTest(DatabaseTestCase):
 
         self.assertEqual(flag.state, 'open')
 
-        with anitya.app.APP.test_client() as c:
+        with self.flask_app.test_client() as c:
             with c.session_transaction() as sess:
                 sess['openid'] = 'http://pingou.id.fedoraproject.org/'
                 sess['fullname'] = 'Pierre-Yves C.'
@@ -533,7 +532,7 @@ class FlaskAdminTest(DatabaseTestCase):
         self.assertEqual(len(project.flags), 1)
         self.assertEqual(project.flags[0].state, 'closed')
 
-        with anitya.app.APP.test_client() as c:
+        with self.flask_app.test_client() as c:
             with c.session_transaction() as sess:
                 sess['openid'] = 'http://pingou.id.fedoraproject.org/'
                 sess['fullname'] = 'Pierre-Yves C.'
@@ -561,7 +560,7 @@ class FlaskAdminTest(DatabaseTestCase):
         self.assertEqual(len(project.flags), 1)
         self.assertEqual(project.flags[0].state, 'open')
 
-        with anitya.app.APP.test_client() as c:
+        with self.flask_app.test_client() as c:
             with c.session_transaction() as sess:
                 sess['openid'] = 'http://pingou.id.fedoraproject.org/'
                 sess['fullname'] = 'Pierre-Yves C.'

--- a/anitya/tests/test_flask_api.py
+++ b/anitya/tests/test_flask_api.py
@@ -26,7 +26,6 @@ anitya tests for the flask API.
 import json
 import unittest
 
-import anitya
 import anitya.lib.model as model
 from anitya.lib.backends import REGEX
 from anitya.tests.base import (DatabaseTestCase, create_distro, create_project,
@@ -45,8 +44,8 @@ class AnityaWebAPItests(DatabaseTestCase):
         """ Set up the environnment, ran before every tests. """
         super(AnityaWebAPItests, self).setUp()
 
-        anitya.app.APP.config['TESTING'] = True
-        self.app = anitya.app.APP.test_client()
+        self.flask_app.config['TESTING'] = True
+        self.app = self.flask_app.test_client()
 
     def test_api_docs_no_slash(self):
         """Assert the legacy /api endpoint redirects to docs."""

--- a/anitya/tests/test_flask_api_v2.py
+++ b/anitya/tests/test_flask_api_v2.py
@@ -49,7 +49,7 @@ class _APItestsMixin(object):
         super(_APItestsMixin, self).setUp()
 
         anitya.app.APP.config['TESTING'] = True
-        self.oidc = anitya.app.APP.oidc
+        self.oidc = anitya.authentication.oidc
         self.app = anitya.app.APP.test_client()
 
 
@@ -249,7 +249,7 @@ class AuthenticationRequiredTests(_APItestsMixin, DatabaseTestCase):
     def _check_authentication_failure_response(self, output):
         data = _read_json(output)
         # Check we get the expected error details
-        if self.oidc is None:
+        if not hasattr(self.oidc, 'flow'):
             exp = {
                 'error': 'oidc_not_configured',
                 'error_description': 'OpenID Connect is not configured on the server'
@@ -335,7 +335,7 @@ class MockAuthenticationTests(_AuthenticatedAPItestsMixin, DatabaseTestCase):
         mock_auth.start()
         self.addCleanup(mock_auth.stop)
 
-        # Replace anitya.app.APP.oidc.user_getfield
+        # Replace anitya.authentication.oidc.user_getfield
         mock_user_data = {
             "email": 'noreply@fedoraproject.org',
         }
@@ -352,7 +352,7 @@ class MockAuthenticationTests(_AuthenticatedAPItestsMixin, DatabaseTestCase):
                 except KeyError:
                     msg = "No mock user data for field {}"
                     raise ValueError(msg.format(fieldname))
-        mock_oidc = mock.patch('anitya.app.APP.oidc', MockOIDC())
+        mock_oidc = mock.patch('anitya.authentication.oidc', MockOIDC())
         mock_oidc.start()
         self.addCleanup(mock_oidc.stop)
 

--- a/anitya/tests/test_flask_api_v2.py
+++ b/anitya/tests/test_flask_api_v2.py
@@ -48,9 +48,9 @@ class _APItestsMixin(object):
     def setUp(self):
         super(_APItestsMixin, self).setUp()
 
-        anitya.app.APP.config['TESTING'] = True
+        self.flask_app.config['TESTING'] = True
         self.oidc = anitya.authentication.oidc
-        self.app = anitya.app.APP.test_client()
+        self.app = self.flask_app.test_client()
 
 
 class AnonymousAccessTests(_APItestsMixin, DatabaseTestCase):

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from math import ceil
+import functools
 
 import flask
 import six.moves.urllib.parse as urlparse
@@ -10,8 +11,26 @@ import anitya.lib
 import anitya.lib.exceptions
 import anitya.lib.model
 
-from anitya.app import APP, SESSION, login_required
 from anitya.lib import utilities
+from anitya.lib.model import Session as SESSION
+
+
+ui_blueprint = flask.Blueprint(
+    'anitya_ui', __name__, static_folder='static', template_folder='templates')
+
+
+def login_required(function):
+    ''' Flask decorator to retrict access to logged-in users. '''
+    @functools.wraps(function)
+    def decorated_function(*args, **kwargs):
+        """ Decorated function, actually does the work. """
+        if not flask.g.auth.logged_in:
+            flask.flash('Login required', 'errors')
+            return flask.redirect(
+                flask.url_for('anitya_ui.login', next=flask.request.url))
+
+        return function(*args, **kwargs)
+    return decorated_function
 
 
 def get_extended_pattern(pattern):
@@ -37,7 +56,7 @@ def is_safe_url(target):
         ref_url.netloc == test_url.netloc
 
 
-@APP.route('/')
+@ui_blueprint.route('/')
 def index():
     total = anitya.lib.model.Project.all(SESSION, count=True)
     return flask.render_template(
@@ -47,101 +66,98 @@ def index():
     )
 
 
-@APP.route('/about')
+@ui_blueprint.route('/about')
 def about():
     """A backwards-compatibility route for old documentation links"""
-    new_path = flask.url_for('static', filename='docs/index.html')
+    new_path = flask.url_for('anitya_ui.static', filename='docs/index.html')
     return flask.redirect(new_path)
 
 
-@APP.route('/fedmsg')
+@ui_blueprint.route('/fedmsg')
 def fedmsg():
     """A backwards-compatibility route for old documentation links"""
-    new_path = flask.url_for('static', filename='docs/user-guide.html')
+    new_path = flask.url_for('anitya_ui.static', filename='docs/user-guide.html')
     return flask.redirect(new_path)
 
 
-@APP.route('/login/', methods=('GET', 'POST'))
-@APP.route('/login', methods=('GET', 'POST'))
-@APP.oid.loginhandler
+@ui_blueprint.route('/login/', methods=('GET', 'POST'))
+@ui_blueprint.route('/login', methods=('GET', 'POST'))
 def login():
     ''' Handle the login when no OpenID server have been selected in the
     list.
     '''
-    next_url = flask.url_for('index')
+    next_url = flask.url_for('anitya_ui.index')
     if 'next' in flask.request.args:
         if is_safe_url(flask.request.args['next']):
             next_url = flask.request.args['next']
 
-    APP.oid.store_factory = lambda: None
+    flask.current_app.oid.store_factory = lambda: None
     if flask.g.auth.logged_in:
         return flask.redirect(next_url)
 
     openid_server = flask.request.form.get('openid', None)
     if openid_server:
-        return APP.oid.try_login(
+        return flask.current_app.oid.try_login(
             openid_server, ask_for=['email', 'fullname', 'nickname'])
 
     return flask.render_template(
         'login.html',
-        next=APP.oid.get_next_url(), error=APP.oid.fetch_error())
+        next=flask.current_app.oid.get_next_url(),
+        error=flask.current_app.oid.fetch_error())
 
 
-@APP.route('/login/fedora/', methods=('GET', 'POST'))
-@APP.route('/login/fedora', methods=('GET', 'POST'))
-@APP.oid.loginhandler
+@ui_blueprint.route('/login/fedora/', methods=('GET', 'POST'))
+@ui_blueprint.route('/login/fedora', methods=('GET', 'POST'))
 def fedora_login():
     ''' Handles login against the Fedora OpenID server. '''
-    error = APP.oid.fetch_error()
+    error = flask.current_app.oid.fetch_error()
     if error:
         flask.flash('Error during login: %s' % error, 'errors')
-        return flask.redirect(flask.url_for('index'))
+        return flask.redirect(flask.url_for('anitya_ui.index'))
 
-    APP.oid.store_factory = lambda: None
-    return APP.oid.try_login(
-        APP.config['ANITYA_WEB_FEDORA_OPENID'],
+    flask.current_app.oid.store_factory = lambda: None
+    return flask.current_app.oid.try_login(
+        flask.current_app.config['ANITYA_WEB_FEDORA_OPENID'],
         ask_for=['email', 'nickname'],
         ask_for_optional=['fullname'])
 
 
-@APP.route('/login/google/', methods=('GET', 'POST'))
-@APP.route('/login/google', methods=('GET', 'POST'))
-@APP.oid.loginhandler
+@ui_blueprint.route('/login/google/', methods=('GET', 'POST'))
+@ui_blueprint.route('/login/google', methods=('GET', 'POST'))
 def google_login():
     ''' Handles login via the Google OpenID. '''
-    error = APP.oid.fetch_error()
+    error = flask.current_app.oid.fetch_error()
     if error:
         flask.flash('Error during login: %s' % error, 'errors')
-        return flask.redirect(flask.url_for('index'))
+        return flask.redirect(flask.url_for('anitya_ui.index'))
 
-    APP.oid.store_factory = lambda: None
-    return APP.oid.try_login(
+    flask.current_app.oid.store_factory = lambda: None
+    return flask.current_app.oid.try_login(
         "https://www.google.com/accounts/o8/id",
         ask_for=['email', 'fullname'])
 
 
-@APP.route('/login/yahoo/', methods=('GET', 'POST'))
-@APP.route('/login/yahoo', methods=('GET', 'POST'))
-@APP.oid.loginhandler
+@ui_blueprint.route('/login/yahoo/', methods=('GET', 'POST'))
+@ui_blueprint.route('/login/yahoo', methods=('GET', 'POST'))
 def yahoo_login():
     ''' Handles login via the Yahoo OpenID. '''
-    error = APP.oid.fetch_error()
+    error = flask.current_app.oid.fetch_error()
     if error:
         flask.flash('Error during login: %s' % error, 'errors')
-        return flask.redirect(flask.url_for('index'))
+        return flask.redirect(flask.url_for('anitya_ui.index'))
 
-    APP.oid.store_factory = lambda: None
-    return APP.oid.try_login(
+    flask.current_app.oid.store_factory = lambda: None
+    return flask.current_app.oid.try_login(
         "https://me.yahoo.com/",
         ask_for=['email', 'fullname'])
 
 
-@APP.route('/logout/')
-@APP.route('/logout')
+@ui_blueprint.route('/logout/')
+@ui_blueprint.route('/logout')
 def logout():
     ''' Logout the user. '''
     flask.session.pop('openid')
-    next_url = flask.url_for('index')
+    next_url = flask.url_for('anitya_ui.index')
     if 'next' in flask.request.args:
         if is_safe_url(flask.request.args['next']):
             next_url = flask.request.args['next']
@@ -149,8 +165,8 @@ def logout():
     return flask.redirect(next_url)
 
 
-@APP.route('/project/<int:project_id>')
-@APP.route('/project/<int:project_id>/')
+@ui_blueprint.route('/project/<int:project_id>')
+@ui_blueprint.route('/project/<int:project_id>/')
 def project(project_id):
 
     project = anitya.lib.model.Project.by_id(SESSION, project_id)
@@ -165,8 +181,8 @@ def project(project_id):
     )
 
 
-@APP.route('/project/<project_name>')
-@APP.route('/project/<project_name>/')
+@ui_blueprint.route('/project/<project_name>')
+@ui_blueprint.route('/project/<project_name>/')
 def project_name(project_name):
 
     page = flask.request.args.get('page', 1)
@@ -196,8 +212,8 @@ def project_name(project_name):
         page=page)
 
 
-@APP.route('/projects')
-@APP.route('/projects/')
+@ui_blueprint.route('/projects')
+@ui_blueprint.route('/projects/')
 def projects():
 
     page = flask.request.args.get('page', 1)
@@ -221,9 +237,9 @@ def projects():
         page=page)
 
 
-@APP.route('/projects/updates')
-@APP.route('/projects/updates/')
-@APP.route('/projects/updates/<status>')
+@ui_blueprint.route('/projects/updates')
+@ui_blueprint.route('/projects/updates/')
+@ui_blueprint.route('/projects/updates/<status>')
 def projects_updated(status='updated'):
 
     page = flask.request.args.get('page', 1)
@@ -267,8 +283,8 @@ def projects_updated(status='updated'):
     )
 
 
-@APP.route('/distros')
-@APP.route('/distros/')
+@ui_blueprint.route('/distros')
+@ui_blueprint.route('/distros/')
 def distros():
 
     page = flask.request.args.get('page', 1)
@@ -292,8 +308,8 @@ def distros():
         page=page)
 
 
-@APP.route('/distro/<distroname>')
-@APP.route('/distro/<distroname>/')
+@ui_blueprint.route('/distro/<distroname>')
+@ui_blueprint.route('/distro/<distroname>/')
 def distro(distroname):
 
     page = flask.request.args.get('page', 1)
@@ -320,9 +336,9 @@ def distro(distroname):
         page=page)
 
 
-@APP.route('/projects/search')
-@APP.route('/projects/search/')
-@APP.route('/projects/search/<pattern>')
+@ui_blueprint.route('/projects/search')
+@ui_blueprint.route('/projects/search/')
+@ui_blueprint.route('/projects/search/<pattern>')
 def projects_search(pattern=None):
 
     pattern = flask.request.args.get('pattern', pattern) or '*'
@@ -355,7 +371,7 @@ def projects_search(pattern=None):
         flask.flash(
             'Only one result matching with an exact match, redirecting')
         return flask.redirect(
-            flask.url_for('project', project_id=projects[0].id))
+            flask.url_for('anitya_ui.project', project_id=projects[0].id))
 
     total_page = int(ceil(projects_count / float(50)))
 
@@ -369,9 +385,9 @@ def projects_search(pattern=None):
         page=page)
 
 
-@APP.route('/distro/<distroname>/search')
-@APP.route('/distro/<distroname>/search/')
-@APP.route('/distro/<distroname>/search/<pattern>')
+@ui_blueprint.route('/distro/<distroname>/search')
+@ui_blueprint.route('/distro/<distroname>/search/')
+@ui_blueprint.route('/distro/<distroname>/search/<pattern>')
 def distro_projects_search(distroname, pattern=None):
 
     pattern = flask.request.args.get('pattern', pattern) or '*'
@@ -407,7 +423,7 @@ def distro_projects_search(distroname, pattern=None):
         flask.flash(
             'Only one result matching with an exact match, redirecting')
         return flask.redirect(
-            flask.url_for('project', project_id=projects[0].id))
+            flask.url_for('anitya_ui.project', project_id=projects[0].id))
 
     total_page = int(ceil(projects_count / float(50)))
 
@@ -422,7 +438,7 @@ def distro_projects_search(distroname, pattern=None):
         page=page)
 
 
-@APP.route('/project/new', methods=['GET', 'POST'])
+@ui_blueprint.route('/project/new', methods=['GET', 'POST'])
 @login_required
 def new_project():
     """
@@ -490,7 +506,7 @@ def new_project():
 
         if project:
             return flask.redirect(
-                flask.url_for('project', project_id=project.id)
+                flask.url_for('anitya_ui.project', project_id=project.id)
             )
 
     return flask.render_template(
@@ -502,7 +518,7 @@ def new_project():
     ), 400
 
 
-@APP.route('/project/<project_id>/edit', methods=['GET', 'POST'])
+@ui_blueprint.route('/project/<project_id>/edit', methods=['GET', 'POST'])
 @login_required
 def edit_project(project_id):
 
@@ -538,7 +554,7 @@ def edit_project(project_id):
             flask.flash(str(err), 'errors')
 
         return flask.redirect(
-            flask.url_for('project', project_id=project_id)
+            flask.url_for('anitya_ui.project', project_id=project_id)
         )
 
     return flask.render_template(
@@ -551,7 +567,7 @@ def edit_project(project_id):
     )
 
 
-@APP.route('/project/<project_id>/flag', methods=['GET', 'POST'])
+@ui_blueprint.route('/project/<project_id>/flag', methods=['GET', 'POST'])
 @login_required
 def flag_project(project_id):
 
@@ -576,7 +592,7 @@ def flag_project(project_id):
             flask.flash(str(err), 'errors')
 
         return flask.redirect(
-            flask.url_for('project', project_id=project.id)
+            flask.url_for('anitya_ui.project', project_id=project.id)
         )
 
     return flask.render_template(
@@ -588,7 +604,7 @@ def flag_project(project_id):
     )
 
 
-@APP.route('/project/<project_id>/map', methods=['GET', 'POST'])
+@ui_blueprint.route('/project/<project_id>/map', methods=['GET', 'POST'])
 @login_required
 def map_project(project_id):
 
@@ -615,13 +631,13 @@ def map_project(project_id):
             SESSION.commit()
             flask.flash('Mapping added')
         except anitya.lib.exceptions.AnityaInvalidMappingException as err:
-            err.link = flask.url_for('project', project_id=err.project_id)
+            err.link = flask.url_for('anitya_ui.project', project_id=err.project_id)
             flask.flash(err.message, 'error')
         except anitya.lib.exceptions.AnityaException as err:
             flask.flash(str(err), 'error')
 
         return flask.redirect(
-            flask.url_for('project', project_id=project.id)
+            flask.url_for('anitya_ui.project', project_id=project.id)
         )
 
     return flask.render_template(
@@ -632,7 +648,7 @@ def map_project(project_id):
     )
 
 
-@APP.route('/project/<project_id>/map/<pkg_id>', methods=['GET', 'POST'])
+@ui_blueprint.route('/project/<project_id>/map/<pkg_id>', methods=['GET', 'POST'])
 @login_required
 def edit_project_mapping(project_id, pkg_id):
 
@@ -662,13 +678,13 @@ def edit_project_mapping(project_id, pkg_id):
             SESSION.commit()
             flask.flash('Mapping edited')
         except anitya.lib.exceptions.AnityaInvalidMappingException as err:
-            err.link = flask.url_for('project', project_id=err.project_id)
+            err.link = flask.url_for('anitya_ui.project', project_id=err.project_id)
             flask.flash(err.message, 'error')
         except anitya.lib.exceptions.AnityaException as err:
             flask.flash(str(err), 'error')
 
         return flask.redirect(
-            flask.url_for('project', project_id=project_id))
+            flask.url_for('anitya_ui.project', project_id=project_id))
 
     return flask.render_template(
         'mapping.html',

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -693,3 +693,29 @@ def edit_project_mapping(project_id, pkg_id):
         package=package,
         form=form,
     )
+
+
+def format_examples(examples):
+    ''' Return the plugins examples as HTML links. '''
+    output = ''
+    if examples:
+        for cnt, example in enumerate(examples):
+            if cnt > 0:
+                output += " <br /> "
+            output += "<a href='%(url)s'>%(url)s</a> " % ({'url': example})
+
+    return output
+
+
+def context_class(category):
+    ''' Return bootstrap context class for a given category. '''
+    values = {
+        'message': 'default',
+        'error': 'danger',
+        'info': 'info',
+    }
+    return values.get(category, 'warning')
+
+
+ui_blueprint.add_app_template_filter(format_examples, name='format_examples')
+ui_blueprint.add_app_template_filter(context_class, name='context_class')

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -11,6 +11,7 @@ import anitya.lib
 import anitya.lib.exceptions
 import anitya.lib.model
 
+from . import authentication
 from anitya.lib import utilities
 from anitya.lib.model import Session as SESSION
 
@@ -82,6 +83,7 @@ def fedmsg():
 
 @ui_blueprint.route('/login/', methods=('GET', 'POST'))
 @ui_blueprint.route('/login', methods=('GET', 'POST'))
+@authentication.oid.loginhandler
 def login():
     ''' Handle the login when no OpenID server have been selected in the
     list.
@@ -91,32 +93,33 @@ def login():
         if is_safe_url(flask.request.args['next']):
             next_url = flask.request.args['next']
 
-    flask.current_app.oid.store_factory = lambda: None
+    authentication.oid.store_factory = lambda: None
     if flask.g.auth.logged_in:
         return flask.redirect(next_url)
 
     openid_server = flask.request.form.get('openid', None)
     if openid_server:
-        return flask.current_app.oid.try_login(
+        return authentication.oid.try_login(
             openid_server, ask_for=['email', 'fullname', 'nickname'])
 
     return flask.render_template(
         'login.html',
-        next=flask.current_app.oid.get_next_url(),
-        error=flask.current_app.oid.fetch_error())
+        next=authentication.oid.get_next_url(),
+        error=authentication.oid.fetch_error())
 
 
 @ui_blueprint.route('/login/fedora/', methods=('GET', 'POST'))
 @ui_blueprint.route('/login/fedora', methods=('GET', 'POST'))
+@authentication.oid.loginhandler
 def fedora_login():
     ''' Handles login against the Fedora OpenID server. '''
-    error = flask.current_app.oid.fetch_error()
+    error = authentication.oid.fetch_error()
     if error:
         flask.flash('Error during login: %s' % error, 'errors')
         return flask.redirect(flask.url_for('anitya_ui.index'))
 
-    flask.current_app.oid.store_factory = lambda: None
-    return flask.current_app.oid.try_login(
+    authentication.oid.store_factory = lambda: None
+    return authentication.oid.try_login(
         flask.current_app.config['ANITYA_WEB_FEDORA_OPENID'],
         ask_for=['email', 'nickname'],
         ask_for_optional=['fullname'])
@@ -124,30 +127,32 @@ def fedora_login():
 
 @ui_blueprint.route('/login/google/', methods=('GET', 'POST'))
 @ui_blueprint.route('/login/google', methods=('GET', 'POST'))
+@authentication.oid.loginhandler
 def google_login():
     ''' Handles login via the Google OpenID. '''
-    error = flask.current_app.oid.fetch_error()
+    error = authentication.oid.fetch_error()
     if error:
         flask.flash('Error during login: %s' % error, 'errors')
         return flask.redirect(flask.url_for('anitya_ui.index'))
 
-    flask.current_app.oid.store_factory = lambda: None
-    return flask.current_app.oid.try_login(
+    authentication.oid.store_factory = lambda: None
+    return authentication.oid.try_login(
         "https://www.google.com/accounts/o8/id",
         ask_for=['email', 'fullname'])
 
 
 @ui_blueprint.route('/login/yahoo/', methods=('GET', 'POST'))
 @ui_blueprint.route('/login/yahoo', methods=('GET', 'POST'))
+@authentication.oid.loginhandler
 def yahoo_login():
     ''' Handles login via the Yahoo OpenID. '''
-    error = flask.current_app.oid.fetch_error()
+    error = authentication.oid.fetch_error()
     if error:
         flask.flash('Error during login: %s' % error, 'errors')
         return flask.redirect(flask.url_for('anitya_ui.index'))
 
-    flask.current_app.oid.store_factory = lambda: None
-    return flask.current_app.oid.try_login(
+    authentication.oid.store_factory = lambda: None
+    return authentication.oid.try_login(
         "https://me.yahoo.com/",
         ask_for=['email', 'fullname'])
 

--- a/ansible/roles/anitya-dev/files/anitya.service
+++ b/ansible/roles/anitya-dev/files/anitya.service
@@ -4,7 +4,7 @@ After=network.target
 Documentation=https://github.com/fedora-infra/anitya/
 
 [Service]
-Environment="FLASK_APP=/home/vagrant/devel/anitya/app.py"
+Environment="FLASK_APP=/home/vagrant/devel/runserver.py"
 Environment="FLASK_DEBUG=1"
 Environment="ANITYA_WEB_CONFIG=/home/vagrant/anitya.toml"
 ExecStart=/home/vagrant/.virtualenvs/anitya/bin/flask run --host 0.0.0.0 --port 5000

--- a/createdb.py
+++ b/createdb.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from anitya.app import APP
+from anitya.config import config
 from anitya.lib import utilities
 
 utilities.init(
-    APP.config['DB_URL'],
+    config['DB_URL'],
     None,
     debug=True,
     create=True)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,7 +9,7 @@ Anitya provides several APIs for users.
 HTTP API v2
 ===========
 
-.. autoflask:: anitya.app:APP
+.. autoflask:: anitya.app:create()
    :undoc-static:
    :modules: anitya.api_v2
    :order: path
@@ -18,7 +18,7 @@ HTTP API v2
 HTTP API v1
 ===========
 
-.. autoflask:: anitya.app:APP
+.. autoflask:: anitya.app:create()
    :undoc-static:
    :modules: anitya.api
    :order: path

--- a/files/anitya.wsgi
+++ b/files/anitya.wsgi
@@ -18,5 +18,6 @@
 
 
 ## The most import line to make the wsgi working
-#from anitya.app import APP as application
+#from anitya.app import create
+#application = create()
 #application.debug = True

--- a/files/anitya_cron.py
+++ b/files/anitya_cron.py
@@ -12,9 +12,9 @@ import logging
 # with a global shared requests session.
 import multiprocessing.dummy as multiprocessing
 
-from anitya.lib import utilities
+from anitya.config import config
+from anitya.lib import utilities, model
 import anitya
-import anitya.app
 import anitya.lib.exceptions
 import anitya.lib.model
 
@@ -51,7 +51,7 @@ def projects_by_feed(session):
 
 def update_project(project_id):
     """ Check for updates on the specified project. """
-    session = utilities.init(anitya.app.APP.config['DB_URL'])
+    session = utilities.init(config['DB_URL'])
     project = anitya.lib.model.Project.by_id(session, project_id)
     try:
         utilities.check_project_release(project, session),
@@ -66,7 +66,8 @@ def main(debug, feed):
     ''' Retrieve all the packages and for each of them update the release
     version.
     '''
-    session = anitya.app.SESSION
+    model.initialize(config)
+    session = model.Session()
     run = anitya.lib.model.Run(status='started')
     session.add(run)
     session.commit()
@@ -96,7 +97,7 @@ def main(debug, feed):
 
     project_ids = [project.id for project in projects]
 
-    N = anitya.app.APP.config.get('CRON_POOL', 10)
+    N = config.get('CRON_POOL', 10)
     LOG.info("Launching pool (%i) to update %i projects", N, len(project_ids))
     p = multiprocessing.Pool(N)
     p.map(update_project, project_ids)

--- a/files/migrate_wiki.py
+++ b/files/migrate_wiki.py
@@ -14,6 +14,7 @@ import os
 import pprint
 
 from cnucnu.package_list import PackageList
+from anitya.config import config
 import anitya.app
 import anitya.lib
 import anitya.lib.plugins
@@ -119,7 +120,7 @@ def migrate_wiki(agent):
     print "Migrating from wiki as %r" % agent
 
     SESSION = anitya.lib.utilities.init(
-        anitya.app.APP.config['DB_URL'],
+        config['DB_URL'],
         None,
         create=True)
 

--- a/runserver.py
+++ b/runserver.py
@@ -1,50 +1,17 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-""" The flask application """
+"""
+An instance of the Flask application.
 
-import argparse
-import os
+This is intended to be run with the Flask CLI for development purposes only::
 
-from anitya.app import APP
+    $ export ANITYA_WEB_CONFIG=<config_file>
+    $ export FLASK_DEBUG=1
+    $ export FLASK_APP=<this_file>
+    $ flask run --host 0.0.0.0 --port 5000
+"""
 
-
-parser = argparse.ArgumentParser(
-    description='Run the anitya app')
-parser.add_argument(
-    '--config', '-c', dest='config',
-    help='Configuration file to use for anitya.')
-parser.add_argument(
-    '--debug', dest='debug', action='store_true',
-    default=False,
-    help='Expand the level of data returned.')
-parser.add_argument(
-    '--profile', dest='profile', action='store_true',
-    default=False,
-    help='Profile the anitya application.')
-parser.add_argument(
-    '--port', '-p', default=5000,
-    help='Port for the flask application.')
-parser.add_argument(
-    '--host', default='127.0.0.1',
-    help='IP address for the flask application to bind to.'
-)
-
-args = parser.parse_args()
+from anitya.app import create
 
 
-if args.profile:
-    from werkzeug.contrib.profiler import ProfilerMiddleware
-    APP.config['PROFILE'] = True
-    APP.wsgi_app = ProfilerMiddleware(APP.wsgi_app, restrictions=[30])
-
-
-if args.config:
-    config = args.config
-    if not config.startswith('/'):
-        here = os.path.join(os.path.dirname(os.path.abspath(__file__)))
-        config = os.path.join(here, config)
-    os.environ['ANITYA_WEB_CONFIG'] = config
-
-
-APP.debug = True
-APP.run(port=int(args.port), host=args.host)
+app = create()


### PR DESCRIPTION
This refactor removes the module-level ``anitya.app.APP`` object and replaces it with a function that will create and configure a complete Flask application. This, among other things, makes testing easier since each test can create, configure, and modify its own Flask application object. Check out http://flask.pocoo.org/docs/0.12/patterns/appfactories/ for an overview of the general pattern.

I did my best to break this up into a series of commits that are atomic and make sense. They're probably not as neat as I'd like, but hopefully they make this PR a little less painful to review (sorry!).