### PR TITLE
Add users to Anitya and provide authenticated API access

### DIFF
--- a/alembic/versions/3fae8239eeec_add_an_api_token_table.py
+++ b/alembic/versions/3fae8239eeec_add_an_api_token_table.py
@@ -1,0 +1,34 @@
+"""Add an API token table.
+
+Revision ID: 3fae8239eeec
+Revises: feeaa70ead67
+Create Date: 2017-07-31 20:13:54.179584
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+from anitya.lib.model import GUID
+
+
+# revision identifiers, used by Alembic.
+revision = '3fae8239eeec'
+down_revision = 'feeaa70ead67'
+
+
+def upgrade():
+    """Create the ``tokens`` table."""
+    op.create_table(
+        'tokens',
+        sa.Column('token', sa.String(length=40), nullable=False),
+        sa.Column('created', sa.DateTime(), nullable=False),
+        sa.Column('user_id', GUID(), nullable=False),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ),
+        sa.PrimaryKeyConstraint('token')
+    )
+
+
+def downgrade():
+    """Drop the ``tokens`` table."""
+    op.drop_table('tokens')

--- a/alembic/versions/3fae8239eeec_add_an_api_token_table.py
+++ b/alembic/versions/3fae8239eeec_add_an_api_token_table.py
@@ -1,19 +1,104 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of the Anitya project.
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """Add an API token table.
 
 Revision ID: 3fae8239eeec
 Revises: feeaa70ead67
 Create Date: 2017-07-31 20:13:54.179584
 """
+import uuid
 
 from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.types import TypeDecorator, CHAR
 import sqlalchemy as sa
-
-from anitya.lib.model import GUID
 
 
 # revision identifiers, used by Alembic.
 revision = '3fae8239eeec'
 down_revision = 'feeaa70ead67'
+
+
+class GUID(TypeDecorator):
+    """
+    Platform-independent GUID type.
+
+    If PostgreSQL is being used, use its native UUID type, otherwise use a CHAR(32) type.
+    """
+    impl = CHAR
+
+    def load_dialect_impl(self, dialect):
+        """
+        PostgreSQL has a native UUID type, so use it if we're using PostgreSQL.
+
+        Args:
+            dialect (sqlalchemy.engine.interfaces.Dialect): The dialect in use.
+
+        Returns:
+            sqlalchemy.types.TypeEngine: Either a PostgreSQL UUID or a CHAR(32) on other
+                dialects.
+        """
+        if dialect.name == 'postgresql':
+            return dialect.type_descriptor(UUID())
+        else:
+            return dialect.type_descriptor(CHAR(32))
+
+    def process_bind_param(self, value, dialect):
+        """
+        Process the value being bound.
+
+        If PostgreSQL is in use, just use the string representation of the UUID.
+        Otherwise, use the integer as a hex-encoded string.
+
+        Args:
+            value (object): The value that's being bound to the object.
+            dialect (sqlalchemy.engine.interfaces.Dialect): The dialect in use.
+
+        Returns:
+            str: The value of the UUID as a string.
+        """
+        if value is None:
+            return value
+        elif dialect.name == 'postgresql':
+            return str(value)
+        else:
+            if not isinstance(value, uuid.UUID):
+                return "%.32x" % uuid.UUID(value).int
+            else:
+                # hexstring
+                return "%.32x" % value.int
+
+    def process_result_value(self, value, dialect):
+        """
+        Casts the UUID value to the native Python type.
+
+        Args:
+            value (object): The database value.
+            dialect (sqlalchemy.engine.interfaces.Dialect): The dialect in use.
+
+        Returns:
+            uuid.UUID: The value as a Python :class:`uuid.UUID`.
+        """
+        if value is None:
+            return value
+        else:
+            return uuid.UUID(value)
 
 
 def upgrade():

--- a/alembic/versions/a52d2fe99d4f_users.py
+++ b/alembic/versions/a52d2fe99d4f_users.py
@@ -1,0 +1,36 @@
+"""
+Add a table for Users.
+
+Revision ID: a52d2fe99d4f
+Revises: 8040ef9a9dda
+Create Date: 2017-07-06 18:08:56.027650
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+from anitya.lib.model import GUID
+
+
+# revision identifiers, used by Alembic.
+revision = 'a52d2fe99d4f'
+down_revision = '8040ef9a9dda'
+
+
+def upgrade():
+    op.create_table(
+        'users',
+        sa.Column('id', GUID, nullable=False),
+        sa.Column('email', sa.String(length=256), nullable=False),
+        sa.Column('username', sa.String(length=256), nullable=False),
+        sa.Column('active', sa.Boolean(), nullable=False),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_users_email'), 'users', ['email'], unique=True)
+    op.create_index(op.f('ix_users_username'), 'users', ['username'], unique=True)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_users_username'), table_name='users')
+    op.drop_index(op.f('ix_users_email'), table_name='users')
+    op.drop_table('users')

--- a/alembic/versions/a52d2fe99d4f_users.py
+++ b/alembic/versions/a52d2fe99d4f_users.py
@@ -5,11 +5,12 @@ Revision ID: a52d2fe99d4f
 Revises: 8040ef9a9dda
 Create Date: 2017-07-06 18:08:56.027650
 """
+import uuid
 
 from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.types import TypeDecorator, CHAR
 import sqlalchemy as sa
-
-from anitya.lib.model import GUID
 
 
 # revision identifiers, used by Alembic.
@@ -17,10 +18,77 @@ revision = 'a52d2fe99d4f'
 down_revision = '8040ef9a9dda'
 
 
+class GUID(TypeDecorator):
+    """
+    Platform-independent GUID type.
+
+    If PostgreSQL is being used, use its native UUID type, otherwise use a CHAR(32) type.
+    """
+    impl = CHAR
+
+    def load_dialect_impl(self, dialect):
+        """
+        PostgreSQL has a native UUID type, so use it if we're using PostgreSQL.
+
+        Args:
+            dialect (sqlalchemy.engine.interfaces.Dialect): The dialect in use.
+
+        Returns:
+            sqlalchemy.types.TypeEngine: Either a PostgreSQL UUID or a CHAR(32) on other
+                dialects.
+        """
+        if dialect.name == 'postgresql':
+            return dialect.type_descriptor(UUID())
+        else:
+            return dialect.type_descriptor(CHAR(32))
+
+    def process_bind_param(self, value, dialect):
+        """
+        Process the value being bound.
+
+        If PostgreSQL is in use, just use the string representation of the UUID.
+        Otherwise, use the integer as a hex-encoded string.
+
+        Args:
+            value (object): The value that's being bound to the object.
+            dialect (sqlalchemy.engine.interfaces.Dialect): The dialect in use.
+
+        Returns:
+            str: The value of the UUID as a string.
+        """
+        if value is None:
+            return value
+        elif dialect.name == 'postgresql':
+            return str(value)
+        else:
+            if not isinstance(value, uuid.UUID):
+                return "%.32x" % uuid.UUID(value).int
+            else:
+                # hexstring
+                return "%.32x" % value.int
+
+    def process_result_value(self, value, dialect):
+        """
+        Casts the UUID value to the native Python type.
+
+        Args:
+            value (object): The database value.
+            dialect (sqlalchemy.engine.interfaces.Dialect): The dialect in use.
+
+        Returns:
+            uuid.UUID: The value as a Python :class:`uuid.UUID`.
+        """
+        if value is None:
+            return value
+        else:
+            return uuid.UUID(value)
+
+
 def upgrade():
+    """Add a "users" table."""
     op.create_table(
         'users',
-        sa.Column('id', GUID, nullable=False),
+        sa.Column('id', GUID(), nullable=False),
         sa.Column('email', sa.String(length=256), nullable=False),
         sa.Column('username', sa.String(length=256), nullable=False),
         sa.Column('active', sa.Boolean(), nullable=False),
@@ -31,6 +99,7 @@ def upgrade():
 
 
 def downgrade():
+    """Drop the "users" table."""
     op.drop_index(op.f('ix_users_username'), table_name='users')
     op.drop_index(op.f('ix_users_email'), table_name='users')
     op.drop_table('users')

--- a/alembic/versions/feeaa70ead67_social_authentication_table.py
+++ b/alembic/versions/feeaa70ead67_social_authentication_table.py
@@ -1,0 +1,89 @@
+"""Social authentication table
+
+Revision ID: feeaa70ead67
+Revises: a52d2fe99d4f
+Create Date: 2017-07-07 14:23:30.605238
+"""
+
+from alembic import op
+from social_sqlalchemy import storage
+import sqlalchemy as sa
+
+from anitya.lib.model import GUID
+
+
+# revision identifiers, used by Alembic.
+revision = 'feeaa70ead67'
+down_revision = 'a52d2fe99d4f'
+
+
+def upgrade():
+    op.create_table(
+        'social_auth_association',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('server_url', sa.String(length=255), nullable=True),
+        sa.Column('handle', sa.String(length=255), nullable=True),
+        sa.Column('secret', sa.String(length=255), nullable=True),
+        sa.Column('issued', sa.Integer(), nullable=True),
+        sa.Column('lifetime', sa.Integer(), nullable=True),
+        sa.Column('assoc_type', sa.String(length=64), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('server_url', 'handle')
+    )
+    op.create_table(
+        'social_auth_code',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('email', sa.String(length=200), nullable=True),
+        sa.Column('code', sa.String(length=32), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('code', 'email')
+    )
+    op.create_index(op.f('ix_social_auth_code_code'), 'social_auth_code', ['code'], unique=False)
+    op.create_table(
+        'social_auth_nonce',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('server_url', sa.String(length=255), nullable=True),
+        sa.Column('timestamp', sa.Integer(), nullable=True),
+        sa.Column('salt', sa.String(length=40), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('server_url', 'timestamp', 'salt')
+    )
+    op.create_table(
+        'social_auth_partial',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('token', sa.String(length=32), nullable=True),
+        sa.Column('data', storage.JSONType(), nullable=True),
+        sa.Column('next_step', sa.Integer(), nullable=True),
+        sa.Column('backend', sa.String(length=32), nullable=True),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(
+        op.f('ix_social_auth_partial_token'), 'social_auth_partial', ['token'], unique=False)
+    op.create_table(
+        'social_auth_usersocialauth',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('provider', sa.String(length=32), nullable=True),
+        sa.Column('extra_data', storage.JSONType(), nullable=True),
+        sa.Column('uid', sa.String(length=255), nullable=True),
+        sa.Column('user_id', GUID, nullable=False),
+        sa.ForeignKeyConstraint(['user_id'], [u'users.id'], ),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(
+        op.f('ix_social_auth_usersocialauth_user_id'),
+        'social_auth_usersocialauth',
+        ['user_id'],
+        unique=False
+    )
+
+
+def downgrade():
+    op.drop_index(
+        op.f('ix_social_auth_usersocialauth_user_id'), table_name='social_auth_usersocialauth')
+    op.drop_table('social_auth_usersocialauth')
+    op.drop_index(op.f('ix_social_auth_partial_token'), table_name='social_auth_partial')
+    op.drop_table('social_auth_partial')
+    op.drop_table('social_auth_nonce')
+    op.drop_index(op.f('ix_social_auth_code_code'), table_name='social_auth_code')
+    op.drop_table('social_auth_code')
+    op.drop_table('social_auth_association')

--- a/alembic/versions/feeaa70ead67_social_authentication_table.py
+++ b/alembic/versions/feeaa70ead67_social_authentication_table.py
@@ -1,15 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of the Anitya project.
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """Social authentication table
 
 Revision ID: feeaa70ead67
 Revises: a52d2fe99d4f
 Create Date: 2017-07-07 14:23:30.605238
 """
+import uuid
 
 from alembic import op
 from social_sqlalchemy import storage
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.types import TypeDecorator, CHAR
 import sqlalchemy as sa
-
-from anitya.lib.model import GUID
 
 
 # revision identifiers, used by Alembic.
@@ -17,7 +36,74 @@ revision = 'feeaa70ead67'
 down_revision = 'a52d2fe99d4f'
 
 
+class GUID(TypeDecorator):
+    """
+    Platform-independent GUID type.
+
+    If PostgreSQL is being used, use its native UUID type, otherwise use a CHAR(32) type.
+    """
+    impl = CHAR
+
+    def load_dialect_impl(self, dialect):
+        """
+        PostgreSQL has a native UUID type, so use it if we're using PostgreSQL.
+
+        Args:
+            dialect (sqlalchemy.engine.interfaces.Dialect): The dialect in use.
+
+        Returns:
+            sqlalchemy.types.TypeEngine: Either a PostgreSQL UUID or a CHAR(32) on other
+                dialects.
+        """
+        if dialect.name == 'postgresql':
+            return dialect.type_descriptor(UUID())
+        else:
+            return dialect.type_descriptor(CHAR(32))
+
+    def process_bind_param(self, value, dialect):
+        """
+        Process the value being bound.
+
+        If PostgreSQL is in use, just use the string representation of the UUID.
+        Otherwise, use the integer as a hex-encoded string.
+
+        Args:
+            value (object): The value that's being bound to the object.
+            dialect (sqlalchemy.engine.interfaces.Dialect): The dialect in use.
+
+        Returns:
+            str: The value of the UUID as a string.
+        """
+        if value is None:
+            return value
+        elif dialect.name == 'postgresql':
+            return str(value)
+        else:
+            if not isinstance(value, uuid.UUID):
+                return "%.32x" % uuid.UUID(value).int
+            else:
+                # hexstring
+                return "%.32x" % value.int
+
+    def process_result_value(self, value, dialect):
+        """
+        Casts the UUID value to the native Python type.
+
+        Args:
+            value (object): The database value.
+            dialect (sqlalchemy.engine.interfaces.Dialect): The dialect in use.
+
+        Returns:
+            uuid.UUID: The value as a Python :class:`uuid.UUID`.
+        """
+        if value is None:
+            return value
+        else:
+            return uuid.UUID(value)
+
+
 def upgrade():
+    """Create the tables necessary for the python-social-auth library."""
     op.create_table(
         'social_auth_association',
         sa.Column('id', sa.Integer(), nullable=False),
@@ -65,7 +151,7 @@ def upgrade():
         sa.Column('provider', sa.String(length=32), nullable=True),
         sa.Column('extra_data', storage.JSONType(), nullable=True),
         sa.Column('uid', sa.String(length=255), nullable=True),
-        sa.Column('user_id', GUID, nullable=False),
+        sa.Column('user_id', GUID(), nullable=False),
         sa.ForeignKeyConstraint(['user_id'], [u'users.id'], ),
         sa.PrimaryKeyConstraint('id')
     )
@@ -78,6 +164,7 @@ def upgrade():
 
 
 def downgrade():
+    """Drop the tables necessary for the python-social-auth library."""
     op.drop_index(
         op.f('ix_social_auth_usersocialauth_user_id'), table_name='social_auth_usersocialauth')
     op.drop_table('social_auth_usersocialauth')

--- a/anitya/api_v2.py
+++ b/anitya/api_v2.py
@@ -68,7 +68,6 @@ class ProjectsResource(Resource):
     The ``api/v2/projects/`` API endpoint.
     """
 
-    @authentication.parse_api_token
     def get(self):
         """
         Lists all projects.
@@ -140,7 +139,6 @@ class ProjectsResource(Resource):
             order_by=model.Project.name, **args)
         return projects_page.as_dict()
 
-    @authentication.require_api_token("upstream")
     def post(self):
         """
         Create a new project.

--- a/anitya/app.py
+++ b/anitya/app.py
@@ -13,24 +13,24 @@ routes should be placed in ``anitya.api_v2``.
 import logging
 import logging.config
 import logging.handlers
+import uuid
 
 import flask
-from bunch import Bunch
 from flask_restful import Api
+from flask_login import LoginManager, login_required, current_user  # noqa
+from social_core.backends.utils import load_backends
+from social_flask.routes import social_auth
+from social_flask_sqlalchemy import models as social_models
 
 from anitya.config import config as anitya_config
 from anitya.lib import utilities
-from anitya.lib.model import Session as SESSION, initialize as initialize_db
+from anitya.lib.model import Session as SESSION, initialize as initialize_db, User
 from . import ui, admin, api, api_v2, authentication  # noqa: F401
 import anitya.lib
 import anitya.mail_logging
 
 
 __version__ = '0.11.0'
-
-
-# For API compatibility
-login_required = ui.login_required
 
 
 def create(config=None):
@@ -55,6 +55,24 @@ def create(config=None):
     # Set up the Flask extensions
     authentication.configure_openid(app)
 
+    app.register_blueprint(social_auth)
+    if len(social_models.UserSocialAuth.__table_args__) == 0:
+        # This is a bit of a hack - this initialization call sets up the SQLAlchemy
+        # models with our own models and multiple calls to this function will cause
+        # SQLAlchemy to fail with sqlalchemy.exc.InvalidRequestError. Only calling it
+        # when there are no table arguments should ensure we only call it one time.
+        #
+        # Be aware that altering the configuration values this function uses, namely
+        # the SOCIAL_AUTH_USER_MODEL, after the first time ``create`` has been called
+        # will *not* cause the new configuration to be used for subsequent calls to
+        # ``create``.
+        social_models.init_social(app, SESSION)
+
+    login_manager = LoginManager()
+    login_manager.user_loader(user_loader)
+    login_manager.login_view = '/login/'
+    login_manager.init_app(app)
+
     # Register the v2 API resources
     app.api = Api(app)
     app.api.add_resource(api_v2.ProjectsResource, '/api/v2/projects/')
@@ -63,7 +81,7 @@ def create(config=None):
     app.register_blueprint(ui.ui_blueprint)
     app.register_blueprint(api.api_blueprint)
 
-    app.before_request(check_auth)
+    app.before_request(global_user)
     app.teardown_request(shutdown_session)
 
     app.context_processor(inject_variable)
@@ -80,23 +98,26 @@ def create(config=None):
     return app
 
 
-def check_auth():
-    ''' Set the flask.g variables using the session information if the user
-    is logged in.
-    '''
+def user_loader(user_id):
+    """
+    Used to reload a :class:`User` object from the session.
 
-    flask.g.auth = Bunch(
-        logged_in=False,
-        method=None,
-        id=None,
-    )
-    if 'openid' in flask.session:
-        flask.g.auth.logged_in = True
-        flask.g.auth.method = u'openid'
-        flask.g.auth.openid = flask.session.get('openid')
-        flask.g.auth.fullname = flask.session.get('fullname', None)
-        flask.g.auth.nickname = flask.session.get('nickname', None)
-        flask.g.auth.email = flask.session.get('email', None)
+    Args:
+        user_id (unicode): The user's ID as a unicode string.
+
+    Returns:
+        User: The user with the given user ID, if it exists. Otherwise, ``None`` is returned.
+    """
+    try:
+        return User.query.get(uuid.UUID(user_id))
+    except (TypeError, ValueError):
+        # Return None if the type was wrong
+        pass
+
+
+def global_user():
+    """Set the flask.g variables using the session information if the user is logged in."""
+    flask.g.user = current_user._get_current_object()
 
 
 def shutdown_session(exception=None):
@@ -119,29 +140,6 @@ def inject_variable():
         is_admin=admin.is_admin(),
         justedit=justedit,
         cron_status=cron_status,
+        user=current_user,
+        available_backends=load_backends(anitya_config['SOCIAL_AUTH_AUTHENTICATION_BACKENDS']),
     )
-
-
-@authentication.oid.after_login
-def after_openid_login(resp):
-    ''' This function saved the information about the user right after the
-    login was successful on the OpenID server.
-    '''
-    default = flask.url_for('anitya_ui.index')
-    blacklist = flask.current_app.config['BLACKLISTED_USERS']
-    if resp.identity_url:
-        next_url = flask.request.args.get('next', default)
-        openid_url = resp.identity_url
-        if openid_url in blacklist or resp.email in blacklist:
-            flask.flash(
-                'We are very sorry but your account has been blocked from '
-                'logging in to this service.', 'error')
-            return flask.redirect(next_url)
-
-        flask.session['openid'] = openid_url
-        flask.session['fullname'] = resp.fullname
-        flask.session['nickname'] = resp.nickname or resp.fullname
-        flask.session['email'] = resp.email
-        return flask.redirect(next_url)
-    else:
-        return flask.redirect(default)

--- a/anitya/config.py
+++ b/anitya/config.py
@@ -40,11 +40,6 @@ DEFAULTS = dict(
     DB_URL='sqlite:////var/tmp/anitya-dev.sqlite',
     # List of admins based on their openid
     ANITYA_WEB_ADMINS=[],
-    ANITYA_WEB_FEDORA_OPENID='https://id.fedoraproject.org',
-    ANITYA_WEB_ALLOW_FAS_OPENID=True,
-    ANITYA_WEB_ALLOW_GOOGLE_OPENID=True,
-    ANITYA_WEB_ALLOW_YAHOO_OPENID=True,
-    ANITYA_WEB_ALLOW_GENERIC_OPENID=True,
     ADMIN_EMAIL='admin@fedoraproject.org',
     ANITYA_LOG_CONFIG={
         'version': 1,
@@ -81,19 +76,21 @@ DEFAULTS = dict(
     # errors occur.
     EMAIL_ERRORS=False,
     BLACKLISTED_USERS=[],
-    OIDC_CLIENT_SECRETS=os.path.join(
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-        'client_secrets.json'
+    SESSION_PROTECTION='strong',
+    SOCIAL_AUTH_AUTHENTICATION_BACKENDS=(
+        'social_core.backends.fedora.FedoraOpenId',
+        'social_core.backends.yahoo.YahooOpenId',
+        'social_core.backends.open_id.OpenIdAuth',
+        # 'social_core.backends.google_openidconnect.GoogleOpenIdConnect',
+        # 'social_core.backends.github.GithubOAuth2',
     ),
-    # Force the application to require HTTPS to save the cookie. This should only
-    # be `False` in a development environment running on the local host!
-    OIDC_ID_TOKEN_COOKIE_SECURE=True,
-    OIDC_REQUIRE_VERIFIED_EMAIL=True,
-    OIDC_OPENID_REALM='http://localhost:5000/oidc_callback',
-    OIDC_SCOPES=[
-        'https://release-monitoring.org/oidc/upstream',
-        'https://release-monitoring.org/oidc/downstream',
-    ],
+    SOCIAL_AUTH_STORAGE='social_flask_sqlalchemy.models.FlaskStorage',
+    SOCIAL_AUTH_USER_MODEL='anitya.lib.model.User',
+    # Force the application to require HTTPS on authentication redirects.
+    SOCIAL_AUTH_REDIRECT_IS_HTTPS=True,
+    SOCIAL_AUTH_LOGIN_URL='/login/',
+    SOCIAL_AUTH_LOGIN_REDIRECT_URL='/',
+    SOCIAL_AUTH_LOGIN_ERROR_URL='/login-error/',
 )
 
 # Start with a basic logging configuration, which will be replaced by any user-

--- a/anitya/config.py
+++ b/anitya/config.py
@@ -81,8 +81,6 @@ DEFAULTS = dict(
         'social_core.backends.fedora.FedoraOpenId',
         'social_core.backends.yahoo.YahooOpenId',
         'social_core.backends.open_id.OpenIdAuth',
-        # 'social_core.backends.google_openidconnect.GoogleOpenIdConnect',
-        # 'social_core.backends.github.GithubOAuth2',
     ),
     SOCIAL_AUTH_STORAGE='social_flask_sqlalchemy.models.FlaskStorage',
     SOCIAL_AUTH_USER_MODEL='anitya.lib.model.User',

--- a/anitya/lib/model.py
+++ b/anitya/lib/model.py
@@ -30,6 +30,7 @@ import datetime
 import logging
 import time
 import string
+import uuid
 
 import six
 import sqlalchemy as sa
@@ -39,7 +40,6 @@ from sqlalchemy.orm import (
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.types import TypeDecorator, CHAR
-import uuid
 
 from anitya.config import config as anitya_config
 from .versions import GLOBAL_DEFAULT as DEFAULT_VERSION_SCHEME

--- a/anitya/lib/model.py
+++ b/anitya/lib/model.py
@@ -24,7 +24,10 @@ try:
     # The Python 3.6+ API
     from secrets import choice as random_choice
 except ImportError:
-    from random import choice as random_choice
+    # Fall back to random with os.urandom
+    import random
+    random = random.SystemRandom()
+    random_choice = random.choice
 import collections
 import datetime
 import logging

--- a/anitya/lib/utilities.py
+++ b/anitya/lib/utilities.py
@@ -356,8 +356,19 @@ def edit_project(
 def map_project(
         session, project, package_name, distribution, user_id,
         old_package_name=None, old_distro_name=None):
-    """ Map a project to a distribution.
+    """
+    Map a project to a distribution.
 
+    Args:
+        session (sqlalchemy.orm.session.Session): The database session.
+        project (anitya.lib.model.Project): The project to map to a distribution.
+        package_name (str): The name of the mapped package.
+        distribution (str): The name of the distribution.
+        user_id (str): The user ID.
+        old_package_name (str): The name of the old package mapping, if this is being
+            used to edit a mapping.
+        old_distro_name (str): The name of the old distro of the package mapping, if this
+            is being used to edit a mapping.
     """
     distribution = distribution.strip()
 

--- a/anitya/mail_logging.py
+++ b/anitya/mail_logging.py
@@ -109,7 +109,7 @@ class ContextInjector(logging.Filter):  # pragma: no cover
             pass
         try:
             record.username = "%s -- %s" % (
-                flask.g.auth.openid, flask.g.auth.email)
+                flask.g.user.id, flask.g.user.email)
         except:
             pass
 

--- a/anitya/templates/flags.html
+++ b/anitya/templates/flags.html
@@ -38,7 +38,7 @@
         <li>
             {% if page > 1%}
               <a href="{{ url_for('anitya_ui.browse_flags', page=page-1, project=project,
-                user=user, from_date=from_date) }}">
+                user=flags_for_user, from_date=from_date) }}">
                 «
               </a>
             {% else %}
@@ -51,7 +51,7 @@
         <li>
             {% if page < total_page %}
               <a href="{{ url_for('anitya_ui.browse_flags', page=page+1, project=project,
-                user=user, from_date=from_date) }}">
+                user=flags_for_user, from_date=from_date) }}">
                 »
               </a>
             {% else %}
@@ -78,7 +78,7 @@
       </div>
       <div class="form-group col-xs-6 col-sm-4">
         <input type="text" name="user" placeholder="User identifier"
-            class="form-control" value="{{ user }}"/>
+            class="form-control" value="{{ flags_for_user }}"/>
       </div>
       <div class="form-group col-xs-6 col-sm-2">
         <div class='input-group date' id='datetimepicker'>

--- a/anitya/templates/login.html
+++ b/anitya/templates/login.html
@@ -7,20 +7,27 @@
   <div class="col-md-4">
 
   <div class="list-group">
-    {% if config.get('ANITYA_WEB_ALLOW_GENERIC_OPENID') %}
-    <span class="list-group-item">
-        <h4 class="list-group-item-heading">OpenId Login</h4>
-          <form role="form" action="{{url_for('anitya_ui.login')}}" method="post">
-            <input name="openid" placeholder="https://id.openid.server">
-            <span class="pull-right">
-                <button type="submit" class="btn btn-success">
-                    <span class="glyphicon glyphicon-plus"></span>
-                    Login</button>
-            </span>
-          </form>
-        <div class="clearfix"></div>
-    </span>
-    {% endif %}
+    {% for name, backend in available_backends.items() %}
+
+      {% if name == 'openid'%}
+        <span class="list-group-item">
+            <h4 class="list-group-item-heading">OpenId Login</h4>
+              <form role="form" action="{{url_for('anitya_ui.login')}}" method="post">
+                <input name="openid" placeholder="https://id.openid.server">
+                <span class="pull-right">
+                    <button type="submit" class="btn btn-success">
+                        <span class="glyphicon glyphicon-plus"></span>
+                        Login</button>
+                </span>
+              </form>
+            <div class="clearfix"></div>
+        </span>
+      {% else %}
+        <span class="list-group-item">
+          <a href="{{url_for('social.auth', backend=name)}}">{{ backend.__name__ }}</a>
+        </span>
+      {% endif %}
+    {% endfor %}
   </div>
   </div>
 </div>

--- a/anitya/templates/logs.html
+++ b/anitya/templates/logs.html
@@ -72,7 +72,7 @@
       {% if is_admin %}
       <div class="form-group col-xs-6 col-sm-3">
         <input type="text" name="user" placeholder="User identifier"
-            class="form-control" value="{{ user }}"/>
+            class="form-control" value="{{ user.username }}"/>
       </div>
       {% endif %}
       <div class="form-group col-xs-6 col-sm-3">

--- a/anitya/templates/master.html
+++ b/anitya/templates/master.html
@@ -98,7 +98,7 @@
               </a>
             </li>
 
-            {%- if g.auth.logged_in -%}
+            {%- if user and user.is_authenticated -%}
             {%- if current == 'Add projects' -%}
             <li class="active">
             {%- else -%}
@@ -129,29 +129,11 @@
                </li>
             {%- endif -%}
             <li>
-              <a href="{{url_for('anitya_ui.logout')}}?next={{request.url}}">logout</a>
+              <a href="{{url_for('anitya_ui.logout')}}">logout</a>
             </li>
             {%- else -%}
             <li>
-                <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                    <b class="caret"></b> login
-                </a>
-                <ul class="dropdown-menu">
-                  {%- if config['ANITYA_WEB_FEDORA_OPENID'] and
-                        config['ANITYA_WEB_ALLOW_FAS_OPENID'] -%}
-                  <li><a href="{{url_for('anitya_ui.fedora_login')}}">Fedora</a></li>
-                  <li class="divider"></li>
-                  {%- endif -%}
-                  {%- if config['ANITYA_WEB_ALLOW_GOOGLE_OPENID'] -%}
-                  <li><a href="{{url_for('anitya_ui.google_login')}}">Google</a></li>
-                  {%- endif -%}
-                  {%- if config['ANITYA_WEB_ALLOW_YAHOO_OPENID'] -%}
-                  <li><a href="{{url_for('anitya_ui.yahoo_login')}}">Yahoo</a></li>
-                  {%- endif -%}
-                  {%- if config['ANITYA_WEB_ALLOW_GENERIC_OPENID'] -%}
-                  <li><a href="{{url_for('anitya_ui.login')}}">Other OpenID</a></li>
-                  {%- endif -%}
-                </ul>
+              <a href="{{url_for('anitya_ui.login')}}">login</a>
             </li>
             {%- endif -%}
             <li>

--- a/anitya/templates/project.html
+++ b/anitya/templates/project.html
@@ -59,7 +59,7 @@
                 </div>
             </div>
             <div class="col-md-4">
-              {% if g.auth.logged_in and (not project.versions or is_admin
+              {% if user and user.is_authenticated and (not project.versions or is_admin
                 or justedit) %}
               <button type="submit" class="btn btn-success btn-sm pull-right"
                   id="testcheck" tabindex=3>
@@ -171,7 +171,7 @@
             </dl>
           </div><!-- end group-item-text -->
         </div><!-- end group-item -->
-        {% if g.auth.logged_in %}
+        {% if user and user.is_authenticated %}
         <div class="list-group-item">
           <div class="list-group-item-text">
             <p><a href="{{ url_for('anitya_ui.map_project', project_id=project.id) }}">
@@ -259,7 +259,7 @@
     if (event.which == 69 && !$("#searchbox").is(':focus')) { //e
       window.location.replace("{{ url_for('anitya_ui.edit_project', project_id=project.id) }}");
     }
-    {% if g.auth.logged_in and (not project.versions or is_admin) %}
+    {% if user and user.is_authenticated and (not project.versions or is_admin) %}
     if (event.which == 67 && !$("#searchbox").is(':focus')) { //c
       checkrelease();
       return false;

--- a/anitya/templates/project_delete.html
+++ b/anitya/templates/project_delete.html
@@ -49,7 +49,7 @@
           {% endfor %}
 
         </table>
-          {% if g.auth.logged_in %}
+          {% if user and user.is_authenticated %}
           {{ form.csrf_token }}
           <p class="pull-right">
             <a href="{{ url_for('anitya_ui.delete_project', project_id=project.id) }}">

--- a/anitya/tests/base.py
+++ b/anitya/tests/base.py
@@ -27,14 +27,10 @@ import unittest
 import os
 
 from flask import request_started
-from flask_openid import OpenID
-from flask_oidc import OpenIDConnect
 from social_flask_sqlalchemy.models import PSABase
 from sqlalchemy import create_engine, event
-import flask
 import flask_login
 import vcr
-import mock
 
 from anitya import app, config
 from anitya.lib import model, utilities
@@ -109,16 +105,6 @@ class AnityaTestCase(unittest.TestCase):
 
         This simply starts recording a VCR on start-up and stops on tearDown.
         """
-        mock_oidc = mock.patch(
-            'anitya.authentication.oidc',
-            OpenIDConnect(credentials_store=flask.session),
-        )
-        mock_oidc.start()
-        self.addCleanup(mock_oidc.stop)
-        mock_oid = mock.patch('anitya.authentication.oid', OpenID())
-        mock_oid.start()
-        self.addCleanup(mock_oid.stop)
-
         self.config = config.config.copy()
         self.config['TESTING'] = True
         self.flask_app = app.create(self.config)

--- a/anitya/tests/test_app.py
+++ b/anitya/tests/test_app.py
@@ -20,12 +20,15 @@
 
 import logging
 import unittest
+import uuid
 
 from sqlalchemy.exc import UnboundExecutionError
+import six
 
 from anitya import app
 from anitya.config import config as anitya_config
-from anitya.lib.model import Session
+from anitya.lib.model import Session, User
+from anitya.tests.base import DatabaseTestCase
 
 
 class CreateTests(unittest.TestCase):
@@ -46,6 +49,7 @@ class CreateTests(unittest.TestCase):
         """Assert a SMTPHandler is added to the anitya logger when ``EMAIL_ERRORS=True``."""
         config = {
             'DB_URL': 'sqlite://',
+            'SOCIAL_AUTH_USER_MODEL': 'anitya.lib.model.User',
             'EMAIL_ERRORS': True,
             'SMTP_SERVER': 'smtp.example.com',
             'ADMIN_EMAIL': 'admin@example.com',
@@ -65,5 +69,35 @@ class CreateTests(unittest.TestCase):
         self.assertRaises(UnboundExecutionError, Session.get_bind)
         Session.remove()
 
-        app.create({'DB_URL': 'sqlite://'})
+        app.create({
+            'DB_URL': 'sqlite://',
+            'SOCIAL_AUTH_USER_MODEL': 'anitya.lib.model.User',
+        })
         self.assertEqual('sqlite://', str(Session().get_bind().url))
+
+
+class UserLoaderTests(DatabaseTestCase):
+    """Tests for the :func:`anitya.app.user_loader`` functions."""
+
+    def setUp(self):
+        super(UserLoaderTests, self).setUp()
+
+        session = Session()
+        self.user = User(email='user@example.com', username='user')
+        session.add(self.user)
+        session.commit()
+
+    def test_success(self):
+        """Assert users are loaded successfully when a valid ID is provided."""
+        loaded_user = app.user_loader(six.text_type(self.user.id))
+        self.assertEqual(loaded_user, self.user)
+
+    def test_missing_user(self):
+        """Assert ``None`` is returned when there is no user with the given ID."""
+        loaded_user = app.user_loader(six.text_type(uuid.uuid4()))
+        self.assertTrue(loaded_user is None)
+
+    def test_incorrect_type(self):
+        """Assert ``None`` is returned when the user ID isn't a UUID."""
+        loaded_user = app.user_loader('Not a UUID')
+        self.assertTrue(loaded_user is None)

--- a/anitya/tests/test_app.py
+++ b/anitya/tests/test_app.py
@@ -20,15 +20,12 @@
 
 import logging
 import unittest
-import uuid
 
 from sqlalchemy.exc import UnboundExecutionError
-import six
 
 from anitya import app
 from anitya.config import config as anitya_config
-from anitya.lib.model import Session, User
-from anitya.tests.base import DatabaseTestCase
+from anitya.lib.model import Session
 
 
 class CreateTests(unittest.TestCase):
@@ -74,30 +71,3 @@ class CreateTests(unittest.TestCase):
             'SOCIAL_AUTH_USER_MODEL': 'anitya.lib.model.User',
         })
         self.assertEqual('sqlite://', str(Session().get_bind().url))
-
-
-class UserLoaderTests(DatabaseTestCase):
-    """Tests for the :func:`anitya.app.user_loader`` functions."""
-
-    def setUp(self):
-        super(UserLoaderTests, self).setUp()
-
-        session = Session()
-        self.user = User(email='user@example.com', username='user')
-        session.add(self.user)
-        session.commit()
-
-    def test_success(self):
-        """Assert users are loaded successfully when a valid ID is provided."""
-        loaded_user = app.user_loader(six.text_type(self.user.id))
-        self.assertEqual(loaded_user, self.user)
-
-    def test_missing_user(self):
-        """Assert ``None`` is returned when there is no user with the given ID."""
-        loaded_user = app.user_loader(six.text_type(uuid.uuid4()))
-        self.assertTrue(loaded_user is None)
-
-    def test_incorrect_type(self):
-        """Assert ``None`` is returned when the user ID isn't a UUID."""
-        loaded_user = app.user_loader('Not a UUID')
-        self.assertTrue(loaded_user is None)

--- a/anitya/tests/test_authentication.py
+++ b/anitya/tests/test_authentication.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of the Anitya project.
+# Copyright (C) 2017  Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+"""Tests for the :mod:`anitya.authentication` module."""
+
+import uuid
+
+import six
+import mock
+
+from anitya import authentication
+from anitya.lib.model import Session, User, ApiToken
+from anitya.tests.base import DatabaseTestCase
+
+
+class LoadUserFromRequestTests(DatabaseTestCase):
+    """Tests for the :class:`anitya.authentication.SessionInterface`` class."""
+
+    def setUp(self):
+        super(LoadUserFromRequestTests, self).setUp()
+        self.app = self.flask_app.test_client()
+        session = Session()
+        self.user = User(email='user@example.com', username='user')
+        self.api_token = ApiToken(user=self.user)
+        session.add_all([self.user, self.api_token])
+        session.commit()
+
+    def test_success(self):
+        """Assert that users can authenticate via the 'Authorization' header."""
+        mock_request = mock.Mock()
+        mock_request.headers = {'Authorization': 'token ' + self.api_token.token}
+        user = authentication.load_user_from_request(mock_request)
+        self.assertEqual(self.user, user)
+
+    def test_no_token_in_db(self):
+        """Assert that an invalid token results in a User of ``None``."""
+        mock_request = mock.Mock()
+        mock_request.headers = {'Authorization': 'token ' 'myinvalidtoken'}
+        self.assertEqual(None, authentication.load_user_from_request(mock_request))
+
+    def test_no_header(self):
+        """Assert that no user is authenticated when the header is absent."""
+        mock_request = mock.Mock()
+        mock_request.headers = {}
+        self.assertEqual(None, authentication.load_user_from_request(mock_request))
+
+    def test_unkown_auth_type(self):
+        """Assert that unknown authentication types are rejected."""
+        mock_request = mock.Mock(spec='werkzeug.wrappers.Request')
+        mock_request.headers = {'Authorization': 'Basic ' + self.api_token.token}
+        self.assertEqual(None, authentication.load_user_from_request(mock_request))
+
+
+class LoadUserFromSessionTests(DatabaseTestCase):
+    """Tests for the :func:`anitya.authentication.load_user_from_session`` functions."""
+
+    def setUp(self):
+        super(LoadUserFromSessionTests, self).setUp()
+
+        session = Session()
+        self.user = User(email='user@example.com', username='user')
+        session.add(self.user)
+        session.commit()
+
+    def test_success(self):
+        """Assert users are loaded successfully when a valid ID is provided."""
+        loaded_user = authentication.load_user_from_session(six.text_type(self.user.id))
+        self.assertEqual(loaded_user, self.user)
+
+    def test_missing_user(self):
+        """Assert ``None`` is returned when there is no user with the given ID."""
+        loaded_user = authentication.load_user_from_session(six.text_type(uuid.uuid4()))
+        self.assertTrue(loaded_user is None)
+
+    def test_incorrect_type(self):
+        """Assert ``None`` is returned when the user ID isn't a UUID."""
+        loaded_user = authentication.load_user_from_session('Not a UUID')
+        self.assertTrue(loaded_user is None)
+
+
+class RequireTokenTests(DatabaseTestCase):
+    """Tests for the :func:`anitya.authentication.require_token` decorator."""
+
+    def setUp(self):
+        super(RequireTokenTests, self).setUp()
+        self.app = self.flask_app.test_client()
+        session = Session()
+        self.user = User(email='user@example.com', username='user')
+        self.api_token = ApiToken(user=self.user)
+        session.add_all([self.user, self.api_token])
+        session.commit()
+
+    @mock.patch('flask_login.current_user')
+    def test_unauthenticated(self, mock_current_user):
+        """Assert decorated functions return HTTP 401 when no user is logged in."""
+        mock_current_user.is_authenticated = False
+        error_details = {
+            'error': 'authentication_required',
+            'error_description': 'Authentication is required to access this API.',
+        }
+        expected_response = (error_details, 401, {'WWW-Authenticate': 'Token'})
+
+        @authentication.require_token
+        def test_func():
+            return 'This should not happen!'
+
+        self.assertEqual(expected_response, test_func())
+
+    @mock.patch('flask_login.current_user')
+    def test_authenticated(self, mock_current_user):
+        """Assert decorated functions return the function's result when a user is logged in."""
+        mock_current_user.is_authenticated = True
+
+        @authentication.require_token
+        def test_func():
+            return 'Carry on!'
+
+        self.assertEqual('Carry on!', test_func())

--- a/anitya/tests/test_flask.py
+++ b/anitya/tests/test_flask.py
@@ -23,8 +23,6 @@
 anitya tests for the flask application.
 '''
 
-import unittest
-
 from six.moves.urllib import parse
 import mock
 
@@ -681,8 +679,6 @@ class EditProjectMappingTests(DatabaseTestCase):
             self.assertEqual(1, len(packages))
             self.assertEqual('Python Project', packages[0].package_name)
 
-    # You can't actually edit the distro at the moment, bug
-    @unittest.expectedFailure
     def test_edit_project_mapping_distro(self):
         """Assert a project's package distro can be edited."""
         with login_user(self.flask_app, self.user):

--- a/anitya/tests/test_flask_admin.py
+++ b/anitya/tests/test_flask_admin.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2014  Red Hat, Inc.
+# Copyright © 2014-2017  Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions
@@ -17,566 +17,737 @@
 # code or documentation are not subject to the GNU General Public
 # License and may only be used or replicated with the express permission
 # of Red Hat, Inc.
-#
+"""Tests for the :mod:`anitya.admin` module."""
 
-'''
-anitya tests for the flask application.
-'''
+import mock
+import six
 
-import datetime
-import unittest
-
+from anitya import admin
 from anitya.lib import model
-from anitya.tests.base import (DatabaseTestCase, create_distro, create_project,
-                               create_package, create_flagged_project)
+from anitya.tests.base import DatabaseTestCase, login_user
 
 
-class FlaskAdminTest(DatabaseTestCase):
-    """ Flask tests for the admin controller. """
+class IsAdminTests(DatabaseTestCase):
+    """Tests for the :func:`anitya.admin.is_admin` function."""
 
     def setUp(self):
-        """ Set up the environnment, ran before every tests. """
-        super(FlaskAdminTest, self).setUp()
+        super(IsAdminTests, self).setUp()
 
-        self.flask_app.config['TESTING'] = True
-        self.flask_app.config['ANITYA_WEB_ADMINS'] = ['http://pingou.id.fedoraproject.org/']
-        self.app = self.flask_app.test_client()
+        # Add a regular user and an admin user
+        session = model.Session()
+        self.user = model.User(email='user@example.com', username='user')
+        self.admin = model.User(email='admin@example.com', username='admin')
+        session.add_all([self.user, self.admin])
+        session.commit()
+
+        mock_config = mock.patch.dict(
+            model.anitya_config, {'ANITYA_WEB_ADMINS': [six.text_type(self.admin.id)]})
+        mock_config.start()
+        self.addCleanup(mock_config.stop)
+
+    def test_admin_user(self):
+        """Assert admin users passed via parameter returns True."""
+        self.assertTrue(admin.is_admin(self.admin))
+
+    def test_non_admin_user(self):
+        """Assert regular users passed via parameter returns False."""
+        self.assertFalse(admin.is_admin(self.user))
+
+
+class AddDistroTests(DatabaseTestCase):
+    """Tests for the :func:`anitya.admin.add_distro` view function."""
+
+    def setUp(self):
+        super(AddDistroTests, self).setUp()
+
+        # Add a regular user and an admin user
+        session = model.Session()
+        self.user = model.User(email='user@example.com', username='user')
+        self.admin = model.User(email='admin@example.com', username='admin')
+        session.add_all([self.user, self.admin])
+        session.commit()
+
+        mock_config = mock.patch.dict(
+            model.anitya_config, {'ANITYA_WEB_ADMINS': [six.text_type(self.admin.id)]})
+        mock_config.start()
+        self.addCleanup(mock_config.stop)
+
+        self.client = self.flask_app.test_client()
+
+    def test_non_admin_get(self):
+        """Assert non-admin users cannot add a distribution."""
+        with login_user(self.flask_app, self.user):
+            output = self.client.get('/distro/add')
+            self.assertEqual(401, output.status_code)
+
+    def test_no_csrf_token(self):
+        """Assert submitting without a CSRF token, no change is made."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.post('/distro/add', data={'name': 'Fedora'})
+            self.assertEqual(200, output.status_code)
+            self.assertEqual(0, model.Distro.query.count())
+
+    def test_invalid_csrf_token(self):
+        """Assert submitting with an invalid CSRF token, no change is made."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.post('/distro/add', data={'csrf_token': 'abc', 'name': 'Fedora'})
+            self.assertEqual(200, output.status_code)
+            self.assertEqual(0, model.Distro.query.count())
+
+    def test_admin_get(self):
+        """Assert admin users can view the add a distribution page."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/distro/add')
+            self.assertEqual(200, output.status_code)
 
     def test_add_distro(self):
-        """ Test the add_distro function. """
-        output = self.app.get('/distro/add', follow_redirects=True)
-        self.assertEqual(output.status_code, 200)
-        self.assertTrue(
-            b'<ul id="flashes" class="list-group">'
-            b'<li class="list-group-item list-group-item-warning">'
-            b'Login required</li></ul>' in output.data)
-
-        with self.flask_app.test_client() as c:
-            with c.session_transaction() as sess:
-                sess['openid'] = 'openid_url'
-                sess['fullname'] = 'Pierre-Yves C.'
-                sess['nickname'] = 'pingou'
-                sess['email'] = 'pingou@pingoured.fr'
-
-            output = c.get('/distro/add', follow_redirects=True)
-            self.assertEqual(output.status_code, 401)
-
-        with self.flask_app.test_client() as c:
-            with c.session_transaction() as sess:
-                sess['openid'] = 'http://pingou.id.fedoraproject.org/'
-                sess['fullname'] = 'Pierre-Yves C.'
-                sess['nickname'] = 'pingou'
-                sess['email'] = 'pingou@pingoured.fr'
-
-            output = c.get('/distro/add')
-            self.assertEqual(output.status_code, 200)
-
-            self.assertTrue(b'<h1>Add a new disribution</h1>' in output.data)
-            self.assertIn(
-                b'<td><input id="name" name="name" tabindex="1" type="text"'
-                b' value=""></td>', output.data)
-
-            data = {
-                'name': 'Debian',
-            }
-
-            output = c.post(
-                '/distro/add', data=data, follow_redirects=True)
-            self.assertEqual(output.status_code, 200)
-            self.assertTrue(b'<h1>Add a new disribution</h1>' in output.data)
-            self.assertIn(
-                b'<td><input id="name" name="name" tabindex="1" type="text"'
-                b' value="Debian"></td>', output.data)
-
+        """Assert admins can add distributions."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/distro/add')
             csrf_token = output.data.split(
                 b'name="csrf_token" type="hidden" value="')[1].split(b'">')[0]
+            data = {'name': 'Fedora', 'csrf_token': csrf_token}
 
-            data['csrf_token'] = csrf_token
+            output = self.client.post('/distro/add', data=data, follow_redirects=True)
 
-            output = c.post(
-                '/distro/add', data=data, follow_redirects=True)
-            self.assertEqual(output.status_code, 200)
-            self.assertTrue(
-                b'<h1>Distributions participating</h1>' in output.data)
-            self.assertTrue(
-                b'<a href="/distro/Debian/edit">' in output.data)
+            # self.assertEqual(201, output.status_code)
+            self.assertTrue(b'Distribution added' in output.data)
 
-            output = c.post(
-                '/distro/add', data=data, follow_redirects=True)
-            self.assertEqual(output.status_code, 200)
-            self.assertTrue(
-                b'class="list-group-item list-group-item-danger">'
-                b'Could not add this distro, already exists?</'
-                in output.data)
-            self.assertTrue(
-                b'<h1>Distributions participating</h1>' in output.data)
-            self.assertTrue(
-                b'<a href="/distro/Debian/edit">' in output.data)
-
-    def test_edit_distro(self):
-        """ Test the edit_distro function. """
-        self.test_add_distro()
-
-        output = self.app.get('/distro/Debian/edit', follow_redirects=True)
-        self.assertEqual(output.status_code, 200)
-        self.assertTrue(
-            b'<ul id="flashes" class="list-group">'
-            b'<li class="list-group-item list-group-item-warning">'
-            b'Login required</li></ul>' in output.data)
-
-        with self.flask_app.test_client() as c:
-            with c.session_transaction() as sess:
-                sess['openid'] = 'openid_url'
-                sess['fullname'] = 'Pierre-Yves C.'
-                sess['nickname'] = 'pingou'
-                sess['email'] = 'pingou@pingoured.fr'
-
-            output = c.get('/distro/foobar/edit', follow_redirects=True)
-            self.assertEqual(output.status_code, 404)
-
-            output = c.get('/distro/Debian/edit', follow_redirects=True)
-            self.assertEqual(output.status_code, 401)
-
-        with self.flask_app.test_client() as c:
-            with c.session_transaction() as sess:
-                sess['openid'] = 'http://pingou.id.fedoraproject.org/'
-                sess['fullname'] = 'Pierre-Yves C.'
-                sess['nickname'] = 'pingou'
-                sess['email'] = 'pingou@pingoured.fr'
-
-            output = c.get('/distro/Debian/edit', follow_redirects=True)
-            self.assertEqual(output.status_code, 200)
-            self.assertTrue(
-                b'<h1>Edit disribution: Debian</h1>' in output.data)
-            self.assertIn(
-                b'<td><input id="name" name="name" tabindex="1" type="text" '
-                b'value="Debian"></td>', output.data)
-
-            data = {
-                'name': 'debian',
-            }
-
-            output = c.post(
-                '/distro/Debian/edit', data=data, follow_redirects=True)
-            self.assertEqual(output.status_code, 200)
-            self.assertTrue(
-                b'<h1>Edit disribution: Debian</h1>' in output.data)
-            self.assertIn(
-                b'<td><input id="name" name="name" tabindex="1" type="text"'
-                b' value="debian"></td>', output.data)
-
+    def test_duplicate_distro(self):
+        """Assert trying to create a duplicate distribution results in HTTP 409."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/distro/add')
             csrf_token = output.data.split(
                 b'name="csrf_token" type="hidden" value="')[1].split(b'">')[0]
+            data = {'name': 'Fedora', 'csrf_token': csrf_token}
 
-            data['csrf_token'] = csrf_token
+            create_output = self.client.post('/distro/add', data=data, follow_redirects=True)
+            dup_output = self.client.post('/distro/add', data=data, follow_redirects=True)
 
-            output = c.post(
-                '/distro/Debian/edit', data=data, follow_redirects=True)
-            self.assertEqual(output.status_code, 200)
-            self.assertTrue(
-                b'<h1>Distributions participating</h1>' in output.data)
-            self.assertTrue(
-                b'<a href="/distro/debian/edit">' in output.data)
+            # self.assertEqual(201, create_output.status_code)
+            # self.assertEqual(409, dup_output.status_code)
+            self.assertTrue(b'Distribution added' in create_output.data)
+            self.assertTrue(b'Could not add this distro' in dup_output.data)
 
-    def test_delete_project(self):
-        """ Test the delete_project function. """
-        create_distro(self.session)
-        create_project(self.session)
 
-        output = self.app.get('/project/1/delete', follow_redirects=True)
-        self.assertEqual(output.status_code, 200)
-        self.assertTrue(
-            b'<ul id="flashes" class="list-group">'
-            b'<li class="list-group-item list-group-item-warning">'
-            b'Login required</li></ul>' in output.data)
+class EditDistroTests(DatabaseTestCase):
+    """Tests for the :func:`anitya.admin.edit_distro` view function."""
 
-        with self.flask_app.test_client() as c:
-            with c.session_transaction() as sess:
-                sess['openid'] = 'openid_url'
-                sess['fullname'] = 'Pierre-Yves C.'
-                sess['nickname'] = 'pingou'
-                sess['email'] = 'pingou@pingoured.fr'
+    def setUp(self):
+        super(EditDistroTests, self).setUp()
 
-            output = c.get('/project/100/delete', follow_redirects=True)
-            self.assertEqual(output.status_code, 404)
+        # Add a regular user and an admin user
+        session = model.Session()
+        self.user = model.User(email='user@example.com', username='user')
+        self.admin = model.User(email='admin@example.com', username='admin')
 
-            output = c.get('/project/1/delete', follow_redirects=True)
-            self.assertEqual(output.status_code, 401)
+        # Add distributions to edit
+        self.fedora = model.Distro(name='Fedora')
+        self.centos = model.Distro(name='CentOS')
 
-        output = c.get('/projects/')
-        self.assertEqual(output.status_code, 200)
-        self.assertTrue(b'<h1>Projects monitored</h1>' in output.data)
-        self.assertEqual(output.data.count(b'<a href="/project/1'), 1)
-        self.assertEqual(output.data.count(b'<a href="/project/2'), 1)
-        self.assertEqual(output.data.count(b'<a href="/project/3'), 1)
+        session.add_all([self.user, self.admin, self.fedora, self.centos])
+        session.commit()
 
-        with self.flask_app.test_client() as c:
-            with c.session_transaction() as sess:
-                sess['openid'] = 'http://pingou.id.fedoraproject.org/'
-                sess['fullname'] = 'Pierre-Yves C.'
-                sess['nickname'] = 'pingou'
-                sess['email'] = 'pingou@pingoured.fr'
+        mock_config = mock.patch.dict(
+            model.anitya_config, {'ANITYA_WEB_ADMINS': [six.text_type(self.admin.id)]})
+        mock_config.start()
+        self.addCleanup(mock_config.stop)
 
-            output = c.get('/project/1/delete', follow_redirects=True)
-            self.assertEqual(output.status_code, 200)
-            self.assertTrue(
-                b'<h1>Delete project geany?</h1>' in output.data)
-            self.assertTrue(
-                b'<button type="submit" name="confirm" value="Yes"'
-                in output.data)
+        self.client = self.flask_app.test_client()
 
-            data = {
-                'confirm': 'Yes',
-            }
+    def test_non_admin_get(self):
+        """Assert non-admin users cannot GET the edit distribution view."""
+        with login_user(self.flask_app, self.user):
+            output = self.client.get('/distro/Fedora/edit')
+            self.assertEqual(401, output.status_code)
 
-            output = c.post(
-                '/project/1/delete', data=data, follow_redirects=True)
-            self.assertEqual(output.status_code, 200)
-            self.assertTrue(
-                b'<h1>Delete project geany?</h1>' in output.data)
-            self.assertTrue(
-                b'<button type="submit" name="confirm" value="Yes"'
-                in output.data)
+    def test_non_admin_post(self):
+        """Assert non-admin users cannot POST to the edit distribution view."""
+        with login_user(self.flask_app, self.user):
+            output = self.client.post('/distro/Fedora/edit')
+            self.assertEqual(401, output.status_code)
 
+    def test_admin_get(self):
+        """Assert admin users can get the edit distribution view."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/distro/Fedora/edit')
+            self.assertEqual(200, output.status_code)
+
+    def test_admin_post(self):
+        """Assert admin users can edit a distribution."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/distro/Fedora/edit')
             csrf_token = output.data.split(
                 b'name="csrf_token" type="hidden" value="')[1].split(b'">')[0]
+            data = {'name': 'Top', 'csrf_token': csrf_token}
 
-            data['csrf_token'] = csrf_token
-            del(data['confirm'])
+            output = self.client.post('/distro/Fedora/edit', data=data, follow_redirects=True)
+            self.assertEqual(200, output.status_code)
+            self.assertEqual(200, self.client.get('/distro/Top/edit').status_code)
 
-            output = c.post(
-                '/project/1/delete', data=data, follow_redirects=True)
-            self.assertEqual(output.status_code, 200)
-            self.assertTrue(
-                b'<h1>Project: geany</h1>' in output.data)
+    def test_missing_distro(self):
+        """Assert requesting a non-existing distro returns HTTP 404."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/distro/LFS/edit')
+            self.assertEqual(404, output.status_code)
 
-            data['confirm'] = True
+    def test_no_csrf_token(self):
+        """Assert submitting without a CSRF token results in no change."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.post('/distro/Fedora/edit', data={'name': 'Top'})
+            self.assertEqual(200, output.status_code)
+            self.assertEqual(0, model.Distro.query.filter_by(name='Top').count())
 
-            output = c.post(
-                '/project/1/delete', data=data, follow_redirects=True)
-            self.assertEqual(output.status_code, 200)
-            self.assertTrue(
-                b'<h1>Projects monitored</h1>' in output.data)
-            self.assertTrue(
-                b'<li class="list-group-item list-group-item-default">'
-                b'Project geany has been removed</li>'
-                in output.data)
-            self.assertEqual(output.data.count(b'<a href="/project/1'), 0)
-            self.assertEqual(output.data.count(b'<a href="/project/2'), 1)
-            self.assertEqual(output.data.count(b'<a href="/project/3'), 1)
+    def test_invalid_csrf_token(self):
+        """Assert submitting with an invalid CSRF token results in no change."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.post(
+                '/distro/Fedora/edit', data={'csrf_token': 'a', 'name': 'Top'})
+            self.assertEqual(200, output.status_code)
+            self.assertEqual(0, model.Distro.query.filter_by(name='Top').count())
 
-    def test_delete_project_mapping(self):
-        """ Test the delete_project_mapping function. """
-        create_distro(self.session)
-        create_project(self.session)
-        create_package(self.session)
 
-        output = self.app.get(
-            '/project/1/delete/Fedora/geany', follow_redirects=True)
-        self.assertEqual(output.status_code, 200)
-        self.assertTrue(
-            b'<ul id="flashes" class="list-group">'
-            b'<li class="list-group-item list-group-item-warning">'
-            b'Login required</li></ul>' in output.data)
+class DeleteDistroTests(DatabaseTestCase):
+    """Tests for the :func:`anitya.admin.delete_distro` view function."""
 
-        with self.flask_app.test_client() as c:
-            with c.session_transaction() as sess:
-                sess['openid'] = 'openid_url'
-                sess['fullname'] = 'Pierre-Yves C.'
-                sess['nickname'] = 'pingou'
-                sess['email'] = 'pingou@pingoured.fr'
+    def setUp(self):
+        super(DeleteDistroTests, self).setUp()
 
-            output = c.get(
-                '/project/100/delete/Fedora/geany', follow_redirects=True)
-            self.assertEqual(output.status_code, 404)
+        # Add a regular user and an admin user
+        session = model.Session()
+        self.user = model.User(email='user@example.com', username='user')
+        self.admin = model.User(email='admin@example.com', username='admin')
 
-            output = c.get(
-                '/project/1/delete/CentOS/geany', follow_redirects=True)
-            self.assertEqual(output.status_code, 404)
+        # Add distributions to delete
+        self.fedora = model.Distro(name='Fedora')
+        self.centos = model.Distro(name='CentOS')
 
-            output = c.get(
-                '/project/1/delete/Fedora/geany2', follow_redirects=True)
-            self.assertEqual(output.status_code, 404)
+        session.add_all([self.user, self.admin, self.fedora, self.centos])
+        session.commit()
 
-            output = c.get(
-                '/project/1/delete/Fedora/geany', follow_redirects=True)
-            self.assertEqual(output.status_code, 401)
+        mock_config = mock.patch.dict(
+            model.anitya_config, {'ANITYA_WEB_ADMINS': [six.text_type(self.admin.id)]})
+        mock_config.start()
+        self.addCleanup(mock_config.stop)
 
-        output = c.get('/project/1/')
-        self.assertEqual(output.status_code, 200)
-        self.assertTrue(b'<h1>Project: geany</h1>' in output.data)
-        self.assertTrue(b'<td>Fedora</td>' in output.data)
+        self.client = self.flask_app.test_client()
 
-        with self.flask_app.test_client() as c:
-            with c.session_transaction() as sess:
-                sess['openid'] = 'http://pingou.id.fedoraproject.org/'
-                sess['fullname'] = 'Pierre-Yves C.'
-                sess['nickname'] = 'pingou'
-                sess['email'] = 'pingou@pingoured.fr'
+    def test_non_admin_get(self):
+        """Assert non-admin users cannot GET the delete distribution view."""
+        with login_user(self.flask_app, self.user):
+            output = self.client.get('/distro/Fedora/delete')
+            self.assertEqual(401, output.status_code)
 
-            output = c.get('/project/1/delete/Fedora/geany', follow_redirects=True)
-            self.assertEqual(output.status_code, 200)
-            self.assertTrue(
-                b'<h1>Project: geany - Delete package</h1>' in output.data)
-            self.assertTrue(
-                b'<button type="submit" name="confirm" value="Yes"'
-                in output.data)
+    def test_non_admin_post(self):
+        """Assert non-admin users cannot POST to the delete distribution view."""
+        with login_user(self.flask_app, self.user):
+            output = self.client.post('/distro/Fedora/delete')
+            self.assertEqual(401, output.status_code)
 
-            data = {
-                'confirm': 'Yes',
-            }
+    def test_admin_get(self):
+        """Assert admin users can get the delete distribution view."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/distro/Fedora/delete')
+            self.assertEqual(200, output.status_code)
 
-            output = c.post(
-                '/project/1/delete/Fedora/geany', data=data,
-                follow_redirects=True)
-            self.assertEqual(output.status_code, 200)
-            self.assertTrue(
-                b'<h1>Project: geany - Delete package</h1>' in output.data)
-            self.assertTrue(
-                b'<button type="submit" name="confirm" value="Yes"'
-                in output.data)
-
+    def test_admin_post(self):
+        """Assert admin users can delete a distribution."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/distro/Fedora/delete')
             csrf_token = output.data.split(
                 b'name="csrf_token" type="hidden" value="')[1].split(b'">')[0]
-
-            data['csrf_token'] = csrf_token
-            del(data['confirm'])
-
-            output = c.post(
-                '/project/1/delete/Fedora/geany', data=data,
-                follow_redirects=True)
-            self.assertEqual(output.status_code, 200)
-            self.assertTrue(b'<h1>Project: geany</h1>' in output.data)
-            self.assertTrue(b'<td>Fedora</td>' in output.data)
-
-            data['confirm'] = True
-
-            output = c.post(
-                '/project/1/delete/Fedora/geany', data=data,
-                follow_redirects=True)
-            self.assertEqual(output.status_code, 200)
-            self.assertTrue(
-                b'class="list-group-item list-group-item-default">'
-                b'Mapping for geany has been removed</li>'
-                in output.data)
-            self.assertTrue(b'<h1>Project: geany</h1>' in output.data)
-            self.assertFalse(b'<td>Fedora</td>' in output.data)
-
-    def test_browse_logs(self):
-        """ Test the browse_logs function. """
-        self.test_add_distro()
-
-        output = self.app.get('/logs', follow_redirects=True)
-        self.assertEqual(output.status_code, 200)
-        self.assertTrue(
-            b'<ul id="flashes" class="list-group">'
-            b'<li class="list-group-item list-group-item-warning">'
-            b'Login required</li></ul>' in output.data)
-
-        with self.flask_app.test_client() as c:
-            with c.session_transaction() as sess:
-                sess['openid'] = 'openid_url'
-                sess['fullname'] = 'Pierre-Yves C.'
-                sess['nickname'] = 'pingou'
-                sess['email'] = 'pingou@pingoured.fr'
-
-            output = c.get('/logs', follow_redirects=True)
-            self.assertEqual(output.status_code, 200)
-
-        with self.flask_app.test_client() as c:
-            with c.session_transaction() as sess:
-                sess['openid'] = 'http://pingou.id.fedoraproject.org/'
-                sess['fullname'] = 'Pierre-Yves C.'
-                sess['nickname'] = 'pingou'
-                sess['email'] = 'pingou@pingoured.fr'
-
-            output = c.get('/logs')
-            self.assertEqual(output.status_code, 200)
-            self.assertTrue(b'<h1>Logs</h1>' in output.data)
-            self.assertTrue(b'added the distro named: Debian' in output.data)
-
-            output = c.get('/logs?page=abc&limit=def&from_date=ghi')
-            self.assertEqual(output.status_code, 200)
-            self.assertTrue(b'<h1>Logs</h1>' in output.data)
-            self.assertTrue(b'added the distro named: Debian' in output.data)
-
-            output = c.get('/logs?from_date=%s' % datetime.datetime.utcnow().date())
-            self.assertEqual(output.status_code, 200)
-            self.assertTrue(b'<h1>Logs</h1>' in output.data)
-            self.assertTrue(b'added the distro named: Debian' in output.data)
-
-            # the Debian log shouldn't show up if the "from date" is tomorrow
-            tomorrow = datetime.datetime.utcnow().date() + datetime.timedelta(days=1)
-            output = c.get('/logs?from_date=%s' % tomorrow)
-            self.assertEqual(output.status_code, 200)
-            self.assertTrue(b'<h1>Logs</h1>' in output.data)
-            self.assertFalse(b'added the distro named: Debian' in output.data)
-
-    def test_browse_flags(self):
-        """ Test the browse_flags function. """
-
-        create_flagged_project(self.session)
-
-        output = self.app.get('/flags', follow_redirects=True)
-        self.assertEqual(output.status_code, 200)
-        self.assertTrue(
-            b'<ul id="flashes" class="list-group">'
-            b'<li class="list-group-item list-group-item-warning">'
-            b'Login required</li></ul>' in output.data)
-
-        with self.flask_app.test_client() as c:
-            with c.session_transaction() as sess:
-                sess['openid'] = 'openid_url'
-                sess['fullname'] = 'Pierre-Yves C.'
-                sess['nickname'] = 'pingou'
-                sess['email'] = 'pingou@pingoured.fr'
-
-            output = c.get('/flags', follow_redirects=True)
-            self.assertEqual(output.status_code, 401)
-
-        with self.flask_app.test_client() as c:
-            with c.session_transaction() as sess:
-                sess['openid'] = 'http://pingou.id.fedoraproject.org/'
-                sess['fullname'] = 'Pierre-Yves C.'
-                sess['nickname'] = 'pingou'
-                sess['email'] = 'pingou@pingoured.fr'
-
-            output = c.get('/flags')
-            self.assertEqual(output.status_code, 200)
-            self.assertTrue(b'<h1>Flags</h1>' in output.data)
-            self.assertTrue(b'geany' in output.data)
-
-            output = c.get('/flags?page=abc&limit=def&from_date=ghi')
-            self.assertEqual(output.status_code, 200)
-            self.assertTrue(b'<h1>Flags</h1>' in output.data)
-            self.assertTrue(b'geany' in output.data)
-
-            output = c.get('/flags?from_date=%s' % datetime.datetime.utcnow().date())
-            self.assertEqual(output.status_code, 200)
-            self.assertTrue(b'<h1>Flags</h1>' in output.data)
-            self.assertTrue(b'geany' in output.data)
-
-            # geany shouldn't show up if the "from date" is tomorrow
-            tomorrow = datetime.datetime.utcnow().date() + datetime.timedelta(days=1)
-            output = c.get('/flags?from_date=%s' % tomorrow)
-            self.assertEqual(output.status_code, 200)
-            self.assertTrue(b'<h1>Flags</h1>' in output.data)
-            self.assertFalse(b'geany' in output.data)
-
-            output = c.get('/flags?from_date=%s&project=geany' % datetime.datetime.utcnow().date())
-            self.assertEqual(output.status_code, 200)
-            self.assertTrue(b'<h1>Flags</h1>' in output.data)
-            self.assertTrue(b'geany' in output.data)
-
-    def test_flag_project(self):
-        """ Test setting the flag state of a project. """
-
-        flag = create_flagged_project(self.session)
-
-        project = model.Project.by_name(self.session, 'geany')[0]
-        self.assertEqual(len(project.flags), 1)
-        self.assertEqual(project.flags[0].state, 'open')
-
-        with self.flask_app.test_client() as c:
-            with c.session_transaction() as sess:
-                sess['openid'] = 'some_invalid_openid_url'
-                sess['fullname'] = 'Pierre-Yves C.'
-                sess['nickname'] = 'pingou'
-                sess['email'] = 'pingou@pingoured.fr'
-
-            output = c.post('/flags/{0}/set/closed'.format(flag.id),
-                            follow_redirects=True)
-
-            # Non-admin ID will complain, insufficient creds
-            self.assertEqual(output.status_code, 401)
-
-        # Nothing should have changed.
-        project = model.Project.by_name(self.session, 'geany')[0]
-        self.assertEqual(len(project.flags), 1)
-        self.assertEqual(project.flags[0].state, 'open')
-
-        self.assertEqual(flag.state, 'open')
-
-        with self.flask_app.test_client() as c:
-            with c.session_transaction() as sess:
-                sess['openid'] = 'http://pingou.id.fedoraproject.org/'
-                sess['fullname'] = 'Pierre-Yves C.'
-                sess['nickname'] = 'pingou'
-                sess['email'] = 'pingou@pingoured.fr'
-
-            output = c.post('/flags/{0}/set/closed'.format(flag.id),
-                            follow_redirects=True)
-            self.assertEqual(output.status_code, 200)
-
-            # Now the flag state should *not* have toggled because while we did
-            # provide a valid admin openid, we did not provide a CSRF token.
-            project = model.Project.by_name(self.session, 'geany')[0]
-            self.assertEqual(len(project.flags), 1)
-            self.assertEqual(project.flags[0].state, 'open')
-
-            # Go ahead and get the csrf token from the page and try again.
-            data = {}
-
-            csrf_token = output.data.split(
-                b'name="csrf_token" type="hidden" value="')[1].split(b'">')[0]
-
-            data['csrf_token'] = csrf_token
-
-            output = c.post('/flags/{0}/set/closed'.format(flag.id),
-                            data=data,
-                            follow_redirects=True)
-            self.assertEqual(output.status_code, 200)
-
-        # Now the flag state should have toggled.
-        project = model.Project.by_name(self.session, 'geany')[0]
-        self.assertEqual(len(project.flags), 1)
-        self.assertEqual(project.flags[0].state, 'closed')
-
-        with self.flask_app.test_client() as c:
-            with c.session_transaction() as sess:
-                sess['openid'] = 'http://pingou.id.fedoraproject.org/'
-                sess['fullname'] = 'Pierre-Yves C.'
-                sess['nickname'] = 'pingou'
-                sess['email'] = 'pingou@pingoured.fr'
-
-            output = c.post('/flags/{0}/set/open'.format(flag.id),
-                            follow_redirects=True)
-
-            # Get a new CSRF Token
-            output = c.get('/distro/add')
-            csrf_token = output.data.split(
-                b'name="csrf_token" type="hidden" value="')[1].split(b'">')[0]
-
-            # Grab the CSRF token again so we can toggle the flag again
             data = {'csrf_token': csrf_token}
 
-            output = c.post('/flags/{0}/set/open'.format(flag.id),
-                            data=data,
-                            follow_redirects=True)
-            self.assertEqual(output.status_code, 200)
+            output = self.client.post('/distro/Fedora/delete', data=data, follow_redirects=True)
+            self.assertEqual(200, output.status_code)
+            self.assertEqual(404, self.client.get('/distro/Fedora/delete').status_code)
 
-        # Make sure we can toggle the flag again.
-        project = model.Project.by_name(self.session, 'geany')[0]
-        self.assertEqual(len(project.flags), 1)
-        self.assertEqual(project.flags[0].state, 'open')
+    def test_missing_distro(self):
+        """Assert requesting a non-existing distro returns HTTP 404."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/distro/LFS/delete')
+            self.assertEqual(404, output.status_code)
 
-        with self.flask_app.test_client() as c:
-            with c.session_transaction() as sess:
-                sess['openid'] = 'http://pingou.id.fedoraproject.org/'
-                sess['fullname'] = 'Pierre-Yves C.'
-                sess['nickname'] = 'pingou'
-                sess['email'] = 'pingou@pingoured.fr'
+    def test_no_csrf_token(self):
+        """Assert submitting without a CSRF token results in no change."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.post('/distro/Fedora/delete', data={})
+            self.assertEqual(200, output.status_code)
+            self.assertEqual(1, model.Distro.query.filter_by(name='Fedora').count())
 
-            output = c.post('/flags/{0}/set/nonsense'.format(flag.id),
-                            follow_redirects=True)
-            self.assertEqual(output.status_code, 422)
-
-        # Make sure that passing garbage doesn't change anything.
-        project = model.Project.by_name(self.session, 'geany')[0]
-        self.assertEqual(len(project.flags), 1)
-        self.assertEqual(project.flags[0].state, 'open')
+    def test_invalid_csrf_token(self):
+        """Assert submitting with an invalid CSRF token results in no change."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.post('/distro/Fedora/delete', data={'csrf_token': 'a'})
+            self.assertEqual(200, output.status_code)
+            self.assertEqual(1, model.Distro.query.filter_by(name='Fedora').count())
 
 
-if __name__ == '__main__':
-    SUITE = unittest.TestLoader().loadTestsFromTestCase(FlaskAdminTest)
-    unittest.TextTestRunner(verbosity=2).run(SUITE)
+class DeleteProjectTests(DatabaseTestCase):
+    """Tests for the :func:`anitya.admin.delete_projects` view function."""
+
+    def setUp(self):
+        super(DeleteProjectTests, self).setUp()
+        self.project = model.Project(
+            name='test_project',
+            homepage='https://example.com/test_project',
+            backend='PyPI',
+        )
+
+        # Add a regular user and an admin user
+        session = model.Session()
+        self.user = model.User(email='user@example.com', username='user')
+        self.admin = model.User(email='admin@example.com', username='admin')
+
+        session.add_all([self.user, self.admin, self.project])
+        session.commit()
+
+        mock_config = mock.patch.dict(
+            model.anitya_config, {'ANITYA_WEB_ADMINS': [six.text_type(self.admin.id)]})
+        mock_config.start()
+        self.addCleanup(mock_config.stop)
+
+        self.client = self.flask_app.test_client()
+
+    def test_non_admin_get(self):
+        """Assert non-admin users cannot GET the delete project view."""
+        with login_user(self.flask_app, self.user):
+            output = self.client.get('/project/{0}/delete'.format(self.project.id))
+            self.assertEqual(401, output.status_code)
+
+    def test_non_admin_post(self):
+        """Assert non-admin users cannot POST to the delete project view."""
+        with login_user(self.flask_app, self.user):
+            output = self.client.post('/project/{0}/delete'.format(self.project.id))
+            self.assertEqual(401, output.status_code)
+
+    def test_missing_project(self):
+        """Assert HTTP 404 is returned if the project doesn't exist."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.post('/project/42/delete')
+            self.assertEqual(404, output.status_code)
+
+    def test_admin_get(self):
+        """Assert admin users can get the delete project view."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/project/{0}/delete'.format(self.project.id))
+            self.assertEqual(200, output.status_code)
+
+    def test_admin_post(self):
+        """Assert admin users can delete projects."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/project/{0}/delete'.format(self.project.id))
+            csrf_token = output.data.split(
+                b'name="csrf_token" type="hidden" value="')[1].split(b'">')[0]
+            data = {'confirm': True, 'csrf_token': csrf_token}
+
+            output = self.client.post(
+                '/project/{0}/delete'.format(self.project.id), data=data, follow_redirects=True)
+
+            self.assertEqual(200, output.status_code)
+            self.assertEqual(0, len(model.Project.query.all()))
+
+    def test_admin_post_unconfirmed(self):
+        """Assert admin users must confirm deleting projects."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/project/{0}/delete'.format(self.project.id))
+            csrf_token = output.data.split(
+                b'name="csrf_token" type="hidden" value="')[1].split(b'">')[0]
+            data = {'csrf_token': csrf_token}
+
+            output = self.client.post('/project/{0}/delete'.format(self.project.id), data=data)
+
+            self.assertEqual(302, output.status_code)
+            self.assertEqual(1, len(model.Project.query.all()))
+
+
+class DeleteProjectMappingTests(DatabaseTestCase):
+    """Tests for the :func:`anitya.admin.delete_project_mapping` view."""
+
+    def setUp(self):
+        super(DeleteProjectMappingTests, self).setUp()
+        self.project = model.Project(
+            name='test_project',
+            homepage='https://example.com/test_project',
+            backend='PyPI',
+        )
+        self.distro = model.Distro(name='Fedora')
+        self.package = model.Packages(
+            distro=self.distro.name, project=self.project, package_name='test-project')
+
+        # Add a regular user and an admin user
+        session = model.Session()
+        self.user = model.User(email='user@example.com', username='user')
+        self.admin = model.User(email='admin@example.com', username='admin')
+
+        session.add_all([self.user, self.admin, self.distro, self.project, self.package])
+        session.commit()
+
+        mock_config = mock.patch.dict(
+            model.anitya_config, {'ANITYA_WEB_ADMINS': [six.text_type(self.admin.id)]})
+        mock_config.start()
+        self.addCleanup(mock_config.stop)
+
+        self.client = self.flask_app.test_client()
+
+    def test_non_admin_get(self):
+        """Assert non-admin users cannot GET the delete project mapping view."""
+        with login_user(self.flask_app, self.user):
+            output = self.client.get('/project/1/delete/Fedora/test-project')
+            self.assertEqual(401, output.status_code)
+
+    def test_non_admin_post(self):
+        """Assert non-admin users cannot POST to the delete project mapping view."""
+        with login_user(self.flask_app, self.user):
+            output = self.client.post('/project/1/delete/Fedora/test-project')
+            self.assertEqual(401, output.status_code)
+
+    def test_admin_get(self):
+        """Assert admin users can GET the delete project mapping view."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/project/1/delete/Fedora/test-project')
+            self.assertEqual(200, output.status_code)
+
+    def test_missing_project(self):
+        """Assert HTTP 404 is returned if the project doesn't exist."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/project/42/delete/Fedora/test-project')
+            self.assertEqual(404, output.status_code)
+
+    def test_missing_distro(self):
+        """Assert HTTP 404 is returned if the distro doesn't exist."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/project/1/delete/LFS/test-project')
+            self.assertEqual(404, output.status_code)
+
+    def test_missing_package(self):
+        """Assert HTTP 404 is returned if the package doesn't exist."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/project/1/delete/Fedora/some-package')
+            self.assertEqual(404, output.status_code)
+
+    def test_admin_post(self):
+        """Assert admin users can delete project mappings."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/project/1/delete/Fedora/test-project')
+            csrf_token = output.data.split(
+                b'name="csrf_token" type="hidden" value="')[1].split(b'">')[0]
+            data = {'confirm': True, 'csrf_token': csrf_token}
+
+            output = self.client.post(
+                '/project/1/delete/Fedora/test-project', data=data, follow_redirects=True)
+
+            self.assertEqual(200, output.status_code)
+            self.assertEqual(0, len(model.Packages.query.all()))
+
+    def test_admin_post_unconfirmed(self):
+        """Assert failing to confirm the action results in no change."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/project/1/delete/Fedora/test-project')
+            csrf_token = output.data.split(
+                b'name="csrf_token" type="hidden" value="')[1].split(b'">')[0]
+            data = {'csrf_token': csrf_token}
+
+            output = self.client.post(
+                '/project/1/delete/Fedora/test-project', data=data, follow_redirects=True)
+
+            self.assertEqual(200, output.status_code)
+            self.assertEqual(1, len(model.Packages.query.all()))
+
+
+class DeleteProjectVersionTests(DatabaseTestCase):
+    """Tests for the :func:`anitya.admin.delete_project_version` view."""
+
+    def setUp(self):
+        super(DeleteProjectVersionTests, self).setUp()
+        session = model.Session()
+
+        # Add a project with a version to delete.
+        self.project = model.Project(
+            name='test_project',
+            homepage='https://example.com/test_project',
+            backend='PyPI',
+        )
+        self.project_version = model.ProjectVersion(project=self.project, version='1.0.0')
+
+        # Add a regular user and an admin user
+        self.user = model.User(email='user@example.com', username='user')
+        self.admin = model.User(email='admin@example.com', username='admin')
+
+        session.add_all([self.user, self.admin, self.project, self.project_version])
+        session.commit()
+
+        mock_config = mock.patch.dict(
+            model.anitya_config, {'ANITYA_WEB_ADMINS': [six.text_type(self.admin.id)]})
+        mock_config.start()
+        self.addCleanup(mock_config.stop)
+
+        self.client = self.flask_app.test_client()
+
+    def test_non_admin_get(self):
+        """Assert non-admin users cannot GET the delete project version view."""
+        with login_user(self.flask_app, self.user):
+            output = self.client.get('/project/1/delete/1.0.0')
+            self.assertEqual(401, output.status_code)
+
+    def test_non_admin_post(self):
+        """Assert non-admin users cannot POST to the delete project mapping view."""
+        with login_user(self.flask_app, self.user):
+            output = self.client.post('/project/1/delete/1.0.0')
+            self.assertEqual(401, output.status_code)
+
+    def test_admin_get(self):
+        """Assert admin users can GET the delete project mapping view."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/project/1/delete/1.0.0')
+            self.assertEqual(200, output.status_code)
+
+    def test_missing_project(self):
+        """Assert HTTP 404 is returned if the project doesn't exist."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/project/42/delete/1.0.0')
+            self.assertEqual(404, output.status_code)
+
+    def test_missing_version(self):
+        """Assert HTTP 404 is returned if the project doesn't exist."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/project/42/delete/9.9.9')
+            self.assertEqual(404, output.status_code)
+
+    def test_admin_post(self):
+        """Assert admin users can delete project mappings."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/project/1/delete/1.0.0')
+            csrf_token = output.data.split(
+                b'name="csrf_token" type="hidden" value="')[1].split(b'">')[0]
+            data = {'confirm': True, 'csrf_token': csrf_token}
+
+            output = self.client.post('/project/1/delete/1.0.0', data=data, follow_redirects=True)
+            self.assertEqual(200, output.status_code)
+            self.assertEqual(0, len(model.ProjectVersion.query.all()))
+
+    def test_admin_post_unconfirmed(self):
+        """Assert failing to confirm the action results in no change."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/project/1/delete/1.0.0')
+            csrf_token = output.data.split(
+                b'name="csrf_token" type="hidden" value="')[1].split(b'">')[0]
+            data = {'csrf_token': csrf_token}
+
+            output = self.client.post('/project/1/delete/1.0.0', data=data)
+            self.assertEqual(302, output.status_code)
+            self.assertEqual(1, len(model.ProjectVersion.query.all()))
+
+
+class BrowseLogsTests(DatabaseTestCase):
+    """Tests for the :func:`anitya.admin.browse_logs` view function."""
+
+    def setUp(self):
+        super(BrowseLogsTests, self).setUp()
+        session = model.Session()
+
+        # Add a regular user and an admin user
+        self.user = model.User(email='user@example.com', username='user')
+        self.admin = model.User(email='admin@example.com', username='admin')
+
+        self.user_log = model.Log(
+            user='user@example.com',
+            project='relational_db',
+            distro='Fedora',
+            description='This is a log',
+        )
+        self.admin_log = model.Log(
+            user='admin',
+            project='best_project',
+            distro='CentOS',
+            description='This is also a log',
+        )
+
+        session.add_all([self.user, self.admin, self.user_log, self.admin_log])
+        session.commit()
+
+        mock_config = mock.patch.dict(
+            model.anitya_config, {'ANITYA_WEB_ADMINS': [six.text_type(self.admin.id)]})
+        mock_config.start()
+        self.addCleanup(mock_config.stop)
+
+        self.client = self.flask_app.test_client()
+
+    def test_non_admin_get(self):
+        """Assert non-admin users get only their own logs."""
+        with login_user(self.flask_app, self.user):
+            output = self.client.get('/logs')
+
+            self.assertEqual(200, output.status_code)
+            self.assertTrue(b'This is a log' in output.data)
+            self.assertFalse(b'This is also a log' in output.data)
+
+    def test_admin_get(self):
+        """Assert admin users can get everyone's logs."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/logs')
+
+            self.assertEqual(200, output.status_code)
+            self.assertTrue(b'This is a log' in output.data)
+            self.assertTrue(b'This is also a log' in output.data)
+
+    def test_from_date(self):
+        """Assert logs can be filtered via a from_date."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/logs?from_date=2017-07-19')
+
+            self.assertEqual(200, output.status_code)
+            self.assertTrue(b'This is a log' in output.data)
+            self.assertTrue(b'This is also a log' in output.data)
+
+    def test_from_date_future(self):
+        """Assert when the from_date doesn't include logs, none are returned."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/logs?from_date=2500-07-01')
+
+            self.assertEqual(200, output.status_code)
+            self.assertFalse(b'This is a log' in output.data)
+            self.assertFalse(b'This is also a log' in output.data)
+
+
+class BrowseFlagsTests(DatabaseTestCase):
+    """Tests for the :func:`anitya.admin.browse_flags` view function."""
+
+    def setUp(self):
+        super(BrowseFlagsTests, self).setUp()
+        session = model.Session()
+
+        # Add a regular user and an admin user
+        self.user = model.User(email='user@example.com', username='user')
+        self.admin = model.User(email='admin@example.com', username='admin')
+
+        self.project1 = model.Project(
+            name='test_project', homepage='https://example.com/test_project', backend='PyPI')
+        self.project2 = model.Project(
+            name='project2', homepage='https://example.com/project2', backend='PyPI')
+        self.flag1 = model.ProjectFlag(
+            reason='I wanted to flag it', user='user', project=self.project1)
+        self.flag2 = model.ProjectFlag(
+            reason='This project is wrong', user='user', project=self.project2)
+
+        session.add_all(
+            [self.user, self.admin, self.project1, self.project2, self.flag1, self.flag2])
+        session.commit()
+
+        mock_config = mock.patch.dict(
+            model.anitya_config, {'ANITYA_WEB_ADMINS': [six.text_type(self.admin.id)]})
+        mock_config.start()
+        self.addCleanup(mock_config.stop)
+
+        self.client = self.flask_app.test_client()
+
+    def test_non_admin_get(self):
+        """Assert non-admin users can't see flags."""
+        with login_user(self.flask_app, self.user):
+            output = self.client.get('/flags')
+            self.assertEqual(401, output.status_code)
+
+    def test_admin_get(self):
+        """Assert admin users can see the flags."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/flags')
+
+            self.assertEqual(200, output.status_code)
+            self.assertTrue(b'I wanted to flag it' in output.data)
+            self.assertTrue(b'This project is wrong' in output.data)
+
+    def test_pages(self):
+        """Assert admin users can see the flags."""
+        with login_user(self.flask_app, self.admin):
+            page_one = self.client.get('/flags?limit=1&page=1')
+
+            self.assertEqual(200, page_one.status_code)
+            self.assertTrue(
+                b'I wanted to flag it' in page_one.data or
+                b'This project is wrong' in page_one.data
+            )
+            self.assertFalse(
+                b'I wanted to flag it' in page_one.data and
+                b'This project is wrong' in page_one.data
+            )
+
+    def test_from_date(self):
+        """Assert admin users can see the flags."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/flags?from_date=2017-07-01')
+
+            self.assertEqual(200, output.status_code)
+            self.assertTrue(b'I wanted to flag it' in output.data)
+            self.assertTrue(b'This project is wrong' in output.data)
+
+    def test_from_date_future(self):
+        """Assert admin users can see the flags."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/flags?from_date=2200-07-01')
+
+            self.assertEqual(200, output.status_code)
+            self.assertFalse(b'I wanted to flag it' in output.data)
+            self.assertFalse(b'This project is wrong' in output.data)
+
+
+class SetFlagStateTests(DatabaseTestCase):
+    """Tests for the :func:`anitya.admin.set_flag_state` view function."""
+
+    def setUp(self):
+        super(SetFlagStateTests, self).setUp()
+        session = model.Session()
+
+        # Add a regular user and an admin user
+        self.user = model.User(email='user@example.com', username='user')
+        self.admin = model.User(email='admin@example.com', username='admin')
+
+        self.project1 = model.Project(
+            name='test_project', homepage='https://example.com/test_project', backend='PyPI')
+        self.project2 = model.Project(
+            name='project2', homepage='https://example.com/project2', backend='PyPI')
+        self.flag1 = model.ProjectFlag(
+            reason='I wanted to flag it', user='user', project=self.project1)
+        self.flag2 = model.ProjectFlag(
+            reason='This project is wrong', user='user', project=self.project2)
+
+        session.add_all(
+            [self.user, self.admin, self.project1, self.project2, self.flag1, self.flag2])
+        session.commit()
+
+        mock_config = mock.patch.dict(
+            model.anitya_config, {'ANITYA_WEB_ADMINS': [six.text_type(self.admin.id)]})
+        mock_config.start()
+        self.addCleanup(mock_config.stop)
+
+        self.client = self.flask_app.test_client()
+
+    def test_non_admin_post(self):
+        """Assert non-admin users can't set flags."""
+        with login_user(self.flask_app, self.user):
+            output = self.client.post('/flags/1/set/closed')
+            self.assertEqual(401, output.status_code)
+
+    def test_bad_state(self):
+        """Assert an invalid stat results in HTTP 422."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.post('/flags/1/set/deferred')
+            self.assertEqual(422, output.status_code)
+
+    def test_missing(self):
+        """Assert trying to set the state of a non-existent flag results in HTTP 404."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.post('/flags/42/set/closed')
+            self.assertEqual(404, output.status_code)
+
+    def test_set_flag(self):
+        """Assert trying to set the state of a non-existent flag results in HTTP 404."""
+        with login_user(self.flask_app, self.admin):
+            output = self.client.get('/flags')
+            csrf_token = output.data.split(
+                b'name="csrf_token" type="hidden" value="')[1].split(b'">')[0]
+
+            output = self.client.post(
+                '/flags/1/set/closed', data={'csrf_token': csrf_token}, follow_redirects=True)
+
+            self.assertEqual(200, output.status_code)
+            self.assertTrue(b'Flag 1 set to closed' in output.data)

--- a/anitya/tests/test_flask_admin.py
+++ b/anitya/tests/test_flask_admin.py
@@ -124,8 +124,6 @@ class AddDistroTests(DatabaseTestCase):
             create_output = self.client.post('/distro/add', data=data, follow_redirects=True)
             dup_output = self.client.post('/distro/add', data=data, follow_redirects=True)
 
-            # self.assertEqual(201, create_output.status_code)
-            # self.assertEqual(409, dup_output.status_code)
             self.assertTrue(b'Distribution added' in create_output.data)
             self.assertTrue(b'Could not add this distro' in dup_output.data)
 

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -389,7 +389,7 @@ def new_project():
                 version_url=form.version_url.data.strip() or None,
                 version_prefix=form.version_prefix.data.strip() or None,
                 regex=form.regex.data.strip() or None,
-                user_id=flask.g.auth.openid,
+                user_id=flask.g.user.username,
                 check_release=form.check_release.data,
             )
             SESSION.commit()
@@ -401,7 +401,7 @@ def new_project():
                     project=project,
                     package_name=form.package_name.data,
                     distribution=form.distro.data,
-                    user_id=flask.g.auth.openid,
+                    user_id=flask.g.user.username,
                 )
                 SESSION.commit()
 
@@ -457,7 +457,7 @@ def edit_project(project_id):
                 version_prefix=form.version_prefix.data.strip(),
                 regex=form.regex.data.strip(),
                 insecure=form.insecure.data,
-                user_id=flask.g.auth.openid,
+                user_id=flask.g.user.username,
                 check_release=form.check_release.data,
             )
             flask.flash('Project edited')
@@ -496,8 +496,8 @@ def flag_project(project_id):
                 SESSION,
                 project=project,
                 reason=form.reason.data,
-                user_email=flask.g.auth.email,
-                user_id=flask.g.auth.openid,
+                user_email=flask.g.user.email,
+                user_id=flask.g.user.username,
             )
             flask.flash('Project flagged for admin review')
         except anitya.lib.exceptions.AnityaException as err:
@@ -538,7 +538,7 @@ def map_project(project_id):
                 project=project,
                 package_name=form.package_name.data.strip(),
                 distribution=form.distro.data.strip(),
-                user_id=flask.g.auth.openid,
+                user_id=flask.g.user.username,
             )
             SESSION.commit()
             flask.flash('Mapping added')
@@ -582,7 +582,7 @@ def edit_project_mapping(project_id, pkg_id):
                 project=project,
                 package_name=form.package_name.data,
                 distribution=form.distro.data,
-                user_id=flask.g.auth.openid,
+                user_id=flask.g.user.username,
                 old_package_name=package.package_name,
                 old_distro_name=package.distro,
             )

--- a/ansible/roles/anitya-dev/files/anitya.toml
+++ b/ansible/roles/anitya-dev/files/anitya.toml
@@ -8,10 +8,7 @@ db_url = 'postgresql://postgres:anypasswordworkslocally@localhost/anitya'
 
 # A set of booleans to enable or disable OpenID providers
 anitya_web_fedora_openid = "https://id.fedoraproject.org"
-anitya_web_allow_fas_openid = true
-anitya_web_allow_google_openid = true
-anitya_web_allow_yahoo_openid = true
-anitya_web_allow_generic_openid = true
+social_auth_redirect_is_https = false
 
 blacklisted_users = []
 

--- a/requirements/el7-requirements.txt
+++ b/requirements/el7-requirements.txt
@@ -1,6 +1,7 @@
 # Requirements that are pinned to the library versions available in EL7
 alembic == 0.8.3
 bunch == 1.0.1
+blinker
 python-dateutil == 1.5
 fedmsg == 0.18.2
 Flask == 0.10.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,6 +6,9 @@ flask-openid
 # Need the fixes for https://github.com/puiterwijk/flask-oidc/issues/12
 #                and https://github.com/puiterwijk/flask-oidc/issues/24
 flask-oidc >= 1.1.1
+flask-login
+social-auth-app-flask
+social-auth-app-flask-sqlalchemy
 flask-restful
 flask-wtf
 jinja2 >= 2.4

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,5 @@
 alembic
+blinker
 bunch
 python-dateutil
 fedmsg

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -1,3 +1,4 @@
+blinker
 coverage
 flake8
 pytest


### PR DESCRIPTION
This is still very much a work in progress, but just in case people are interested in what I've been up to...

This adds users via python-social-auth and starts using flask-login to manage logins. It _also_ includes API tokens. What it doesn't include is a tidy login page, a UI for generating API tokens, or a way to blacklist users.

Early feedback very much appreciated 😃