### PR TITLE
Drop unused dateutils dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 alembic
 blinker
 python-dateutil
-dateutils
 fedmsg[commands,consumers]
 flask-login
 gunicorn


### PR DESCRIPTION
This was removed in #490, but appears to have slipped back in due to an
incorrect merge conflict resolution.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>