### PR TITLE
Fix readthedocs requirements

### DIFF
--- a/readthedocs.txt
+++ b/readthedocs.txt
@@ -9,7 +9,9 @@ flask >= 0.10.1
 flask-restful
 flask-wtf
 jinja2 >= 2.4
-sphinx==1.5.6
+social-auth-app-flask
+social-auth-app-flask-sqlalchemy
+sphinx
 sphinxcontrib-httpdomain
 sqlalchemy >= 0.9
 straight.plugin==1.4.0-post-1


### PR DESCRIPTION
sphinx no longer needs pinning and the build needs social-auth installed.

Build tested with http://jcline-anitya.readthedocs.io/en/latest/ 