### PR TITLE
Add a basic v2 API for packages

### DIFF
--- a/anitya/app.py
+++ b/anitya/app.py
@@ -73,6 +73,7 @@ def create(config=None):
     # Register the v2 API resources
     app.api = Api(app)
     app.api.add_resource(api_v2.ProjectsResource, '/api/v2/projects/')
+    app.api.add_resource(api_v2.PackagesResource, '/api/v2/packages/')
 
     # Register all the view blueprints
     app.register_blueprint(ui.ui_blueprint)

--- a/anitya/authentication.py
+++ b/anitya/authentication.py
@@ -80,7 +80,10 @@ def load_user_from_request(request):
     api_key = request.headers.get('Authorization')
     if api_key:
         _log.debug('Attempting to authenticate via user-provided "Authorization" header')
-        key_type, key_value = api_key.split()
+        try:
+            key_type, key_value = api_key.split()
+        except ValueError:
+            return
         if key_type.lower() == 'token':
             try:
                 api_token = ApiToken.query.filter_by(token=key_value).one()

--- a/anitya/db/__init__.py
+++ b/anitya/db/__init__.py
@@ -25,3 +25,4 @@ from .meta import initialize, Session, Base, Page, BaseQuery  # noqa: F401
 from .models import (  # noqa: F401
     Log, Distro, Packages, Project, ProjectVersion, ProjectFlag, Run, User, ApiToken
 )
+from .events import set_ecosystem  # noqa: F401

--- a/anitya/db/events.py
+++ b/anitya/db/events.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of the Anitya project.
+# Copyright © 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions
+# of the GNU General Public License v.2, or (at your option) any later
+# version.  This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.  You
+# should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+"""This module contains functions that are triggered by SQLAlchemy events."""
+import logging
+
+from sqlalchemy import event
+
+from anitya.lib import plugins
+from .meta import Session
+from .models import Project
+
+
+_log = logging.getLogger(__name__)
+
+
+@event.listens_for(Session, 'before_flush')
+def set_ecosystem(session, flush_context, instances):
+    """
+    An SQLAlchemy event listener that sets the ecosystem for a project if it's null.
+
+    Args:
+        session (sqlalchemy.orm.session.Session): The session that is about to be committed.
+        flush_context (sqlalchemy.orm.session.UOWTransaction): Unused.
+        instances (object): deprecated and unused
+
+    Raises:
+        ValueError: If the ecosystem_name isn't valid.
+    """
+    for new_obj in session.new:
+        if isinstance(new_obj, Project):
+            if new_obj.ecosystem_name is None:
+                ecosystems = [e for e in plugins.ECOSYSTEM_PLUGINS.get_plugins()
+                              if e.default_backend == new_obj.backend]
+                if ecosystems:
+                    new_obj.ecosystem_name = ecosystems[0].name
+                else:
+                    new_obj.ecosystem_name = new_obj.homepage
+                _log.info('Settings the ecosystem on %r to %s by default',
+                          new_obj, new_obj.ecosystem_name)
+            else:
+                # Validate the field
+                valid_names = [e.name for e in plugins.ECOSYSTEM_PLUGINS.get_plugins()]
+                valid_names.append(new_obj.homepage)
+                if new_obj.ecosystem_name not in valid_names:
+                    raise ValueError('Invalid ecosystem_name "{}", must be one of {}'.format(
+                        new_obj.ecosystem_name, valid_names))

--- a/anitya/db/migrations/versions/34b9bb5fa388_make_ecosystem_non_nullable.py
+++ b/anitya/db/migrations/versions/34b9bb5fa388_make_ecosystem_non_nullable.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of the Anitya project.
+# Copyright © 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions
+# of the GNU General Public License v.2, or (at your option) any later
+# version.  This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.  You
+# should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+"""
+Make ecosystem non-nullable.
+
+Revision ID: 34b9bb5fa388
+Revises: 3fae8239eeec
+Create Date: 2018-01-15 22:10:34.624110
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '34b9bb5fa388'
+down_revision = '3fae8239eeec'
+
+
+def upgrade():
+    """Make the ecosystem_name non-nullable after setting null instances to the homepage."""
+    op.execute("""
+        UPDATE projects
+        SET ecosystem_name=homepage
+        WHERE ecosystem_name IS NULL
+    """)
+    op.alter_column(
+        'projects', 'ecosystem_name', existing_type=sa.VARCHAR(length=200), nullable=False)
+
+
+def downgrade():
+    """Make the ecosystem_name nullable."""
+    op.alter_column(
+        'projects', 'ecosystem_name', existing_type=sa.VARCHAR(length=200), nullable=True)
+    op.execute("""
+        UPDATE projects
+        SET ecosystem_name=NULL
+        WHERE ecosystem_name=homepage
+    """)

--- a/anitya/db/models.py
+++ b/anitya/db/models.py
@@ -329,7 +329,7 @@ class Project(Base):
     homepage = sa.Column(sa.String(200), nullable=False)
 
     backend = sa.Column(sa.String(200), default='custom')
-    ecosystem_name = sa.Column(sa.String(200), nullable=True, index=True)
+    ecosystem_name = sa.Column(sa.String(200), nullable=False, index=True)
     version_url = sa.Column(sa.String(200), nullable=True)
     regex = sa.Column(sa.String(200), nullable=True)
     version_prefix = sa.Column(sa.String(200), nullable=True)
@@ -355,12 +355,6 @@ class Project(Base):
     def validate_backend(self, key, value):
         if value not in BACKEND_PLUGINS.get_plugin_names():
             raise ValueError('Backend "{}" is not supported.'.format(value))
-        return value
-
-    @validates('ecosystem_name')
-    def validate_ecosystem_name(self, key, value):
-        if value and value not in ECOSYSTEM_PLUGINS.get_plugin_names():
-            raise ValueError('Ecosystem "{}" is not supported.'.format(value))
         return value
 
     @property

--- a/anitya/lib/utilities.py
+++ b/anitya/lib/utilities.py
@@ -244,16 +244,10 @@ def create_project(
     """ Create the project in the database.
 
     """
-    # Set the ecosystem if there's one associated with the given backend
-    ecosystems = [e for e in plugins.ECOSYSTEM_PLUGINS.get_plugins()
-                  if e.default_backend == backend]
-    ecosystem_name = ecosystems[0].name if len(ecosystems) == 1 else None
-
     project = models.Project(
         name=name,
         homepage=homepage,
         backend=backend,
-        ecosystem_name=ecosystem_name,
         version_url=version_url,
         regex=regex,
         version_prefix=version_prefix,

--- a/anitya/tests/db/test_events.py
+++ b/anitya/tests/db/test_events.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of the Anitya project.
+# Copyright © 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions
+# of the GNU General Public License v.2, or (at your option) any later
+# version.  This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.  You
+# should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# Any Red Hat trademarks that are incorporated in the source
+# code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission
+# of Red Hat, Inc.
+"""Tests for the :mod:`anitya.db.events` module."""
+
+from anitya.db import models, Session
+from anitya.tests.base import DatabaseTestCase
+
+
+class SetEcosystemTests(DatabaseTestCase):
+
+    def test_set_manually(self):
+        """Assert the ecosystem can be set manually."""
+        project = models.Project(
+            name='requests',
+            homepage='https://pypi.org/requests',
+            ecosystem_name='crates.io',
+            backend='PyPI',
+        )
+
+        Session.add(project)
+        Session.commit()
+
+        project = models.Project.query.all()[0]
+        self.assertEqual('crates.io', project.ecosystem_name)
+
+    def test_set_automatically(self):
+        """Assert the ecosystem gets set automatically based on the backend."""
+        project = models.Project(
+            name='requests',
+            homepage='https://pypi.org/requests',
+            backend='PyPI',
+        )
+
+        Session.add(project)
+        Session.commit()
+
+        project = models.Project.query.all()[0]
+        self.assertEqual('pypi', project.ecosystem_name)
+
+    def test_invalid(self):
+        """Assert invalid ecosystems raise an exception."""
+        project = models.Project(
+            name='requests',
+            homepage='https://pypi.org/requests',
+            backend='PyPI',
+            ecosystem_name='invalid_ecosystem',
+        )
+
+        Session.add(project)
+        self.assertRaises(ValueError, Session.commit)

--- a/anitya/tests/db/test_models.py
+++ b/anitya/tests/db/test_models.py
@@ -70,7 +70,7 @@ class ProjectTests(DatabaseTestCase):
             backend='Nope',
         )
 
-    def test_validate_ecosystem_none(self):
+    def test_default_ecosystem_is_homepage(self):
         project = models.Project(
             name='test',
             homepage='http://example.com',
@@ -80,7 +80,8 @@ class ProjectTests(DatabaseTestCase):
         self.session.add(project)
         self.session.commit()
         self.assertEqual(1, self.session.query(models.Project).count())
-        self.assertEqual(None, self.session.query(models.Project).one().ecosystem_name)
+        self.assertEqual(
+            'http://example.com', self.session.query(models.Project).one().ecosystem_name)
 
     def test_validate_ecosystem_good(self):
         project = models.Project(
@@ -93,16 +94,6 @@ class ProjectTests(DatabaseTestCase):
         self.session.commit()
         self.assertEqual(1, self.session.query(models.Project).count())
         self.assertEqual('pypi', self.session.query(models.Project).one().ecosystem_name)
-
-    def test_validate_ecosystem_bad(self):
-        self.assertRaises(
-            ValueError,
-            models.Project,
-            name='test',
-            homepage='http://example.com',
-            backend='custom',
-            ecosystem_name='Nope',
-        )
 
     def test_get_version_class(self):
         project = models.Project(

--- a/anitya/tests/test_flask_api_v2.py
+++ b/anitya/tests/test_flask_api_v2.py
@@ -115,6 +115,72 @@ class ProjectsResourceGetTests(DatabaseTestCase):
 
         self.assertEqual(data, exp)
 
+    def test_filter_projects_by_ecosystem(self):
+        """Assert projects can be filtered by ecosystem."""
+        create_project(self.session)
+
+        output = self.app.get(
+            '/api/v2/projects/?ecosystem=http%3A%2F%2Fsubsurface.hohndel.org%2F')
+        self.assertEqual(output.status_code, 200)
+        data = _read_json(output)
+
+        for item in data['items']:
+            del item['created_on']
+            del item['updated_on']
+
+        exp = {
+            'page': 1,
+            'items_per_page': 25,
+            'total_items': 1,
+            'items': [
+                {
+                    "id": 2,
+                    "backend": "custom",
+                    "homepage": "http://subsurface.hohndel.org/",
+                    "name": "subsurface",
+                    "regex": "DEFAULT",
+                    "version": None,
+                    "version_url": "http://subsurface.hohndel.org/downloads/",
+                    "versions": []
+                }
+            ]
+        }
+
+        self.assertEqual(data, exp)
+
+    def test_filter_projects_by_name(self):
+        """Assert projects can be filtered by name."""
+        create_project(self.session)
+
+        output = self.app.get(
+            '/api/v2/projects/?name=subsurface')
+        self.assertEqual(output.status_code, 200)
+        data = _read_json(output)
+
+        for item in data['items']:
+            del item['created_on']
+            del item['updated_on']
+
+        exp = {
+            'page': 1,
+            'items_per_page': 25,
+            'total_items': 1,
+            'items': [
+                {
+                    "id": 2,
+                    "backend": "custom",
+                    "homepage": "http://subsurface.hohndel.org/",
+                    "name": "subsurface",
+                    "regex": "DEFAULT",
+                    "version": None,
+                    "version_url": "http://subsurface.hohndel.org/downloads/",
+                    "versions": []
+                }
+            ]
+        }
+
+        self.assertEqual(data, exp)
+
     def test_list_projects_items_per_page(self):
         """Assert pagination works and page size is adjustable."""
         api_endpoint = '/api/v2/projects/?items_per_page=1'


### PR DESCRIPTION
This adds an API to create and see packages in Anitya. 

There's some prep work here that makes the ecosystem field non-nullable  and to automatically set it for projects. I'm setting it to a project's homepage if it's not part of an ecosystem (such as PyPI). This lets users uniquely identify projects using the name and ecosystem. 

In most cases this would be something like ("PyPI", "requests") so that's nice and simple. GCC would be ("https://gcc.gnu.org/", "gcc").