### PR TITLE
Use a platform whitelist for libraries.io

### DIFF
--- a/anitya/config.py
+++ b/anitya/config.py
@@ -92,7 +92,7 @@ DEFAULTS = dict(
     SOCIAL_AUTH_LOGIN_URL='/login/',
     SOCIAL_AUTH_LOGIN_REDIRECT_URL='/',
     SOCIAL_AUTH_LOGIN_ERROR_URL='/login-error/',
-    CREATE_LIBRARIESIO_PROJECTS=False,
+    LIBRARIESIO_PLATFORM_WHITELIST=[],
 )
 
 # Start with a basic logging configuration, which will be replaced by any user-

--- a/anitya/librariesio_consumer.py
+++ b/anitya/librariesio_consumer.py
@@ -157,7 +157,7 @@ class LibrariesioConsumer(FedmsgConsumer):
 
         session = Session()
         project = models.Project.by_name_and_ecosystem(session, name, ecosystem.name)
-        if project is None and config.config['CREATE_LIBRARIESIO_PROJECTS'] is True:
+        if project is None and platform in config.config['LIBRARIESIO_PLATFORM_WHITELIST']:
             try:
                 project = utilities.create_project(
                     session,
@@ -172,7 +172,10 @@ class LibrariesioConsumer(FedmsgConsumer):
             except exceptions.AnityaException as e:
                 _log.error('A new project was discovered via libraries.io, %r, '
                            'but we failed with "%s"', project, str(e))
-        elif project is not None:
+        elif project is None:
+            _log.info('Discovered new project, %s, on the %s platform, but anitya is '
+                      'configured to not create the project', name, platform)
+        else:
             _log.info('libraries.io has found an update (version %s) for project %r',
                       version, project)
             # This will fetch the version, emit fedmsgs, add log entries, and

--- a/anitya/tests/test_config.py
+++ b/anitya/tests/test_config.py
@@ -50,7 +50,7 @@ social_auth_login_url = "/login/"
 social_auth_login_redirect_url = "/"
 social_auth_login_error_url = "/login-error/"
 
-create_librariesio_projects = true
+librariesio_platform_whitelist = ['pypi', 'rubygems']
 
 [anitya_log_config]
     version = 1
@@ -165,7 +165,7 @@ class LoadTests(unittest.TestCase):
             'SOCIAL_AUTH_LOGIN_URL': '/login/',
             'SOCIAL_AUTH_LOGIN_REDIRECT_URL': '/',
             'SOCIAL_AUTH_LOGIN_ERROR_URL': '/login-error/',
-            'CREATE_LIBRARIESIO_PROJECTS': True,
+            'LIBRARIESIO_PLATFORM_WHITELIST': ['pypi', 'rubygems'],
         }
         config = anitya_config.load()
         self.assertEqual(sorted(expected_config.keys()), sorted(config.keys()))

--- a/anitya/tests/test_librariesio_consumer.py
+++ b/anitya/tests/test_librariesio_consumer.py
@@ -146,14 +146,14 @@ class LibrariesioConsumerTests(DatabaseTestCase):
     def test_new_project_configured_off(self):
         """libraries.io events shouldn't create projects if the configuration is off."""
         consumer = LibrariesioConsumer(self.mock_hub)
-        with mock.patch.dict(config.config, {'CREATE_LIBRARIESIO_PROJECTS': False}):
+        with mock.patch.dict(config.config, {'LIBRARIESIO_PLATFORM_WHITELIST': []}):
             consumer.consume(self.supported_fedmsg)
         self.assertEqual(0, self.session.query(Project).count())
 
     def test_new_project_configured_on(self):
         """Assert that a libraries.io event about an unknown project creates that project"""
         consumer = LibrariesioConsumer(self.mock_hub)
-        with mock.patch.dict(config.config, {'CREATE_LIBRARIESIO_PROJECTS': True}):
+        with mock.patch.dict(config.config, {'LIBRARIESIO_PLATFORM_WHITELIST': ['pypi']}):
             consumer.consume(self.supported_fedmsg)
         self.assertEqual(1, self.session.query(Project).count())
         project = self.session.query(Project).first()
@@ -167,7 +167,7 @@ class LibrariesioConsumerTests(DatabaseTestCase):
         """Assert failures to create projects are logged as errors."""
         mock_create.side_effect = AnityaException("boop")
         consumer = LibrariesioConsumer(self.mock_hub)
-        with mock.patch.dict(config.config, {'CREATE_LIBRARIESIO_PROJECTS': True}):
+        with mock.patch.dict(config.config, {'LIBRARIESIO_PLATFORM_WHITELIST': ['pypi']}):
             consumer.consume(self.supported_fedmsg)
         self.assertEqual(0, self.session.query(Project).count())
         mock_log.error.assert_called_once_with(


### PR DESCRIPTION
There's over 600,000 Javascript projects we don't care about tracking,
so allow platform whitelisting for automatic creation.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>