### PR TITLE
Lowercase Documentation in menu to docs

### DIFF
--- a/anitya/templates/master.html
+++ b/anitya/templates/master.html
@@ -47,7 +47,7 @@
         <div class="navbar-collapse collapse">
           <ul class="nav navbar-nav">
               <li>
-                  <a href="{{ url_for('anitya_ui.static', filename='docs/index.html') }}">Documentation</a>
+                  <a href="{{ url_for('anitya_ui.static', filename='docs/index.html') }}">docs</a>
               </li>
             {%- if current == 'projects' -%}
             <li class="active">


### PR DESCRIPTION
This makes it consistent with the rest of menu.

![image](https://user-images.githubusercontent.com/8781107/41641488-9b105b1a-748f-11e8-9582-3b120d590ecc.png)
