### PR TITLE
 Provide a more helpful error to users of multiple providers

### DIFF
--- a/anitya/app.py
+++ b/anitya/app.py
@@ -20,9 +20,10 @@ from flask_login import LoginManager, current_user
 from social_core.backends.utils import load_backends
 from social_flask.routes import social_auth
 from social_flask_sqlalchemy import models as social_models
+from sqlalchemy.exc import IntegrityError
 
 from anitya.config import config as anitya_config
-from anitya.db import Session, initialize as initialize_db
+from anitya.db import Session, initialize as initialize_db, models
 from anitya.lib import utilities
 from . import ui, admin, api, api_v2, authentication
 import anitya.lib
@@ -81,6 +82,7 @@ def create(config=None):
 
     app.before_request(global_user)
     app.teardown_request(shutdown_session)
+    app.register_error_handler(IntegrityError, integrity_error_handler)
 
     app.context_processor(inject_variable)
 
@@ -124,3 +126,27 @@ def inject_variable():
         user=current_user,
         available_backends=load_backends(anitya_config['SOCIAL_AUTH_AUTHENTICATION_BACKENDS']),
     )
+
+
+def integrity_error_handler(error):
+    """
+    Flask error handler for unhandled IntegrityErrors.
+
+    Args:
+        error (IntegrityError): The exception to be handled.
+
+    Returns:
+        tuple: A tuple of (message, HTTP error code).
+    """
+    # Because social auth provides the route and raises the exception, this is
+    # the simplest way to turn the error into a nicely formatted error message
+    # for the user.
+    if 'email' in error.params:
+        Session.rollback()
+        other_user = models.User.query.filter_by(email=error.params['email']).one()
+        social_auth_user = other_user.social_auth.filter_by(user_id=other_user.id).one()
+        msg = ("Error: There's already an account associated with your email, "
+               "authenticate with {}.".format(social_auth_user.provider))
+        return msg, 400
+
+    return 'The server encountered an unexpected error', 500

--- a/ansible/roles/anitya-dev/tasks/main.yml
+++ b/ansible/roles/anitya-dev/tasks/main.yml
@@ -11,6 +11,7 @@
   dnf: name={{ item }} state=present
   with_items:
     - gcc
+    - make
     - libffi-devel
     - openssl-devel
     - postgresql-devel


### PR DESCRIPTION
If a user signs in with identity provider A and then signs in with
identity provider B and both providers have the same email for that
user, an IntegrityError happens when social_auth tries to make a new
user. Handle this and inform the user what provider they should use to
authenticate.

Ideally we could merge the accounts and let users auth with either one,
but this is more involved because not all providers confirm the email of
the user, so if a malicious user signs up with another user's email and
then it got merged, they could perform actions as the user.

Fixes #559