### PR TITLE
Simplify the topic mangling so other environments work

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,7 +4,7 @@ include =
     anitya/*
 
 [report]
-fail_under = 83
+fail_under = 88
 precision = 2
 exclude_lines =
     pragma: no cover

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@ anitya.db
 client_secrets.json
 oidc_credentials.json
 anitya/static/docs/
+.pytest_cache/
 coverage.xml
 htmlcov

--- a/anitya/librariesio_consumer.py
+++ b/anitya/librariesio_consumer.py
@@ -102,7 +102,7 @@ class LibrariesioConsumer(FedmsgConsumer):
             configuration to enable this consumer.
     """
     topic = [
-        'org.fedoraproject.prod.sse2fedmsg.librariesio',
+        'sse2fedmsg.librariesio',
     ]
 
     config_key = 'anitya.libraryio.enabled'
@@ -110,12 +110,8 @@ class LibrariesioConsumer(FedmsgConsumer):
     def __init__(self, hub):
         # If we're in development mode, add the dev versions of the topics so
         # local playback with fedmsg-dg-replay works as expected.
-        if hub.config['environment'] == 'dev':
-            prefix, env = hub.config['topic_prefix'], hub.config['environment']
-            self.topic = self.topic + [
-                '.'.join([prefix, env] + topic.split('.')[3:])
-                for topic in self.topic
-            ]
+        prefix, env = hub.config['topic_prefix'], hub.config['environment']
+        self.topic = ['.'.join([prefix, env, topic]) for topic in self.topic]
         _log.info('Subscribing to the following fedmsg topics: %r', self.topic)
 
         initialize(config.config)

--- a/anitya/tests/test_librariesio_consumer.py
+++ b/anitya/tests/test_librariesio_consumer.py
@@ -80,21 +80,18 @@ class LibrariesioConsumerTests(DatabaseTestCase):
         self.mock_hub = mock.Mock(config={'environment': 'dev', 'topic_prefix': 'anitya'})
 
     def test_dev_environment_topics(self):
-        """Assert when the environment is set to dev, both dev and prod topic is used."""
-        expected_topics = [
-            'org.fedoraproject.prod.sse2fedmsg.librariesio',
-            'anitya.dev.sse2fedmsg.librariesio',
-        ]
-        consumer = LibrariesioConsumer(self.mock_hub)
+        """Assert when the environment is set to dev, the dev topic is used."""
+        mock_hub = mock.Mock(config={'environment': 'dev', 'topic_prefix': 'anitya'})
+        consumer = LibrariesioConsumer(mock_hub)
 
-        self.assertEqual(expected_topics, consumer.topic)
+        self.assertEqual([u'anitya.dev.sse2fedmsg.librariesio'], consumer.topic)
 
     def test_prod_environment_topics(self):
         """Assert when the environment is set to prod, only the prod topic is used."""
         mock_hub = mock.Mock(config={'environment': 'prod', 'topic_prefix': 'anitya'})
         consumer = LibrariesioConsumer(mock_hub)
 
-        self.assertEqual(['org.fedoraproject.prod.sse2fedmsg.librariesio'], consumer.topic)
+        self.assertEqual([u'anitya.prod.sse2fedmsg.librariesio'], consumer.topic)
 
     @mock.patch('anitya.librariesio_consumer._log')
     def test_no_ecosystem(self, mock_log):


### PR DESCRIPTION
I stole this from other consumers when I first implemented this, but it
actually makes no sense. Drop the if statement and always use whatever
prefix and environment fedmsg is using.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>