### PR TITLE
Issue #533: sort all projects by (name, ecosystem)

### DIFF
--- a/anitya/api_v2.py
+++ b/anitya/api_v2.py
@@ -325,7 +325,8 @@ class ProjectsResource(Resource):
             q = q.filter_by(ecosystem_name=ecosystem)
         if name:
             q = q.filter_by(name=name)
-        projects_page = q.paginate(order_by=models.Project.name, **args)
+        projects_page = q.paginate(
+            order_by=(models.Project.name, models.Project.ecosystem_name), **args)
         return projects_page.as_dict()
 
     @authentication.require_token


### PR DESCRIPTION
The list of all projects is already sorted by the project name. But it
results in inconsistent order over long periods of time (~8 hours) as
there is no explicit rule to sort two projects with the same name.
Two examples of multiple projects with the same name are readline and
zlib.

For api v2, add a second sort rule, based on the ecosystem to make the
results predictable.

Signed-off-by: Ricardo Martincoski <ricardo.martincoski@gmail.com>