### PR TITLE
Pass posargs to pytest in tox.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ whitelist_externals =
 commands =
     rm -rf htmlcov coverage.xml
     py.test --cov-config .coveragerc --cov=anitya --cov-report term \
-        --cov-report xml --cov-report html
+        --cov-report xml --cov-report html {posargs}
 
 
 [testenv:docs]


### PR DESCRIPTION
This allows one to pass args to `pytest` such as limiting which tests to run.

It's already passed to `flake8`, but that's super-quick. It seems much more useful to be able to limit things passed to `pytest`, which takes much longer.