### PR TITLE
Use the new url for CPAN, in https

### DIFF
--- a/anitya/lib/backends/cpan.py
+++ b/anitya/lib/backends/cpan.py
@@ -24,8 +24,8 @@ class CpanBackend(BaseBackend):
 
     name = 'CPAN (perl)'
     examples = [
-        'http://search.cpan.org/dist/Net-Whois-Raw/',
-        'http://search.cpan.org/dist/SOAP/',
+        'https://metacpan.org/release/Net-Whois-Raw/',
+        'https://metacpan.org/release/SOAP/',
     ]
 
     @classmethod
@@ -59,7 +59,7 @@ class CpanBackend(BaseBackend):
             when the versions cannot be retrieved correctly
 
         '''
-        url = 'http://search.cpan.org/dist/%(name)s/' % {
+        url = 'https://metacpan.org/release/%(name)s/' % {
             'name': project.name}
 
         regex = REGEX % {'name': project.name}
@@ -73,7 +73,7 @@ class CpanBackend(BaseBackend):
         by querying an RSS feed.
         '''
 
-        url = 'http://search.cpan.org/uploads.rdf'
+        url = 'https://metacpan.org/feed/recent'
 
         try:
             response = cls.call_url(url)
@@ -90,5 +90,5 @@ class CpanBackend(BaseBackend):
         for entry in items:
             title = entry['title']['value']
             name, version = title.rsplit('-', 1)
-            homepage = 'http://search.cpan.org/dist/%s/' % name
+            homepage = 'https://metacpan.org/release/%s/' % name
             yield name, homepage, cls.name, version

--- a/anitya/lib/backends/cpan.py
+++ b/anitya/lib/backends/cpan.py
@@ -9,10 +9,14 @@
 
 """
 
-import anitya.lib.xml2dict as xml2dict
+import logging
+
+from defusedxml import ElementTree as ET
 
 from anitya.lib.backends import BaseBackend, get_versions_by_regex, REGEX
 from anitya.lib.exceptions import AnityaPluginException
+
+_log = logging.getLogger(__name__)
 
 
 class CpanBackend(BaseBackend):
@@ -81,14 +85,15 @@ class CpanBackend(BaseBackend):
             raise AnityaPluginException('Could not contact %s' % url)
 
         try:
-            parser = xml2dict.XML2Dict()
-            data = parser.fromstring(response.text)
-        except Exception:  # pragma: no cover
+            root = ET.fromstring(response.text)
+        except ET.ParseError:
             raise AnityaPluginException('No XML returned by %s' % url)
 
-        items = data['RDF']['item']
-        for entry in items:
-            title = entry['title']['value']
-            name, version = title.rsplit('-', 1)
+        for item in root.iter(tag='{http://purl.org/rss/1.0/}item'):
+            title = item.find('{http://purl.org/rss/1.0/}title')
+            try:
+                name, version = title.text.rsplit('-', 1)
+            except ValueError:
+                _log.info('Unable to parse CPAN package %s into a name and version')
             homepage = 'https://metacpan.org/release/%s/' % name
             yield name, homepage, cls.name, version

--- a/anitya/tests/lib/backends/test_cpan.py
+++ b/anitya/tests/lib/backends/test_cpan.py
@@ -100,13 +100,11 @@ class CpanBackendtests(DatabaseTestCase):
         items = list(generator)
 
         self.assertEqual(items[0], (
-            'Dist-Zilla-PluginBundle-Author-Plicease',
-            'http://search.cpan.org/dist/Dist-Zilla-PluginBundle-Author-Plicease/',
-            'CPAN (perl)', '2.06'))
+            'URI-Fast', 'https://metacpan.org/release/URI-Fast/',
+            'CPAN (perl)', '0.38_06'))
         self.assertEqual(items[1], (
-            'Dist-Zilla-Plugin-Author-Plicease',
-            'http://search.cpan.org/dist/Dist-Zilla-Plugin-Author-Plicease/',
-            'CPAN (perl)', '2.06'))
+            'Model-Envoy', 'https://metacpan.org/release/Model-Envoy/',
+            'CPAN (perl)', '0.2.4'))
         # etc...
 
 

--- a/anitya/tests/request-data/anitya.tests.lib.backends.test_cpan.CpanBackendtests.test_cpan_check_feed
+++ b/anitya/tests/request-data/anitya.tests.lib.backends.test_cpan.CpanBackendtests.test_cpan_check_feed
@@ -6,407 +6,479 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       From: [admin@fedoraproject.org]
-      User-Agent: [Anitya 0.9.1 at upstream-monitoring.org]
+      User-Agent: [Anitya 0.12.1 at upstream-monitoring.org]
     method: GET
-    uri: http://search.cpan.org/uploads.rdf
+    uri: https://metacpan.org/feed/recent
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\n<rdf:RDF\n
-        xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\n xmlns=\"http://purl.org/rss/1.0/\"\n
-        xmlns:admin=\"http://webns.net/mvcb/\"\n xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"\n
-        xmlns:dc=\"http://purl.org/dc/elements/1.1/\"\n xmlns:syn=\"http://purl.org/rss/1.0/modules/syndication/\"\n
-        xmlns:taxo=\"http://purl.org/rss/1.0/modules/taxonomy/\"\n>\n\n<channel rdf:about=\"http://search.cpan.org/\">\n<title>search.cpan.org</title>\n<link>http://search.cpan.org/</link>\n<description>The
-        CPAN search site</description>\n<dc:date>2016-05-11T03:36+00:00</dc:date>\n<syn:updateBase>1901-01-01T00:00+00:00</syn:updateBase>\n<syn:updateFrequency>1</syn:updateFrequency>\n<syn:updatePeriod>hourly</syn:updatePeriod>\n<items>\n
-        <rdf:Seq>\n  <rdf:li rdf:resource=\"http://search.cpan.org/~plicease/Dist-Zilla-PluginBundle-Author-Plicease-2.06/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~plicease/Dist-Zilla-Plugin-Author-Plicease-2.06/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~rsavage/GraphViz2-Marpa-2.08/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~jandrew/Spreadsheet-XLSX-Reader-LibXML-v0.42.2/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~rsavage/String-Dirify-1.03/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~canid/Yote-Server-1.04/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~canid/Yote-1.38/\" />\n
-        \ <rdf:li rdf:resource=\"http://search.cpan.org/~qrry/Sentry-Raven-1.04/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~shlomif/WWW-LinkChecker-Internal-v0.4.0/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~mik/CryptX-0.034/\" />\n
-        \ <rdf:li rdf:resource=\"http://search.cpan.org/~jandrew/Spreadsheet-Reader-ExcelXML-v0.2.0/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~mongodb/MongoDB-v1.4.0/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~srezic/CPAN-Plugin-Sysdeps-0.06/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~drolsky/MooseX-Getopt-0.70/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~canid/Lock-Server-1.64/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~jhthorsen/Mojolicious-Plugin-AssetPack-1.09/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~drolsky/Test-Class-Moose-0.72-TRIAL/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~canid/Lock-Server-1.63/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~aspose/AsposePdfCloud-PdfApi-1.00/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~mlawren/OptArgs2-0.0.1_2/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~weters/Text-CSV-Easy-0.54/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~corion/HTML-Selector-XPath-0.19/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~pevans/Tickit-0.56/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~salva/Net-SSH2-0.59_19/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~pevans/Tickit-Widgets-0.23/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~perlancar/Rinci-1.1.80/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~perlancar/Perinci-Sub-Util-PropertyModule-0.45/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~perlancar/Perinci-Sub-PropertyUtil-0.11/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~perlancar/Perinci-Sub-Normalize-0.17/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~perlancar/Perinci-Sub-FeatureUtil-0.04/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~perlancar/Perinci-Sub-DepUtil-0.04/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~plicease/Test-Alien-0.07/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~mche/Mojolicious-Plugin-RoutesAuthDBI-0.441/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~mche/Mojolicious-Plugin-RoutesAuthDBI-0.440/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~zdm/Pcore-Nginx-v0.9.1/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~zdm/Pcore-v0.23.6/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~hmbrand/Config-Perl-V-0.26/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~exodist/Test2-Tools-EventDumper-0.000007/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~zdm/Pcore-API-Whois-v0.1.1/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~exodist/Test2-Suite-0.000030/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~exodist/Test2-AsyncSubtest-0.000015/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~exodist/Test-Simple-1.302015/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~zdm/Pcore-API-Whois-v0.1.0/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~mdom/dategrep-0.55/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~perljedi/Test-Mock-Wrapper-0.18/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~gonzus/URI-XSEscape-0.000007/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~wangq/App-Fasops-0.3.13/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~mche/DBIx-POS-Template-0.0001/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~wangq/AlignDB-IntSpan-1.0.7/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~nics/Catmandu-1.01/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~mrf/Dredd-Hooks-0.05/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~fglock/Perlito5-9.021/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~manwar/Date-Utils-0.17/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~taniguchi/Number-Phone-JP-0.20160502/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~reneeb/Module-OTRS-CoreList-0.12/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~melmothx/Text-Amuse-Compile-0.57/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~mik/Crypt-SRP-0.016/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~mche/DBIx-POS-Template-0.00006/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~mche/DBIx-POS-Template-0.00005/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~edf/Geo-Address-Formatter-1.56/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~bkb/Test-CGI-External-0.16/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~shantanu/Dist-Zilla-PluginBundle-SHANTANU-0.42/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~shantanu/Printer-ESCPOS-0.025/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~cfaber/Config-Simple-Conf-1.8/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~mithaldu/Acme-MITHALDU-XSGrabBag-1.161310/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~rsavage/WWW-Scraper-Wikipedia-ISO3166-1.04/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~starlight/TAP-Formatter-Bamboo-0.04_02/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~rsavage/WWW-Scraper-Wikipedia-ISO3166-1.03/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~diederich/IPC-Transit-1.161300/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~bingos/ExtUtils-MakeMaker-7.17_02/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~vyf/Ouroboros-0.08/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~choroba/Syntax-Construct-0.23/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~choroba/Syntax-Construct-0.22/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~architek/WWW-FBX-0.11/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~cymon/Dancer2-Plugin-Multilang-1.1.2/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~enell/POD2-ES-5.22.0.2/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~mhx/IPC-SysV-2.07/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~jhthorsen/Mojolicious-Plugin-AssetPack-1.08/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~mik/CryptX-0.033/\" />\n
-        \ <rdf:li rdf:resource=\"http://search.cpan.org/~mob/Forks-Super-0.82/\" />\n
-        \ <rdf:li rdf:resource=\"http://search.cpan.org/~drolsky/Test-Class-Moose-0.71/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~bingos/ExtUtils-MakeMaker-7.17_01/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~ddumont/Config-Model-Systemd-0.005/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~drolsky/Test-Class-Moose-0.70/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~plicease/Alien-CMake-0.08/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~tosh/Capstone-0.5/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~plicease/PkgConfig-0.12026/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~gmax/MySQL-Sandbox-3.1.06/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~mlawren/OptArgs2-0.0.1_1/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~rkelsch/Graphics-Framebuffer-5.78/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~oalders/HTTP-BrowserDetect-3.13/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~melmothx/Text-Amuse-Compile-0.56/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~sjdy/Mojo-IRC-Server-Chinese-1.7.8/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~melmothx/Text-Amuse-0.61/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~vroom/WebService-Ooyala-0.03/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~tpoder/Net-NfDump-1.20/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~lucas/Dancer2-Plugin-Pg-0.05/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~bingos/Module-CoreList-5.20160507/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~bingos/CPAN-Perl-Releases-2.76/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~rjbs/perl-5.25.0/\" />\n
-        \ <rdf:li rdf:resource=\"http://search.cpan.org/~rjbs/perl-5.24.0/\" />\n
-        \ <rdf:li rdf:resource=\"http://search.cpan.org/~perlancar/Devel-DieHandler-DumpINC-0.002/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~perlancar/Devel-DieHandler-DumpINC-0.001/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~manwar/Task-Calendar-0.17/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~starlight/TAP-Formatter-Bamboo-0.04_01/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~salva/Net-SSH2-0.59_18/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~rurban/B-C-1.54_03/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~perlancar/Perinci-CmdLine-Lite-1.54/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~perlancar/Complete-File-0.40/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~srezic/CPAN-Plugin-Sysdeps-0.05/\"
-        />\n  <rdf:li rdf:resource=\"http://search.cpan.org/~chromatic/Mojolicious-Plugin-UnicodeNormalize-1.20160509/\"
-        />\n </rdf:Seq>\n</items>\n<image rdf:resource=\"http://search.cpan.org/s/img/cpanrdf.jpg\"
-        />\n</channel>\n<image rdf:about=\"http://search.cpan.org/s/img/cpanrdf.jpg\">\n<title>search.cpan.org</title>\n<url>http://search.cpan.org/s/img/cpanrdf.jpg</url>\n<link>http://search.cpan.org</link>\n</image>\n<item
-        rdf:about=\"http://search.cpan.org/~plicease/Dist-Zilla-PluginBundle-Author-Plicease-2.06/\">\n<title>Dist-Zilla-PluginBundle-Author-Plicease-2.06</title>\n<link>http://search.cpan.org/~plicease/Dist-Zilla-PluginBundle-Author-Plicease-2.06/</link>\n<description>Dist::Zilla
-        plugin bundle used by Plicease</description>\n<dc:creator>&#x27E6;Graham Ollis&#x27E7;</dc:creator>\n<dc:date>2016-05-11T01:26+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~plicease/Dist-Zilla-Plugin-Author-Plicease-2.06/\">\n<title>Dist-Zilla-Plugin-Author-Plicease-2.06</title>\n<link>http://search.cpan.org/~plicease/Dist-Zilla-Plugin-Author-Plicease-2.06/</link>\n<description>Dist::Zilla
-        plugins used by Plicease</description>\n<dc:creator>&#x27E6;Graham Ollis&#x27E7;</dc:creator>\n<dc:date>2016-05-11T01:25+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~rsavage/GraphViz2-Marpa-2.08/\">\n<title>GraphViz2-Marpa-2.08</title>\n<link>http://search.cpan.org/~rsavage/GraphViz2-Marpa-2.08/</link>\n<description>A
-        Marpa-based parser for Graphviz dot files</description>\n<dc:creator>Ron Savage</dc:creator>\n<dc:date>2016-05-11T01:07+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~jandrew/Spreadsheet-XLSX-Reader-LibXML-v0.42.2/\">\n<title>Spreadsheet-XLSX-Reader-LibXML-v0.42.2</title>\n<link>http://search.cpan.org/~jandrew/Spreadsheet-XLSX-Reader-LibXML-v0.42.2/</link>\n<description>Read
-        xlsx spreadsheet files with LibXML</description>\n<dc:creator>Jed Lund</dc:creator>\n<dc:date>2016-05-11T00:24+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~rsavage/String-Dirify-1.03/\">\n<title>String-Dirify-1.03</title>\n<link>http://search.cpan.org/~rsavage/String-Dirify-1.03/</link>\n<description>Convert
-        a string into a directory name</description>\n<dc:creator>Ron Savage</dc:creator>\n<dc:date>2016-05-10T23:42+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~canid/Yote-Server-1.04/\">\n<title>Yote-Server-1.04</title>\n<link>http://search.cpan.org/~canid/Yote-Server-1.04/</link>\n<description>Serve
-        up marshaled perl objects in javascript</description>\n<dc:creator>Eric Wolf</dc:creator>\n<dc:date>2016-05-10T23:16+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~canid/Yote-1.38/\">\n<title>Yote-1.38</title>\n<link>http://search.cpan.org/~canid/Yote-1.38/</link>\n<description>Persistant
-        Perl container objects in a directed graph of lazilly loaded nodes.</description>\n<dc:creator>Eric
-        Wolf</dc:creator>\n<dc:date>2016-05-10T23:16+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~qrry/Sentry-Raven-1.04/\">\n<title>Sentry-Raven-1.04</title>\n<link>http://search.cpan.org/~qrry/Sentry-Raven-1.04/</link>\n<description>A
-        perl sentry client</description>\n<dc:creator>Matt Harrington</dc:creator>\n<dc:date>2016-05-10T22:57+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~shlomif/WWW-LinkChecker-Internal-v0.4.0/\">\n<title>WWW-LinkChecker-Internal-v0.4.0</title>\n<link>http://search.cpan.org/~shlomif/WWW-LinkChecker-Internal-v0.4.0/</link>\n<description>Check
-        a web site for broken internal links.</description>\n<dc:creator>Shlomi Fish</dc:creator>\n<dc:date>2016-05-10T22:46+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~mik/CryptX-0.034/\">\n<title>CryptX-0.034</title>\n<link>http://search.cpan.org/~mik/CryptX-0.034/</link>\n<description>Crypto
-        toolkit</description>\n<dc:creator>Karel Miko</dc:creator>\n<dc:date>2016-05-10T22:31+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~jandrew/Spreadsheet-Reader-ExcelXML-v0.2.0/\">\n<title>Spreadsheet-Reader-ExcelXML-v0.2.0</title>\n<link>http://search.cpan.org/~jandrew/Spreadsheet-Reader-ExcelXML-v0.2.0/</link>\n<description>Read
-        xlsx/xlsm/xml extention Excel files</description>\n<dc:creator>Jed Lund</dc:creator>\n<dc:date>2016-05-10T22:24+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~mongodb/MongoDB-v1.4.0/\">\n<title>MongoDB-v1.4.0</title>\n<link>http://search.cpan.org/~mongodb/MongoDB-v1.4.0/</link>\n<description>Official
-        MongoDB Driver for Perl</description>\n<dc:creator>MongoDB Inc</dc:creator>\n<dc:date>2016-05-10T21:02+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~srezic/CPAN-Plugin-Sysdeps-0.06/\">\n<title>CPAN-Plugin-Sysdeps-0.06</title>\n<link>http://search.cpan.org/~srezic/CPAN-Plugin-Sysdeps-0.06/</link>\n<description>CPAN.pm
-        plugin for installing external dependencies</description>\n<dc:creator>Slaven
-        Rezi&#x107;</dc:creator>\n<dc:date>2016-05-10T20:48+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~drolsky/MooseX-Getopt-0.70/\">\n<title>MooseX-Getopt-0.70</title>\n<link>http://search.cpan.org/~drolsky/MooseX-Getopt-0.70/</link>\n<description>A
-        Moose role for processing command line options</description>\n<dc:creator>Dave
-        Rolsky</dc:creator>\n<dc:date>2016-05-10T20:34+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~canid/Lock-Server-1.64/\">\n<title>Lock-Server-1.64</title>\n<link>http://search.cpan.org/~canid/Lock-Server-1.64/</link>\n<description>Light-weight
-        socket based resource locking manager.</description>\n<dc:creator>Eric Wolf</dc:creator>\n<dc:date>2016-05-10T20:15+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~jhthorsen/Mojolicious-Plugin-AssetPack-1.09/\">\n<title>Mojolicious-Plugin-AssetPack-1.09</title>\n<link>http://search.cpan.org/~jhthorsen/Mojolicious-Plugin-AssetPack-1.09/</link>\n<description>Compress
-        and convert css, less, sass, javascript and coffeescript files</description>\n<dc:creator>Jan
-        Henning Thorsen</dc:creator>\n<dc:date>2016-05-10T19:36+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~drolsky/Test-Class-Moose-0.72-TRIAL/\">\n<title>Test-Class-Moose-0.72-TRIAL</title>\n<link>http://search.cpan.org/~drolsky/Test-Class-Moose-0.72-TRIAL/</link>\n<description>Serious
-        testing for serious Perl</description>\n<dc:creator>Dave Rolsky</dc:creator>\n<dc:date>2016-05-10T19:27+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~canid/Lock-Server-1.63/\">\n<title>Lock-Server-1.63</title>\n<link>http://search.cpan.org/~canid/Lock-Server-1.63/</link>\n<description>Light-weight
-        socket based resource locking manager.</description>\n<dc:creator>Eric Wolf</dc:creator>\n<dc:date>2016-05-10T18:59+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~aspose/AsposePdfCloud-PdfApi-1.00/\">\n<title>AsposePdfCloud-PdfApi-1.00</title>\n<link>http://search.cpan.org/~aspose/AsposePdfCloud-PdfApi-1.00/</link>\n<description>Aspose.Pdf
-        Cloud SDK for Perl</description>\n<dc:creator>Aspose Total</dc:creator>\n<dc:date>2016-05-10T18:29+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~mlawren/OptArgs2-0.0.1_2/\">\n<title>OptArgs2-0.0.1_2</title>\n<link>http://search.cpan.org/~mlawren/OptArgs2-0.0.1_2/</link>\n<description>command-line
-        argument and option processor</description>\n<dc:creator>Mark Lawrence</dc:creator>\n<dc:date>2016-05-10T17:46+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~weters/Text-CSV-Easy-0.54/\">\n<title>Text-CSV-Easy-0.54</title>\n<link>http://search.cpan.org/~weters/Text-CSV-Easy-0.54/</link>\n<description>Easy
-        CSV parsing and building</description>\n<dc:creator>Thomas Peters</dc:creator>\n<dc:date>2016-05-10T17:44+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~corion/HTML-Selector-XPath-0.19/\">\n<title>HTML-Selector-XPath-0.19</title>\n<link>http://search.cpan.org/~corion/HTML-Selector-XPath-0.19/</link>\n<description>CSS
-        Selector to XPath compiler</description>\n<dc:creator>Max Maischein</dc:creator>\n<dc:date>2016-05-10T17:29+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~pevans/Tickit-0.56/\">\n<title>Tickit-0.56</title>\n<link>http://search.cpan.org/~pevans/Tickit-0.56/</link>\n<description>Terminal
-        Interface Construction KIT</description>\n<dc:creator>Paul Evans</dc:creator>\n<dc:date>2016-05-10T17:13+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~salva/Net-SSH2-0.59_19/\">\n<title>Net-SSH2-0.59_19</title>\n<link>http://search.cpan.org/~salva/Net-SSH2-0.59_19/</link>\n<description>Support
-        for the SSH 2 protocol via libssh2.</description>\n<dc:creator>Salvador Fandi&#xF1;o
-        Garc&#xED;a</dc:creator>\n<dc:date>2016-05-10T17:02+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~pevans/Tickit-Widgets-0.23/\">\n<title>Tickit-Widgets-0.23</title>\n<link>http://search.cpan.org/~pevans/Tickit-Widgets-0.23/</link>\n<description>a
-        collection of Tickit::Widget implementations</description>\n<dc:creator>Paul
-        Evans</dc:creator>\n<dc:date>2016-05-10T16:54+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~perlancar/Rinci-1.1.80/\">\n<title>Rinci-1.1.80</title>\n<link>http://search.cpan.org/~perlancar/Rinci-1.1.80/</link>\n<description>Language-neutral
-        metadata for your code</description>\n<dc:creator>perlancar</dc:creator>\n<dc:date>2016-05-10T16:39+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~perlancar/Perinci-Sub-Util-PropertyModule-0.45/\">\n<title>Perinci-Sub-Util-PropertyModule-0.45</title>\n<link>http://search.cpan.org/~perlancar/Perinci-Sub-Util-PropertyModule-0.45/</link>\n<description>Given
-        a Rinci function metadata, find what property modules are required</description>\n<dc:creator>perlancar</dc:creator>\n<dc:date>2016-05-10T16:38+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~perlancar/Perinci-Sub-PropertyUtil-0.11/\">\n<title>Perinci-Sub-PropertyUtil-0.11</title>\n<link>http://search.cpan.org/~perlancar/Perinci-Sub-PropertyUtil-0.11/</link>\n<description>Utility
-        routines for Perinci::Sub::Property::* modules</description>\n<dc:creator>perlancar</dc:creator>\n<dc:date>2016-05-10T16:38+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~perlancar/Perinci-Sub-Normalize-0.17/\">\n<title>Perinci-Sub-Normalize-0.17</title>\n<link>http://search.cpan.org/~perlancar/Perinci-Sub-Normalize-0.17/</link>\n<description>Normalize
-        Rinci function metadata</description>\n<dc:creator>perlancar</dc:creator>\n<dc:date>2016-05-10T16:37+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~perlancar/Perinci-Sub-FeatureUtil-0.04/\">\n<title>Perinci-Sub-FeatureUtil-0.04</title>\n<link>http://search.cpan.org/~perlancar/Perinci-Sub-FeatureUtil-0.04/</link>\n<description>Utility
-        routines for Perinci::Sub::Feature::* modules</description>\n<dc:creator>perlancar</dc:creator>\n<dc:date>2016-05-10T16:37+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~perlancar/Perinci-Sub-DepUtil-0.04/\">\n<title>Perinci-Sub-DepUtil-0.04</title>\n<link>http://search.cpan.org/~perlancar/Perinci-Sub-DepUtil-0.04/</link>\n<description>Utility
-        routines for Perinci::Sub::Dep::* modules</description>\n<dc:creator>perlancar</dc:creator>\n<dc:date>2016-05-10T16:37+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~plicease/Test-Alien-0.07/\">\n<title>Test-Alien-0.07</title>\n<link>http://search.cpan.org/~plicease/Test-Alien-0.07/</link>\n<description>Testing
-        tools for Alien modules</description>\n<dc:creator>&#x27E6;Graham Ollis&#x27E7;</dc:creator>\n<dc:date>2016-05-10T15:34+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~mche/Mojolicious-Plugin-RoutesAuthDBI-0.441/\">\n<title>Mojolicious-Plugin-RoutesAuthDBI-0.441</title>\n<link>http://search.cpan.org/~mche/Mojolicious-Plugin-RoutesAuthDBI-0.441/</link>\n<description>from
-        DBI sql-tables does generate routes, make authentication and make restrict
-        access (authorization) to request. Plugin makes an auth operations throught
-        the plugin L&#x3C;Mojolicious::Plugin::Authentica</description>\n<dc:creator>&#x41C;&#x438;&#x445;&#x430;&#x438;&#x43B;
-        &#x427;&#x435;</dc:creator>\n<dc:date>2016-05-10T14:40+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~mche/Mojolicious-Plugin-RoutesAuthDBI-0.440/\">\n<title>Mojolicious-Plugin-RoutesAuthDBI-0.440</title>\n<link>http://search.cpan.org/~mche/Mojolicious-Plugin-RoutesAuthDBI-0.440/</link>\n<description>from
-        DBI sql-tables does generate routes, make authentication and make restrict
-        access (authorization) to request. Plugin makes an auth operations throught
-        the plugin L&#x3C;Mojolicious::Plugin::Authentica</description>\n<dc:creator>&#x41C;&#x438;&#x445;&#x430;&#x438;&#x43B;
-        &#x427;&#x435;</dc:creator>\n<dc:date>2016-05-10T14:23+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~zdm/Pcore-Nginx-v0.9.1/\">\n<title>Pcore-Nginx-v0.9.1</title>\n<link>http://search.cpan.org/~zdm/Pcore-Nginx-v0.9.1/</link>\n<description>Pcore
-        nginx application</description>\n<dc:creator>Dmytro Zagashev</dc:creator>\n<dc:date>2016-05-10T14:21+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~zdm/Pcore-v0.23.6/\">\n<title>Pcore-v0.23.6</title>\n<link>http://search.cpan.org/~zdm/Pcore-v0.23.6/</link>\n<description>perl
-        applications development environment</description>\n<dc:creator>Dmytro Zagashev</dc:creator>\n<dc:date>2016-05-10T14:19+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~hmbrand/Config-Perl-V-0.26/\">\n<title>Config-Perl-V-0.26</title>\n<link>http://search.cpan.org/~hmbrand/Config-Perl-V-0.26/</link>\n<description>Structured
-        data retrieval of perl -V output</description>\n<dc:creator>H.Merijn Brand</dc:creator>\n<dc:date>2016-05-10T14:18+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~exodist/Test2-Tools-EventDumper-0.000007/\">\n<title>Test2-Tools-EventDumper-0.000007</title>\n<link>http://search.cpan.org/~exodist/Test2-Tools-EventDumper-0.000007/</link>\n<description>Tool
-        for dumping Test2::Event structures.</description>\n<dc:creator>Chad Granum</dc:creator>\n<dc:date>2016-05-10T14:18+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~zdm/Pcore-API-Whois-v0.1.1/\">\n<title>Pcore-API-Whois-v0.1.1</title>\n<link>http://search.cpan.org/~zdm/Pcore-API-Whois-v0.1.1/</link>\n<description></description>\n<dc:creator>Dmytro
-        Zagashev</dc:creator>\n<dc:date>2016-05-10T14:17+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~exodist/Test2-Suite-0.000030/\">\n<title>Test2-Suite-0.000030</title>\n<link>http://search.cpan.org/~exodist/Test2-Suite-0.000030/</link>\n<description>Distribution
-        with a rich set of tools built upon the Test2 framework.</description>\n<dc:creator>Chad
-        Granum</dc:creator>\n<dc:date>2016-05-10T14:16+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~exodist/Test2-AsyncSubtest-0.000015/\">\n<title>Test2-AsyncSubtest-0.000015</title>\n<link>http://search.cpan.org/~exodist/Test2-AsyncSubtest-0.000015/</link>\n<description>Object
-        representing an async subtest.</description>\n<dc:creator>Chad Granum</dc:creator>\n<dc:date>2016-05-10T14:16+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~exodist/Test-Simple-1.302015/\">\n<title>Test-Simple-1.302015</title>\n<link>http://search.cpan.org/~exodist/Test-Simple-1.302015/</link>\n<description>Basic
-        utilities for writing tests.</description>\n<dc:creator>Chad Granum</dc:creator>\n<dc:date>2016-05-10T14:16+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~zdm/Pcore-API-Whois-v0.1.0/\">\n<title>Pcore-API-Whois-v0.1.0</title>\n<link>http://search.cpan.org/~zdm/Pcore-API-Whois-v0.1.0/</link>\n<description></description>\n<dc:creator>Dmytro
-        Zagashev</dc:creator>\n<dc:date>2016-05-10T13:59+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~mdom/dategrep-0.55/\">\n<title>dategrep-0.55</title>\n<link>http://search.cpan.org/~mdom/dategrep-0.55/</link>\n<description>grep
-        for dates</description>\n<dc:creator>Mario Domg&#xF6;rgen</dc:creator>\n<dc:date>2016-05-10T13:56+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~perljedi/Test-Mock-Wrapper-0.18/\">\n<title>Test-Mock-Wrapper-0.18</title>\n<link>http://search.cpan.org/~perljedi/Test-Mock-Wrapper-0.18/</link>\n<description>Flexible
-        and prowerful class and object mocking library for perl</description>\n<dc:creator>Dave
-        Mueller</dc:creator>\n<dc:date>2016-05-10T13:18+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~gonzus/URI-XSEscape-0.000007/\">\n<title>URI-XSEscape-0.000007</title>\n<link>http://search.cpan.org/~gonzus/URI-XSEscape-0.000007/</link>\n<description>Fast
-        XS URI-escaping library, replacing URI::Escape.</description>\n<dc:creator>Gonzalo
-        Diethelm</dc:creator>\n<dc:date>2016-05-10T13:09+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~wangq/App-Fasops-0.3.13/\">\n<title>App-Fasops-0.3.13</title>\n<link>http://search.cpan.org/~wangq/App-Fasops-0.3.13/</link>\n<description>operating
-        blocked fasta files</description>\n<dc:creator>Qiang Wang</dc:creator>\n<dc:date>2016-05-10T13:01+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~mche/DBIx-POS-Template-0.0001/\">\n<title>DBIx-POS-Template-0.0001</title>\n<link>http://search.cpan.org/~mche/DBIx-POS-Template-0.0001/</link>\n<description>is
-        a fork of L&#x3C;DBIx::POS&#x3E;. Define a dictionary of SQL statements in
-        a POD dialect (POS) plus expand template sql with embedded Perl using L&#x3C;Text::Template&#x3E;.</description>\n<dc:creator>&#x41C;&#x438;&#x445;&#x430;&#x438;&#x43B;
-        &#x427;&#x435;</dc:creator>\n<dc:date>2016-05-10T11:48+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~wangq/AlignDB-IntSpan-1.0.7/\">\n<title>AlignDB-IntSpan-1.0.7</title>\n<link>http://search.cpan.org/~wangq/AlignDB-IntSpan-1.0.7/</link>\n<description>Handling
-        of sets containing integer spans.</description>\n<dc:creator>Qiang Wang</dc:creator>\n<dc:date>2016-05-10T11:15+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~nics/Catmandu-1.01/\">\n<title>Catmandu-1.01</title>\n<link>http://search.cpan.org/~nics/Catmandu-1.01/</link>\n<description>a
-        data toolkit</description>\n<dc:creator>Nicolas Steenlant</dc:creator>\n<dc:date>2016-05-10T11:08+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~mrf/Dredd-Hooks-0.05/\">\n<title>Dredd-Hooks-0.05</title>\n<link>http://search.cpan.org/~mrf/Dredd-Hooks-0.05/</link>\n<description>Handler
-        for running Hook files for Dredd</description>\n<dc:creator>Mike Francis</dc:creator>\n<dc:date>2016-05-10T11:07+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~fglock/Perlito5-9.021/\">\n<title>Perlito5-9.021</title>\n<link>http://search.cpan.org/~fglock/Perlito5-9.021/</link>\n<description>a
-        Perl5 compiler </description>\n<dc:creator>Fl&#xE1;vio Soibelmann Glock</dc:creator>\n<dc:date>2016-05-10T10:29+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~manwar/Date-Utils-0.17/\">\n<title>Date-Utils-0.17</title>\n<link>http://search.cpan.org/~manwar/Date-Utils-0.17/</link>\n<description>Common
-        date functions as Moo Role.</description>\n<dc:creator>Mohammad S Anwar</dc:creator>\n<dc:date>2016-05-10T09:54+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~taniguchi/Number-Phone-JP-0.20160502/\">\n<title>Number-Phone-JP-0.20160502</title>\n<link>http://search.cpan.org/~taniguchi/Number-Phone-JP-0.20160502/</link>\n<description>Validate
-        Japanese phone numbers</description>\n<dc:creator>Koichi Taniguchi</dc:creator>\n<dc:date>2016-05-10T09:30+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~reneeb/Module-OTRS-CoreList-0.12/\">\n<title>Module-OTRS-CoreList-0.12</title>\n<link>http://search.cpan.org/~reneeb/Module-OTRS-CoreList-0.12/</link>\n<description>what
-        modules shipped with versions of OTRS (&#x3E;= 2.3.x)</description>\n<dc:creator>Ren&#xE9;e
-        B&#xE4;cker</dc:creator>\n<dc:date>2016-05-10T09:13+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~melmothx/Text-Amuse-Compile-0.57/\">\n<title>Text-Amuse-Compile-0.57</title>\n<link>http://search.cpan.org/~melmothx/Text-Amuse-Compile-0.57/</link>\n<description>Compiler
-        for Text::Amuse</description>\n<dc:creator>Marco Pessotto</dc:creator>\n<dc:date>2016-05-10T07:50+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~mik/Crypt-SRP-0.016/\">\n<title>Crypt-SRP-0.016</title>\n<link>http://search.cpan.org/~mik/Crypt-SRP-0.016/</link>\n<description>Secure
-        Remote Protocol</description>\n<dc:creator>Karel Miko</dc:creator>\n<dc:date>2016-05-10T07:47+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~mche/DBIx-POS-Template-0.00006/\">\n<title>DBIx-POS-Template-0.00006</title>\n<link>http://search.cpan.org/~mche/DBIx-POS-Template-0.00006/</link>\n<description>is
-        a fork of L&#x3C;DBIx::POS&#x3E;. Define a dictionary of SQL statements in
-        a POD dialect (POS) plus expand template sql with embedded Perl using L&#x3C;Text::Template&#x3E;.</description>\n<dc:creator>&#x41C;&#x438;&#x445;&#x430;&#x438;&#x43B;
-        &#x427;&#x435;</dc:creator>\n<dc:date>2016-05-10T07:46+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~mche/DBIx-POS-Template-0.00005/\">\n<title>DBIx-POS-Template-0.00005</title>\n<link>http://search.cpan.org/~mche/DBIx-POS-Template-0.00005/</link>\n<description>is
-        a fork of L&#x3C;DBIx::POS&#x3E;. Define a dictionary of SQL statements in
-        a POD dialect (POS) plus expand template sql with embedded Perl by L&#x3C;Text::Template&#x3E;.</description>\n<dc:creator>&#x41C;&#x438;&#x445;&#x430;&#x438;&#x43B;
-        &#x427;&#x435;</dc:creator>\n<dc:date>2016-05-10T07:28+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~edf/Geo-Address-Formatter-1.56/\">\n<title>Geo-Address-Formatter-1.56</title>\n<link>http://search.cpan.org/~edf/Geo-Address-Formatter-1.56/</link>\n<description>take
-        structured address data and format it according to the various global/country
-        rules</description>\n<dc:creator>Ed Freyfogle</dc:creator>\n<dc:date>2016-05-10T07:22+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~bkb/Test-CGI-External-0.16/\">\n<title>Test-CGI-External-0.16</title>\n<link>http://search.cpan.org/~bkb/Test-CGI-External-0.16/</link>\n<description>run
-        tests on an external CGI program</description>\n<dc:creator>Ben Bullock</dc:creator>\n<dc:date>2016-05-10T05:59+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~shantanu/Dist-Zilla-PluginBundle-SHANTANU-0.42/\">\n<title>Dist-Zilla-PluginBundle-SHANTANU-0.42</title>\n<link>http://search.cpan.org/~shantanu/Dist-Zilla-PluginBundle-SHANTANU-0.42/</link>\n<description>Dist
-        Zilla Plugin Bundle the way I like to use it</description>\n<dc:creator>Shantanu
-        Bhadoria</dc:creator>\n<dc:date>2016-05-10T04:38+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~shantanu/Printer-ESCPOS-0.025/\">\n<title>Printer-ESCPOS-0.025</title>\n<link>http://search.cpan.org/~shantanu/Printer-ESCPOS-0.025/</link>\n<description>Interface
-        for all thermal, dot-matrix and other receipt printers that support ESC-POS
-        specification.</description>\n<dc:creator>Shantanu Bhadoria</dc:creator>\n<dc:date>2016-05-10T04:27+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~cfaber/Config-Simple-Conf-1.8/\">\n<title>Config-Simple-Conf-1.8</title>\n<link>http://search.cpan.org/~cfaber/Config-Simple-Conf-1.8/</link>\n<description>A
-        fast and lightweight configuration file handler </description>\n<dc:creator>Colin
-        Faber</dc:creator>\n<dc:date>2016-05-10T04:24+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~mithaldu/Acme-MITHALDU-XSGrabBag-1.161310/\">\n<title>Acme-MITHALDU-XSGrabBag-1.161310</title>\n<link>http://search.cpan.org/~mithaldu/Acme-MITHALDU-XSGrabBag-1.161310/</link>\n<description>a
-        bunch of XS math functions i&#x27;m not sure where to shove yet</description>\n<dc:creator>Christian
-        Walde</dc:creator>\n<dc:date>2016-05-10T02:37+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~rsavage/WWW-Scraper-Wikipedia-ISO3166-1.04/\">\n<title>WWW-Scraper-Wikipedia-ISO3166-1.04</title>\n<link>http://search.cpan.org/~rsavage/WWW-Scraper-Wikipedia-ISO3166-1.04/</link>\n<description>Gently
-        scrape Wikipedia for ISO3166-2 data </description>\n<dc:creator>Ron Savage</dc:creator>\n<dc:date>2016-05-10T00:36+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~starlight/TAP-Formatter-Bamboo-0.04_02/\">\n<title>TAP-Formatter-Bamboo-0.04_02</title>\n<link>http://search.cpan.org/~starlight/TAP-Formatter-Bamboo-0.04_02/</link>\n<description>Harness
-        output delegate for Atlassian&#x27;s Bamboo CI server</description>\n<dc:creator>Bart&#x142;omiej
-        Fulanty</dc:creator>\n<dc:date>2016-05-10T00:17+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~rsavage/WWW-Scraper-Wikipedia-ISO3166-1.03/\">\n<title>WWW-Scraper-Wikipedia-ISO3166-1.03</title>\n<link>http://search.cpan.org/~rsavage/WWW-Scraper-Wikipedia-ISO3166-1.03/</link>\n<description>Gently
-        scrape Wikipedia for ISO3166-2 data </description>\n<dc:creator>Ron Savage</dc:creator>\n<dc:date>2016-05-10T00:09+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~diederich/IPC-Transit-1.161300/\">\n<title>IPC-Transit-1.161300</title>\n<link>http://search.cpan.org/~diederich/IPC-Transit-1.161300/</link>\n<description>A
-        framework for high performance message passing</description>\n<dc:creator>Dana
-        M. Diederich</dc:creator>\n<dc:date>2016-05-09T23:19+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~bingos/ExtUtils-MakeMaker-7.17_02/\">\n<title>ExtUtils-MakeMaker-7.17_02</title>\n<link>http://search.cpan.org/~bingos/ExtUtils-MakeMaker-7.17_02/</link>\n<description>Create
-        a module Makefile</description>\n<dc:creator>Chris Williams</dc:creator>\n<dc:date>2016-05-09T23:07+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~vyf/Ouroboros-0.08/\">\n<title>Ouroboros-0.08</title>\n<link>http://search.cpan.org/~vyf/Ouroboros-0.08/</link>\n<description>Perl
-        XS macros re-exported as C functions</description>\n<dc:creator>Vickenty Fesunov</dc:creator>\n<dc:date>2016-05-09T23:02+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~choroba/Syntax-Construct-0.23/\">\n<title>Syntax-Construct-0.23</title>\n<link>http://search.cpan.org/~choroba/Syntax-Construct-0.23/</link>\n<description>Identify
-        which non-feature constructs are used in the code.</description>\n<dc:creator>E.
-        Choroba</dc:creator>\n<dc:date>2016-05-09T23:00+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~choroba/Syntax-Construct-0.22/\">\n<title>Syntax-Construct-0.22</title>\n<link>http://search.cpan.org/~choroba/Syntax-Construct-0.22/</link>\n<description>Identify
-        which non-feature constructs are used in the code.</description>\n<dc:creator>E.
-        Choroba</dc:creator>\n<dc:date>2016-05-09T22:51+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~architek/WWW-FBX-0.11/\">\n<title>WWW-FBX-0.11</title>\n<link>http://search.cpan.org/~architek/WWW-FBX-0.11/</link>\n<description>A
-        perl interface to the Freebox v6 Rest API</description>\n<dc:creator>Laurent
-        Kislaire</dc:creator>\n<dc:date>2016-05-09T22:28+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~cymon/Dancer2-Plugin-Multilang-1.1.2/\">\n<title>Dancer2-Plugin-Multilang-1.1.2</title>\n<link>http://search.cpan.org/~cymon/Dancer2-Plugin-Multilang-1.1.2/</link>\n<description>Dancer2
-        Plugin to create multilanguage sites</description>\n<dc:creator>Simone Far&#xE9;</dc:creator>\n<dc:date>2016-05-09T21:43+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~enell/POD2-ES-5.22.0.2/\">\n<title>POD2-ES-5.22.0.2</title>\n<link>http://search.cpan.org/~enell/POD2-ES-5.22.0.2/</link>\n<description>Documentaci&#xF3;n
-        de Perl en espa&#xF1;ol</description>\n<dc:creator>Enrique Nell</dc:creator>\n<dc:date>2016-05-09T21:12+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~mhx/IPC-SysV-2.07/\">\n<title>IPC-SysV-2.07</title>\n<link>http://search.cpan.org/~mhx/IPC-SysV-2.07/</link>\n<description>System
-        V IPC constants and system calls</description>\n<dc:creator>Marcus Holland-Moritz</dc:creator>\n<dc:date>2016-05-09T20:44+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~jhthorsen/Mojolicious-Plugin-AssetPack-1.08/\">\n<title>Mojolicious-Plugin-AssetPack-1.08</title>\n<link>http://search.cpan.org/~jhthorsen/Mojolicious-Plugin-AssetPack-1.08/</link>\n<description>Compress
-        and convert css, less, sass, javascript and coffeescript files</description>\n<dc:creator>Jan
-        Henning Thorsen</dc:creator>\n<dc:date>2016-05-09T20:24+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~mik/CryptX-0.033/\">\n<title>CryptX-0.033</title>\n<link>http://search.cpan.org/~mik/CryptX-0.033/</link>\n<description>Crypto
-        toolkit</description>\n<dc:creator>Karel Miko</dc:creator>\n<dc:date>2016-05-09T20:20+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~mob/Forks-Super-0.82/\">\n<title>Forks-Super-0.82</title>\n<link>http://search.cpan.org/~mob/Forks-Super-0.82/</link>\n<description>extensions
-        and convenience methods to manage background processes</description>\n<dc:creator>Marty
-        O&#x27;Brien</dc:creator>\n<dc:date>2016-05-09T20:11+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~drolsky/Test-Class-Moose-0.71/\">\n<title>Test-Class-Moose-0.71</title>\n<link>http://search.cpan.org/~drolsky/Test-Class-Moose-0.71/</link>\n<description>Serious
-        testing for serious Perl</description>\n<dc:creator>Dave Rolsky</dc:creator>\n<dc:date>2016-05-09T19:18+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~bingos/ExtUtils-MakeMaker-7.17_01/\">\n<title>ExtUtils-MakeMaker-7.17_01</title>\n<link>http://search.cpan.org/~bingos/ExtUtils-MakeMaker-7.17_01/</link>\n<description>Create
-        a module Makefile</description>\n<dc:creator>Chris Williams</dc:creator>\n<dc:date>2016-05-09T19:14+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~ddumont/Config-Model-Systemd-0.005/\">\n<title>Config-Model-Systemd-0.005</title>\n<link>http://search.cpan.org/~ddumont/Config-Model-Systemd-0.005/</link>\n<description>Edit
-        and validate Systemd configuration files</description>\n<dc:creator>Dominique
-        Dumont</dc:creator>\n<dc:date>2016-05-09T18:48+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~drolsky/Test-Class-Moose-0.70/\">\n<title>Test-Class-Moose-0.70</title>\n<link>http://search.cpan.org/~drolsky/Test-Class-Moose-0.70/</link>\n<description>Serious
-        testing for serious Perl</description>\n<dc:creator>Dave Rolsky</dc:creator>\n<dc:date>2016-05-09T18:42+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~plicease/Alien-CMake-0.08/\">\n<title>Alien-CMake-0.08</title>\n<link>http://search.cpan.org/~plicease/Alien-CMake-0.08/</link>\n<description>Build
-        and make available CMake library - L&#x3C;http://cmake.org/&#x3E;</description>\n<dc:creator>&#x27E6;Graham
-        Ollis&#x27E7;</dc:creator>\n<dc:date>2016-05-09T17:54+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~tosh/Capstone-0.5/\">\n<title>Capstone-0.5</title>\n<link>http://search.cpan.org/~tosh/Capstone-0.5/</link>\n<description>Perl
-        extension for capstone-engine</description>\n<dc:creator>Simon Duret</dc:creator>\n<dc:date>2016-05-09T17:02+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~plicease/PkgConfig-0.12026/\">\n<title>PkgConfig-0.12026</title>\n<link>http://search.cpan.org/~plicease/PkgConfig-0.12026/</link>\n<description>Pure-Perl
-        Core-Only replacement for pkg-config</description>\n<dc:creator>&#x27E6;Graham
-        Ollis&#x27E7;</dc:creator>\n<dc:date>2016-05-09T16:57+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~gmax/MySQL-Sandbox-3.1.06/\">\n<title>MySQL-Sandbox-3.1.06</title>\n<link>http://search.cpan.org/~gmax/MySQL-Sandbox-3.1.06/</link>\n<description>Quickly
-        installs one or more MySQL servers in the same host, either standalone or
-        in groups</description>\n<dc:creator>Giuseppe Maxia</dc:creator>\n<dc:date>2016-05-09T16:55+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~mlawren/OptArgs2-0.0.1_1/\">\n<title>OptArgs2-0.0.1_1</title>\n<link>http://search.cpan.org/~mlawren/OptArgs2-0.0.1_1/</link>\n<description>command-line
-        argument and option processor</description>\n<dc:creator>Mark Lawrence</dc:creator>\n<dc:date>2016-05-09T15:40+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~rkelsch/Graphics-Framebuffer-5.78/\">\n<title>Graphics-Framebuffer-5.78</title>\n<link>http://search.cpan.org/~rkelsch/Graphics-Framebuffer-5.78/</link>\n<description>A
-        Simple Framebuffer Graphics Library</description>\n<dc:creator>Richard Kelsch</dc:creator>\n<dc:date>2016-05-09T15:19+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~oalders/HTTP-BrowserDetect-3.13/\">\n<title>HTTP-BrowserDetect-3.13</title>\n<link>http://search.cpan.org/~oalders/HTTP-BrowserDetect-3.13/</link>\n<description>Determine
-        Web browser, version, and platform from an HTTP user agent string</description>\n<dc:creator>Olaf
-        Alders</dc:creator>\n<dc:date>2016-05-09T15:19+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~melmothx/Text-Amuse-Compile-0.56/\">\n<title>Text-Amuse-Compile-0.56</title>\n<link>http://search.cpan.org/~melmothx/Text-Amuse-Compile-0.56/</link>\n<description>Compiler
-        for Text::Amuse</description>\n<dc:creator>Marco Pessotto</dc:creator>\n<dc:date>2016-05-09T15:02+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~sjdy/Mojo-IRC-Server-Chinese-1.7.8/\">\n<title>Mojo-IRC-Server-Chinese-1.7.8</title>\n<link>http://search.cpan.org/~sjdy/Mojo-IRC-Server-Chinese-1.7.8/</link>\n<description>A
-        Chinese IRC server base on Mojolicious</description>\n<dc:creator>sjdy521</dc:creator>\n<dc:date>2016-05-09T14:36+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~melmothx/Text-Amuse-0.61/\">\n<title>Text-Amuse-0.61</title>\n<link>http://search.cpan.org/~melmothx/Text-Amuse-0.61/</link>\n<description>Generate
-        HTML and LaTeX documents from Emacs Muse markup.</description>\n<dc:creator>Marco
-        Pessotto</dc:creator>\n<dc:date>2016-05-09T14:18+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~vroom/WebService-Ooyala-0.03/\">\n<title>WebService-Ooyala-0.03</title>\n<link>http://search.cpan.org/~vroom/WebService-Ooyala-0.03/</link>\n<description>Perl
-        interface to Ooyala&#x27;s API, currently only read</description>\n<dc:creator>Tim
-        Vroom</dc:creator>\n<dc:date>2016-05-09T14:11+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~tpoder/Net-NfDump-1.20/\">\n<title>Net-NfDump-1.20</title>\n<link>http://search.cpan.org/~tpoder/Net-NfDump-1.20/</link>\n<description>Perl
-        API for manipulating with nfdump files based on libnf.net library </description>\n<dc:creator>Tomas
-        Podermanski</dc:creator>\n<dc:date>2016-05-09T13:55+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~lucas/Dancer2-Plugin-Pg-0.05/\">\n<title>Dancer2-Plugin-Pg-0.05</title>\n<link>http://search.cpan.org/~lucas/Dancer2-Plugin-Pg-0.05/</link>\n<description>PostgreSQL
-        connection for Dancer2</description>\n<dc:creator>Lucas Tiago de Moraes</dc:creator>\n<dc:date>2016-05-09T12:57+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~bingos/Module-CoreList-5.20160507/\">\n<title>Module-CoreList-5.20160507</title>\n<link>http://search.cpan.org/~bingos/Module-CoreList-5.20160507/</link>\n<description>what
-        modules shipped with versions of perl</description>\n<dc:creator>Chris Williams</dc:creator>\n<dc:date>2016-05-09T12:21+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~bingos/CPAN-Perl-Releases-2.76/\">\n<title>CPAN-Perl-Releases-2.76</title>\n<link>http://search.cpan.org/~bingos/CPAN-Perl-Releases-2.76/</link>\n<description>Mapping
-        Perl releases on CPAN to the location of the tarballs</description>\n<dc:creator>Chris
-        Williams</dc:creator>\n<dc:date>2016-05-09T12:20+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~rjbs/perl-5.25.0/\">\n<title>perl-5.25.0</title>\n<link>http://search.cpan.org/~rjbs/perl-5.25.0/</link>\n<description>The
-        Perl 5 language interpreter</description>\n<dc:creator>Ricardo SIGNES</dc:creator>\n<dc:date>2016-05-09T12:03+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~rjbs/perl-5.24.0/\">\n<title>perl-5.24.0</title>\n<link>http://search.cpan.org/~rjbs/perl-5.24.0/</link>\n<description>The
-        Perl 5 language interpreter</description>\n<dc:creator>Ricardo SIGNES</dc:creator>\n<dc:date>2016-05-09T11:35+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~perlancar/Devel-DieHandler-DumpINC-0.002/\">\n<title>Devel-DieHandler-DumpINC-0.002</title>\n<link>http://search.cpan.org/~perlancar/Devel-DieHandler-DumpINC-0.002/</link>\n<description>Dump
-        content of %INC when program dies</description>\n<dc:creator>perlancar</dc:creator>\n<dc:date>2016-05-09T11:31+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~perlancar/Devel-DieHandler-DumpINC-0.001/\">\n<title>Devel-DieHandler-DumpINC-0.001</title>\n<link>http://search.cpan.org/~perlancar/Devel-DieHandler-DumpINC-0.001/</link>\n<description>Dump
-        content of %INC when program dies</description>\n<dc:creator>perlancar</dc:creator>\n<dc:date>2016-05-09T11:30+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~manwar/Task-Calendar-0.17/\">\n<title>Task-Calendar-0.17</title>\n<link>http://search.cpan.org/~manwar/Task-Calendar-0.17/</link>\n<description>Bundles
-        Calendar::* packages.</description>\n<dc:creator>Mohammad S Anwar</dc:creator>\n<dc:date>2016-05-09T11:28+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~starlight/TAP-Formatter-Bamboo-0.04_01/\">\n<title>TAP-Formatter-Bamboo-0.04_01</title>\n<link>http://search.cpan.org/~starlight/TAP-Formatter-Bamboo-0.04_01/</link>\n<description>Harness
-        output delegate for Atlassian&#x27;s Bamboo CI server </description>\n<dc:creator>Bart&#x142;omiej
-        Fulanty</dc:creator>\n<dc:date>2016-05-09T11:00+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~salva/Net-SSH2-0.59_18/\">\n<title>Net-SSH2-0.59_18</title>\n<link>http://search.cpan.org/~salva/Net-SSH2-0.59_18/</link>\n<description>Support
-        for the SSH 2 protocol via libssh2.</description>\n<dc:creator>Salvador Fandi&#xF1;o
-        Garc&#xED;a</dc:creator>\n<dc:date>2016-05-09T11:00+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~rurban/B-C-1.54_03/\">\n<title>B-C-1.54_03</title>\n<link>http://search.cpan.org/~rurban/B-C-1.54_03/</link>\n<description>Perl
-        compiler</description>\n<dc:creator>Reini Urban</dc:creator>\n<dc:date>2016-05-09T08:49+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~perlancar/Perinci-CmdLine-Lite-1.54/\">\n<title>Perinci-CmdLine-Lite-1.54</title>\n<link>http://search.cpan.org/~perlancar/Perinci-CmdLine-Lite-1.54/</link>\n<description>A
-        lightweight Rinci/Riap-based command-line application framework</description>\n<dc:creator>perlancar</dc:creator>\n<dc:date>2016-05-09T07:50+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~perlancar/Complete-File-0.40/\">\n<title>Complete-File-0.40</title>\n<link>http://search.cpan.org/~perlancar/Complete-File-0.40/</link>\n<description>Completion
-        routines related to files</description>\n<dc:creator>perlancar</dc:creator>\n<dc:date>2016-05-09T07:50+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~srezic/CPAN-Plugin-Sysdeps-0.05/\">\n<title>CPAN-Plugin-Sysdeps-0.05</title>\n<link>http://search.cpan.org/~srezic/CPAN-Plugin-Sysdeps-0.05/</link>\n<description>CPAN.pm
-        plugin for installing external dependencies</description>\n<dc:creator>Slaven
-        Rezi&#x107;</dc:creator>\n<dc:date>2016-05-09T07:13+00:00</dc:date>\n</item>\n<item
-        rdf:about=\"http://search.cpan.org/~chromatic/Mojolicious-Plugin-UnicodeNormalize-1.20160509/\">\n<title>Mojolicious-Plugin-UnicodeNormalize-1.20160509</title>\n<link>http://search.cpan.org/~chromatic/Mojolicious-Plugin-UnicodeNormalize-1.20160509/</link>\n<description>normalize
-        incoming Unicode parameters</description>\n<dc:creator>chromatic</dc:creator>\n<dc:date>2016-05-09T05:43+00:00</dc:date>\n</item>\n</rdf:RDF>"}
+    body: {string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\n<rdf:RDF\n xmlns:rdf=\"\
+        http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\n xmlns=\"http://purl.org/rss/1.0/\"\
+        \n xmlns:admin=\"http://webns.net/mvcb/\"\n xmlns:atom=\"http://www.w3.org/2005/Atom\"\
+        \n xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"\n xmlns:dc=\"\
+        http://purl.org/dc/elements/1.1/\"\n xmlns:dcterms=\"http://purl.org/dc/terms/\"\
+        \n xmlns:geo=\"http://www.w3.org/2003/01/geo/wgs84_pos#\"\n xmlns:syn=\"http://purl.org/rss/1.0/modules/syndication/\"\
+        \n xmlns:taxo=\"http://purl.org/rss/1.0/modules/taxonomy/\"\n>\n\n<channel\
+        \ rdf:about=\"/\">\n<title>Recent CPAN uploads - MetaCPAN</title>\n<link>/</link>\n\
+        <description></description>\n<items>\n <rdf:Seq>\n  <rdf:li rdf:resource=\"\
+        https://metacpan.org/release/JEFFOBER/URI-Fast-0.38_06\" />\n  <rdf:li rdf:resource=\"\
+        https://metacpan.org/release/HOWARS/Model-Envoy-0.2.4\" />\n  <rdf:li rdf:resource=\"\
+        https://metacpan.org/release/KUERBIS/Term-Form-0.320\" />\n  <rdf:li rdf:resource=\"\
+        https://metacpan.org/release/VKON/Tcl-1.19\" />\n  <rdf:li rdf:resource=\"\
+        https://metacpan.org/release/JMASLAK/JTM-Boilerplate-2.182001\" />\n  <rdf:li\
+        \ rdf:resource=\"https://metacpan.org/release/JMASLAK/JTM-Boilerplate-2.182000\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/DWHEELER/URI-db-0.19\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/LNATION/Time-Random-0.01\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/OETIKER/Zimbra-Expect-0.1.1\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/LTHEISEN/Maven-Agent-1.15\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/HOWARS/Model-Envoy-0.2.3\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/NHORNE/CGI-Buffer-0.81\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/JEFFOBER/Ion-0.07_01\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/VLYON/Dist-Zilla-Plugin-UseBuildPL-0.3\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/VIY/File-Lock-ParentLock-0.08\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/JHTHORSEN/Mojo-GoogleAnalytics-0.04\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/GBROWN/Net-RDAP-0.8\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/JHTHORSEN/Mojolicious-Plugin-AssetPack-2.04\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/VIY/File-Lock-ParentLock-0.07\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/SULLR/IO-Socket-SSL-2.058\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/JHTHORSEN/Mojo-GoogleAnalytics-0.03\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/NML/Test-TCP-2.19_01-TRIAL\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/WYANT/Astro-Coord-ECI-TLE-Iridium-0.100_01\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/WYANT/Astro-SpaceTrack-0.112_01\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/SONGMU/DBIx-Sunny-0.9991\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/SHADKAM/QuickTermChart-QuickTermChart-0.01\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/YANICK/Parallel-ForkManager-1.20\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/SHADKAM/quick_term_chart_180718\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/ZIALI/Mojolicious-Plugin-JSONAPI-2.0\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/ZIALI/JSONAPI-Document-2.2\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/ROMM/Sport-Analytics-NHL-1.11\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/TOBYINK/Types-HTML5-0.001\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/BORISD/App-Unding-0.006\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/TMUELLER/HTTP-Exception-0.04007\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/JEFFOBER/Ion-0.07-TRIAL\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/RAPHI/InfluxDB-HTTP-0.04\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/KUERBIS/Term-Choose-1.607\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/SULLR/IO-Socket-SSL-2.057\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/JEFFOBER/URI-Fast-0.38_05\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/MANWAR/Map-Tube-CLI-0.48\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/HOUSTON/Password-Policy-Rule-Pwned-0.00_02\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/VKON/Tcl-1.18\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/EXODIST/Test2-Harness-0.001067\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/MELMOTHX/Text-Amuse-Compile-1.06\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/KWAKWA/Task-BeLike-KWAKWA-0.02\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/JEFFOBER/URI-Fast-0.38_04\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/ALTREUS/OpusVL-Preferences-0.31\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/MELMOTHX/Text-Amuse-Preprocessor-0.55\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/MCICHRA/Test-APIcast-0.15\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/KUERBIS/Term-Choose-1.606\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/TULAMILI/App-matrixpack-0.0014\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/KUERBIS/Term-Choose-1.605\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/TULAMILI/App-matrixpack-0.0013\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/TULAMILI/App-matrixpack-0.0012\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/SONGMU/DBIx-Sunny-0.9990\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/JMASLAK/File-ByLine-1.181990\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/JDHEDDEN/Thread-Queue-3.13\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/ROCKY/Devel-Callsite-1.0.1\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/ROCKY/Devel-Callsite-1.0.0\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/GENEHACK/Git-Wrapper-0.048_090\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/JEFFOBER/URI-Fast-0.38_03\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/HEXFUSION/Net-Etcd-0.022\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/EXODIST/Test-Simple-1.302139-TRIAL\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/DDUMONT/Software-LicenseMoreUtils-1.002\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/MELMOTHX/Text-Amuse-Compile-1.05\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/CORION/Finance-Bank-Postbank_de-0.51\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/MANWAR/Map-Tube-Madrid-0.13\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/JILLROWE/BioSAILs-Command-1.0\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/PAVELSR/Kayako-RestAPI-0.06\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/WILLBELL/EPFL-Net-ipv6Test-1.01\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/EKAWAS/WSRF-Lite-0.8.3.2\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/TOBYINK/Object-Util-0.009\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/PJDEVOPS/File-Tabular-Web-0.25\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/MLAWREN/App-githook-perltidy-0.11.11_1\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/MEMOWE/EventStore-Tiny-0.4\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/VKON/Tcl-1.17\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/TOBYINK/Exporter-Tiny-1.002001\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/TOBYINK/Exporter-Tiny-1.002000\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/MARTINGO/MikroTik-API-1.0.5\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/PAVELSR/Kayako-RestAPI-0.05\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/PEVANS/Devel-MAT-0.36\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/NALOBIN/Net-Whois-Raw-2.99016\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/PEVANS/Devel-MAT-Dumper-0.36\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/SGRAY/Apache-Defaults-1.01\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/WILLBELL/EPFL-Net-ipv6Test-1.00\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/NML/Danga-Socket-1.62_01-TRIAL\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/JMASLAK/File-ByLine-1.181981-TRIAL\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/OALDERS/lazy-0.000006\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/WYANT/Astro-satpass-0.099_01\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/BINARY/Math-Business-BlackscholesMerton-1.24\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/JMASLAK/File-ByLine-1.181980-TRIAL\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/ROMM/Sport-Analytics-NHL-1.10\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/AMIRI/Elasticsearch-Model-0.1.4\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/JEFFOBER/URI-Fast-0.38_02\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/TURNERJW/Tk-HListbox-2.1\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/BYTERAZOR/Git-LowLevel-0.1\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/BLHOTSKY/App-ElasticSearch-Utilities-5.8\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/CORION/Finance-Bank-Postbank_de-0.50\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/MANWAR/BankAccount-Validator-UK-0.41\"\
+        \ />\n  <rdf:li rdf:resource=\"https://metacpan.org/release/LLAP/Net-Amazon-S3-0.84\"\
+        \ />\n </rdf:Seq>\n</items>\n</channel>\n<item rdf:about=\"https://metacpan.org/release/JEFFOBER/URI-Fast-0.38_06\"\
+        >\n<title>URI-Fast-0.38_06</title>\n<link>https://metacpan.org/release/JEFFOBER/URI-Fast-0.38_06</link>\n\
+        <description>A fast(er) URI parser</description>\n<dc:creator>JEFFOBER</dc:creator>\n\
+        <dc:date>2018-07-19T17:54:25</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/HOWARS/Model-Envoy-0.2.4\"\
+        >\n<title>Model-Envoy-0.2.4</title>\n<link>https://metacpan.org/release/HOWARS/Model-Envoy-0.2.4</link>\n\
+        <description>A Moose Role that can be used to build a model layer that keeps\
+        \ business logic separate from your storage layer.</description>\n<dc:creator>HOWARS</dc:creator>\n\
+        <dc:date>2018-07-19T16:37:03</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/KUERBIS/Term-Form-0.320\"\
+        >\n<title>Term-Form-0.320</title>\n<link>https://metacpan.org/release/KUERBIS/Term-Form-0.320</link>\n\
+        <description>Read lines from STDIN.</description>\n<dc:creator>KUERBIS</dc:creator>\n\
+        <dc:date>2018-07-19T16:31:42</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/VKON/Tcl-1.19\"\
+        >\n<title>Tcl-1.19</title>\n<link>https://metacpan.org/release/VKON/Tcl-1.19</link>\n\
+        <description>Tcl extension module for Perl</description>\n<dc:creator>VKON</dc:creator>\n\
+        <dc:date>2018-07-19T16:25:01</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/JMASLAK/JTM-Boilerplate-2.182001\"\
+        >\n<title>JTM-Boilerplate-2.182001</title>\n<link>https://metacpan.org/release/JMASLAK/JTM-Boilerplate-2.182001</link>\n\
+        <description>Default Boilerplate for Joelle Maslak&#x26;#39;s Code</description>\n\
+        <dc:creator>JMASLAK</dc:creator>\n<dc:date>2018-07-19T15:45:22</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/JMASLAK/JTM-Boilerplate-2.182000\"\
+        >\n<title>JTM-Boilerplate-2.182000</title>\n<link>https://metacpan.org/release/JMASLAK/JTM-Boilerplate-2.182000</link>\n\
+        <description>Default Boilerplate for Joelle Maslak&#x26;#39;s Code</description>\n\
+        <dc:creator>JMASLAK</dc:creator>\n<dc:date>2018-07-19T15:42:31</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/DWHEELER/URI-db-0.19\"\
+        >\n<title>URI-db-0.19</title>\n<link>https://metacpan.org/release/DWHEELER/URI-db-0.19</link>\n\
+        <description>Database URIs</description>\n<dc:creator>DWHEELER</dc:creator>\n\
+        <dc:date>2018-07-19T15:16:59</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/LNATION/Time-Random-0.01\"\
+        >\n<title>Time-Random-0.01</title>\n<link>https://metacpan.org/release/LNATION/Time-Random-0.01</link>\n\
+        <description>Generate a random time in time.</description>\n<dc:creator>LNATION</dc:creator>\n\
+        <dc:date>2018-07-19T14:40:04</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/OETIKER/Zimbra-Expect-0.1.1\"\
+        >\n<title>Zimbra-Expect-0.1.1</title>\n<link>https://metacpan.org/release/OETIKER/Zimbra-Expect-0.1.1</link>\n\
+        <description>Execute multiple commands with a single instance of zmprov or\
+        \ zmmailbox and thus run magnitudes faster</description>\n<dc:creator>OETIKER</dc:creator>\n\
+        <dc:date>2018-07-19T14:30:53</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/LTHEISEN/Maven-Agent-1.15\"\
+        >\n<title>Maven-Agent-1.15</title>\n<link>https://metacpan.org/release/LTHEISEN/Maven-Agent-1.15</link>\n\
+        <description>A base agent for working with maven</description>\n<dc:creator>LTHEISEN</dc:creator>\n\
+        <dc:date>2018-07-19T14:10:15</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/HOWARS/Model-Envoy-0.2.3\"\
+        >\n<title>Model-Envoy-0.2.3</title>\n<link>https://metacpan.org/release/HOWARS/Model-Envoy-0.2.3</link>\n\
+        <description>A Moose Role that can be used to build a model layer that keeps\
+        \ business logic separate from your storage layer.</description>\n<dc:creator>HOWARS</dc:creator>\n\
+        <dc:date>2018-07-19T14:07:16</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/NHORNE/CGI-Buffer-0.81\"\
+        >\n<title>CGI-Buffer-0.81</title>\n<link>https://metacpan.org/release/NHORNE/CGI-Buffer-0.81</link>\n\
+        <description>Verify, Cache and Optimise CGI Output</description>\n<dc:creator>NHORNE</dc:creator>\n\
+        <dc:date>2018-07-19T12:54:34</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/JEFFOBER/Ion-0.07_01\"\
+        >\n<title>Ion-0.07_01</title>\n<link>https://metacpan.org/release/JEFFOBER/Ion-0.07_01</link>\n\
+        <description>A clear and concise API for writing TCP servers and clients</description>\n\
+        <dc:creator>JEFFOBER</dc:creator>\n<dc:date>2018-07-19T12:53:04</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/VLYON/Dist-Zilla-Plugin-UseBuildPL-0.3\"\
+        >\n<title>Dist-Zilla-Plugin-UseBuildPL-0.3</title>\n<link>https://metacpan.org/release/VLYON/Dist-Zilla-Plugin-UseBuildPL-0.3</link>\n\
+        <description>BYOB (Bring Your Own Build.PL)</description>\n<dc:creator>VLYON</dc:creator>\n\
+        <dc:date>2018-07-19T12:37:39</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/VIY/File-Lock-ParentLock-0.08\"\
+        >\n<title>File-Lock-ParentLock-0.08</title>\n<link>https://metacpan.org/release/VIY/File-Lock-ParentLock-0.08</link>\n\
+        <description>share lock among child processes of given pid.</description>\n\
+        <dc:creator>VIY</dc:creator>\n<dc:date>2018-07-19T11:27:48</dc:date>\n</item>\n\
+        <item rdf:about=\"https://metacpan.org/release/JHTHORSEN/Mojo-GoogleAnalytics-0.04\"\
+        >\n<title>Mojo-GoogleAnalytics-0.04</title>\n<link>https://metacpan.org/release/JHTHORSEN/Mojo-GoogleAnalytics-0.04</link>\n\
+        <description>Extract data from Google Analytics using Mojo UserAgent</description>\n\
+        <dc:creator>JHTHORSEN</dc:creator>\n<dc:date>2018-07-19T11:06:02</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/GBROWN/Net-RDAP-0.8\"\
+        >\n<title>Net-RDAP-0.8</title>\n<link>https://metacpan.org/release/GBROWN/Net-RDAP-0.8</link>\n\
+        <description>an interface to the Registration Data Access Protocol (RDAP).</description>\n\
+        <dc:creator>GBROWN</dc:creator>\n<dc:date>2018-07-19T10:38:55</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/JHTHORSEN/Mojolicious-Plugin-AssetPack-2.04\"\
+        >\n<title>Mojolicious-Plugin-AssetPack-2.04</title>\n<link>https://metacpan.org/release/JHTHORSEN/Mojolicious-Plugin-AssetPack-2.04</link>\n\
+        <description>Compress and convert css, less, sass, javascript and coffeescript\
+        \ files</description>\n<dc:creator>JHTHORSEN</dc:creator>\n<dc:date>2018-07-19T09:39:51</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/VIY/File-Lock-ParentLock-0.07\"\
+        >\n<title>File-Lock-ParentLock-0.07</title>\n<link>https://metacpan.org/release/VIY/File-Lock-ParentLock-0.07</link>\n\
+        <description>share lock among child processes of given pid.</description>\n\
+        <dc:creator>VIY</dc:creator>\n<dc:date>2018-07-19T08:37:46</dc:date>\n</item>\n\
+        <item rdf:about=\"https://metacpan.org/release/SULLR/IO-Socket-SSL-2.058\"\
+        >\n<title>IO-Socket-SSL-2.058</title>\n<link>https://metacpan.org/release/SULLR/IO-Socket-SSL-2.058</link>\n\
+        <description>Nearly transparent SSL encapsulation for IO::Socket::INET.</description>\n\
+        <dc:creator>SULLR</dc:creator>\n<dc:date>2018-07-19T07:54:24</dc:date>\n</item>\n\
+        <item rdf:about=\"https://metacpan.org/release/JHTHORSEN/Mojo-GoogleAnalytics-0.03\"\
+        >\n<title>Mojo-GoogleAnalytics-0.03</title>\n<link>https://metacpan.org/release/JHTHORSEN/Mojo-GoogleAnalytics-0.03</link>\n\
+        <description>Extract data from Google Analytics using Mojo UserAgent</description>\n\
+        <dc:creator>JHTHORSEN</dc:creator>\n<dc:date>2018-07-19T07:02:13</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/NML/Test-TCP-2.19_01-TRIAL\"\
+        >\n<title>Test-TCP-2.19_01-TRIAL</title>\n<link>https://metacpan.org/release/NML/Test-TCP-2.19_01-TRIAL</link>\n\
+        <description>testing TCP program</description>\n<dc:creator>NML</dc:creator>\n\
+        <dc:date>2018-07-19T05:32:28</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/WYANT/Astro-Coord-ECI-TLE-Iridium-0.100_01\"\
+        >\n<title>Astro-Coord-ECI-TLE-Iridium-0.100_01</title>\n<link>https://metacpan.org/release/WYANT/Astro-Coord-ECI-TLE-Iridium-0.100_01</link>\n\
+        <description>Class to compute Iridium Classic flares</description>\n<dc:creator>WYANT</dc:creator>\n\
+        <dc:date>2018-07-19T02:40:45</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/WYANT/Astro-SpaceTrack-0.112_01\"\
+        >\n<title>Astro-SpaceTrack-0.112_01</title>\n<link>https://metacpan.org/release/WYANT/Astro-SpaceTrack-0.112_01</link>\n\
+        <description>Download satellite orbital elements from Space Track</description>\n\
+        <dc:creator>WYANT</dc:creator>\n<dc:date>2018-07-19T02:37:59</dc:date>\n</item>\n\
+        <item rdf:about=\"https://metacpan.org/release/SONGMU/DBIx-Sunny-0.9991\"\
+        >\n<title>DBIx-Sunny-0.9991</title>\n<link>https://metacpan.org/release/SONGMU/DBIx-Sunny-0.9991</link>\n\
+        <description>Simple DBI wrapper</description>\n<dc:creator>SONGMU</dc:creator>\n\
+        <dc:date>2018-07-19T01:19:25</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/SHADKAM/QuickTermChart-QuickTermChart-0.01\"\
+        >\n<title>QuickTermChart-QuickTermChart-0.01</title>\n<link>https://metacpan.org/release/SHADKAM/QuickTermChart-QuickTermChart-0.01</link>\n\
+        <description>QuickTermChart/QuickTermChart.pm</description>\n<dc:creator>SHADKAM</dc:creator>\n\
+        <dc:date>2018-07-19T01:01:28</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/YANICK/Parallel-ForkManager-1.20\"\
+        >\n<title>Parallel-ForkManager-1.20</title>\n<link>https://metacpan.org/release/YANICK/Parallel-ForkManager-1.20</link>\n\
+        <description>A simple parallel processing fork manager</description>\n<dc:creator>YANICK</dc:creator>\n\
+        <dc:date>2018-07-19T00:48:24</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/SHADKAM/quick_term_chart_180718\"\
+        >\n<title>quick_term_chart_180718</title>\n<link>https://metacpan.org/release/SHADKAM/quick_term_chart_180718</link>\n\
+        <description>a light perl script to quickly draw chart within the terminal\
+        \ input data can be piped to it</description>\n<dc:creator>SHADKAM</dc:creator>\n\
+        <dc:date>2018-07-19T00:09:04</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/ZIALI/Mojolicious-Plugin-JSONAPI-2.0\"\
+        >\n<title>Mojolicious-Plugin-JSONAPI-2.0</title>\n<link>https://metacpan.org/release/ZIALI/Mojolicious-Plugin-JSONAPI-2.0</link>\n\
+        <description>Mojolicious Plugin for building JSON API compliant applications.</description>\n\
+        <dc:creator>ZIALI</dc:creator>\n<dc:date>2018-07-18T22:24:07</dc:date>\n</item>\n\
+        <item rdf:about=\"https://metacpan.org/release/ZIALI/JSONAPI-Document-2.2\"\
+        >\n<title>JSONAPI-Document-2.2</title>\n<link>https://metacpan.org/release/ZIALI/JSONAPI-Document-2.2</link>\n\
+        <description>Turn DBIx results into JSON API documents.</description>\n<dc:creator>ZIALI</dc:creator>\n\
+        <dc:date>2018-07-18T22:04:46</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/ROMM/Sport-Analytics-NHL-1.11\"\
+        >\n<title>Sport-Analytics-NHL-1.11</title>\n<link>https://metacpan.org/release/ROMM/Sport-Analytics-NHL-1.11</link>\n\
+        <description>Interface to the National Hockey League data</description>\n\
+        <dc:creator>ROMM</dc:creator>\n<dc:date>2018-07-18T21:59:04</dc:date>\n</item>\n\
+        <item rdf:about=\"https://metacpan.org/release/TOBYINK/Types-HTML5-0.001\"\
+        >\n<title>Types-HTML5-0.001</title>\n<link>https://metacpan.org/release/TOBYINK/Types-HTML5-0.001</link>\n\
+        <description>types for parsing strings of HTML into DOMs</description>\n<dc:creator>TOBYINK</dc:creator>\n\
+        <dc:date>2018-07-18T21:47:24</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/BORISD/App-Unding-0.006\"\
+        >\n<title>App-Unding-0.006</title>\n<link>https://metacpan.org/release/BORISD/App-Unding-0.006</link>\n\
+        <description>dark magic, encrypted wallet</description>\n<dc:creator>BORISD</dc:creator>\n\
+        <dc:date>2018-07-18T21:29:27</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/TMUELLER/HTTP-Exception-0.04007\"\
+        >\n<title>HTTP-Exception-0.04007</title>\n<link>https://metacpan.org/release/TMUELLER/HTTP-Exception-0.04007</link>\n\
+        <description>throw HTTP-Errors as (Exception::Class-) Exceptions</description>\n\
+        <dc:creator>TMUELLER</dc:creator>\n<dc:date>2018-07-18T20:52:27</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/JEFFOBER/Ion-0.07-TRIAL\"\
+        >\n<title>Ion-0.07-TRIAL</title>\n<link>https://metacpan.org/release/JEFFOBER/Ion-0.07-TRIAL</link>\n\
+        <description>A clear and concise API for writing TCP servers and clients</description>\n\
+        <dc:creator>JEFFOBER</dc:creator>\n<dc:date>2018-07-18T19:59:16</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/RAPHI/InfluxDB-HTTP-0.04\"\
+        >\n<title>InfluxDB-HTTP-0.04</title>\n<link>https://metacpan.org/release/RAPHI/InfluxDB-HTTP-0.04</link>\n\
+        <description>The Perl way to interact with InfluxDB!</description>\n<dc:creator>RAPHI</dc:creator>\n\
+        <dc:date>2018-07-18T19:41:14</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/KUERBIS/Term-Choose-1.607\"\
+        >\n<title>Term-Choose-1.607</title>\n<link>https://metacpan.org/release/KUERBIS/Term-Choose-1.607</link>\n\
+        <description>Choose items from a list interactively.</description>\n<dc:creator>KUERBIS</dc:creator>\n\
+        <dc:date>2018-07-18T19:41:02</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/SULLR/IO-Socket-SSL-2.057\"\
+        >\n<title>IO-Socket-SSL-2.057</title>\n<link>https://metacpan.org/release/SULLR/IO-Socket-SSL-2.057</link>\n\
+        <description>Nearly transparent SSL encapsulation for IO::Socket::INET.</description>\n\
+        <dc:creator>SULLR</dc:creator>\n<dc:date>2018-07-18T19:16:28</dc:date>\n</item>\n\
+        <item rdf:about=\"https://metacpan.org/release/JEFFOBER/URI-Fast-0.38_05\"\
+        >\n<title>URI-Fast-0.38_05</title>\n<link>https://metacpan.org/release/JEFFOBER/URI-Fast-0.38_05</link>\n\
+        <description>A fast(er) URI parser</description>\n<dc:creator>JEFFOBER</dc:creator>\n\
+        <dc:date>2018-07-18T17:51:45</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/MANWAR/Map-Tube-CLI-0.48\"\
+        >\n<title>Map-Tube-CLI-0.48</title>\n<link>https://metacpan.org/release/MANWAR/Map-Tube-CLI-0.48</link>\n\
+        <description>Command Line Interface for Map::Tube::* map.</description>\n\
+        <dc:creator>MANWAR</dc:creator>\n<dc:date>2018-07-18T17:40:03</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/HOUSTON/Password-Policy-Rule-Pwned-0.00_02\"\
+        >\n<title>Password-Policy-Rule-Pwned-0.00_02</title>\n<link>https://metacpan.org/release/HOUSTON/Password-Policy-Rule-Pwned-0.00_02</link>\n\
+        <description>Compare text to known pwned passwords list</description>\n<dc:creator>HOUSTON</dc:creator>\n\
+        <dc:date>2018-07-18T17:00:44</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/VKON/Tcl-1.18\"\
+        >\n<title>Tcl-1.18</title>\n<link>https://metacpan.org/release/VKON/Tcl-1.18</link>\n\
+        <description>Tcl extension module for Perl</description>\n<dc:creator>VKON</dc:creator>\n\
+        <dc:date>2018-07-18T15:54:30</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/EXODIST/Test2-Harness-0.001067\"\
+        >\n<title>Test2-Harness-0.001067</title>\n<link>https://metacpan.org/release/EXODIST/Test2-Harness-0.001067</link>\n\
+        <description>Test2 Harness designed for the Test2 event system</description>\n\
+        <dc:creator>EXODIST</dc:creator>\n<dc:date>2018-07-18T14:45:51</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/MELMOTHX/Text-Amuse-Compile-1.06\"\
+        >\n<title>Text-Amuse-Compile-1.06</title>\n<link>https://metacpan.org/release/MELMOTHX/Text-Amuse-Compile-1.06</link>\n\
+        <description>Compiler for Text::Amuse</description>\n<dc:creator>MELMOTHX</dc:creator>\n\
+        <dc:date>2018-07-18T14:21:19</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/KWAKWA/Task-BeLike-KWAKWA-0.02\"\
+        >\n<title>Task-BeLike-KWAKWA-0.02</title>\n<link>https://metacpan.org/release/KWAKWA/Task-BeLike-KWAKWA-0.02</link>\n\
+        <description>Be more like KWAKWA - use the modules he likes!</description>\n\
+        <dc:creator>KWAKWA</dc:creator>\n<dc:date>2018-07-18T13:55:48</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/JEFFOBER/URI-Fast-0.38_04\"\
+        >\n<title>URI-Fast-0.38_04</title>\n<link>https://metacpan.org/release/JEFFOBER/URI-Fast-0.38_04</link>\n\
+        <description>A fast(er) URI parser</description>\n<dc:creator>JEFFOBER</dc:creator>\n\
+        <dc:date>2018-07-18T13:55:36</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/ALTREUS/OpusVL-Preferences-0.31\"\
+        >\n<title>OpusVL-Preferences-0.31</title>\n<link>https://metacpan.org/release/ALTREUS/OpusVL-Preferences-0.31</link>\n\
+        <description>Generic DBIC preferences module</description>\n<dc:creator>ALTREUS</dc:creator>\n\
+        <dc:date>2018-07-18T13:23:07</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/MELMOTHX/Text-Amuse-Preprocessor-0.55\"\
+        >\n<title>Text-Amuse-Preprocessor-0.55</title>\n<link>https://metacpan.org/release/MELMOTHX/Text-Amuse-Preprocessor-0.55</link>\n\
+        <description>Helpers for Text::Amuse document formatting.</description>\n\
+        <dc:creator>MELMOTHX</dc:creator>\n<dc:date>2018-07-18T12:24:41</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/MCICHRA/Test-APIcast-0.15\"\
+        >\n<title>Test-APIcast-0.15</title>\n<link>https://metacpan.org/release/MCICHRA/Test-APIcast-0.15</link>\n\
+        <description>Testing framework for APIcast.</description>\n<dc:creator>MCICHRA</dc:creator>\n\
+        <dc:date>2018-07-18T10:46:03</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/KUERBIS/Term-Choose-1.606\"\
+        >\n<title>Term-Choose-1.606</title>\n<link>https://metacpan.org/release/KUERBIS/Term-Choose-1.606</link>\n\
+        <description>Choose items from a list interactively.</description>\n<dc:creator>KUERBIS</dc:creator>\n\
+        <dc:date>2018-07-18T10:12:37</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/TULAMILI/App-matrixpack-0.0014\"\
+        >\n<title>App-matrixpack-0.0014</title>\n<link>https://metacpan.org/release/TULAMILI/App-matrixpack-0.0014</link>\n\
+        <description>Bundles multiple input lines with tab character into one repeatedly.\
+        \ Useful a little more than &#x26;quot;column&#x26;quot; command.</description>\n\
+        <dc:creator>TULAMILI</dc:creator>\n<dc:date>2018-07-18T09:20:40</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/KUERBIS/Term-Choose-1.605\"\
+        >\n<title>Term-Choose-1.605</title>\n<link>https://metacpan.org/release/KUERBIS/Term-Choose-1.605</link>\n\
+        <description>Choose items from a list interactively.</description>\n<dc:creator>KUERBIS</dc:creator>\n\
+        <dc:date>2018-07-18T09:17:44</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/TULAMILI/App-matrixpack-0.0013\"\
+        >\n<title>App-matrixpack-0.0013</title>\n<link>https://metacpan.org/release/TULAMILI/App-matrixpack-0.0013</link>\n\
+        <description>The great new App::matrixpack!</description>\n<dc:creator>TULAMILI</dc:creator>\n\
+        <dc:date>2018-07-18T09:11:09</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/TULAMILI/App-matrixpack-0.0012\"\
+        >\n<title>App-matrixpack-0.0012</title>\n<link>https://metacpan.org/release/TULAMILI/App-matrixpack-0.0012</link>\n\
+        <description>The great new App::matrixpack!</description>\n<dc:creator>TULAMILI</dc:creator>\n\
+        <dc:date>2018-07-18T06:21:56</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/SONGMU/DBIx-Sunny-0.9990\"\
+        >\n<title>DBIx-Sunny-0.9990</title>\n<link>https://metacpan.org/release/SONGMU/DBIx-Sunny-0.9990</link>\n\
+        <description>Simple DBI wrapper</description>\n<dc:creator>SONGMU</dc:creator>\n\
+        <dc:date>2018-07-18T06:03:52</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/JMASLAK/File-ByLine-1.181990\"\
+        >\n<title>File-ByLine-1.181990</title>\n<link>https://metacpan.org/release/JMASLAK/File-ByLine-1.181990</link>\n\
+        <description>Line-by-line file access loops</description>\n<dc:creator>JMASLAK</dc:creator>\n\
+        <dc:date>2018-07-18T03:44:51</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/JDHEDDEN/Thread-Queue-3.13\"\
+        >\n<title>Thread-Queue-3.13</title>\n<link>https://metacpan.org/release/JDHEDDEN/Thread-Queue-3.13</link>\n\
+        <description>Thread-safe queues</description>\n<dc:creator>JDHEDDEN</dc:creator>\n\
+        <dc:date>2018-07-18T02:32:40</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/ROCKY/Devel-Callsite-1.0.1\"\
+        >\n<title>Devel-Callsite-1.0.1</title>\n<link>https://metacpan.org/release/ROCKY/Devel-Callsite-1.0.1</link>\n\
+        <description>Get caller return OP address and Perl interpreter context</description>\n\
+        <dc:creator>ROCKY</dc:creator>\n<dc:date>2018-07-17T23:16:58</dc:date>\n</item>\n\
+        <item rdf:about=\"https://metacpan.org/release/ROCKY/Devel-Callsite-1.0.0\"\
+        >\n<title>Devel-Callsite-1.0.0</title>\n<link>https://metacpan.org/release/ROCKY/Devel-Callsite-1.0.0</link>\n\
+        <description>Get caller return OP address and Perl interpreter context</description>\n\
+        <dc:creator>ROCKY</dc:creator>\n<dc:date>2018-07-17T22:28:42</dc:date>\n</item>\n\
+        <item rdf:about=\"https://metacpan.org/release/GENEHACK/Git-Wrapper-0.048_090\"\
+        >\n<title>Git-Wrapper-0.048_090</title>\n<link>https://metacpan.org/release/GENEHACK/Git-Wrapper-0.048_090</link>\n\
+        <description>Wrap git(7) command-line interface</description>\n<dc:creator>GENEHACK</dc:creator>\n\
+        <dc:date>2018-07-17T21:21:39</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/JEFFOBER/URI-Fast-0.38_03\"\
+        >\n<title>URI-Fast-0.38_03</title>\n<link>https://metacpan.org/release/JEFFOBER/URI-Fast-0.38_03</link>\n\
+        <description>A fast(er) URI parser</description>\n<dc:creator>JEFFOBER</dc:creator>\n\
+        <dc:date>2018-07-17T20:54:56</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/HEXFUSION/Net-Etcd-0.022\"\
+        >\n<title>Net-Etcd-0.022</title>\n<link>https://metacpan.org/release/HEXFUSION/Net-Etcd-0.022</link>\n\
+        <description>Provide access to the etcd v3 API.</description>\n<dc:creator>HEXFUSION</dc:creator>\n\
+        <dc:date>2018-07-17T20:16:26</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/EXODIST/Test-Simple-1.302139-TRIAL\"\
+        >\n<title>Test-Simple-1.302139-TRIAL</title>\n<link>https://metacpan.org/release/EXODIST/Test-Simple-1.302139-TRIAL</link>\n\
+        <description>Basic utilities for writing tests.</description>\n<dc:creator>EXODIST</dc:creator>\n\
+        <dc:date>2018-07-17T19:40:50</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/DDUMONT/Software-LicenseMoreUtils-1.002\"\
+        >\n<title>Software-LicenseMoreUtils-1.002</title>\n<link>https://metacpan.org/release/DDUMONT/Software-LicenseMoreUtils-1.002</link>\n\
+        <description>More utilities and a summary for Software::License</description>\n\
+        <dc:creator>DDUMONT</dc:creator>\n<dc:date>2018-07-17T17:05:27</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/MELMOTHX/Text-Amuse-Compile-1.05\"\
+        >\n<title>Text-Amuse-Compile-1.05</title>\n<link>https://metacpan.org/release/MELMOTHX/Text-Amuse-Compile-1.05</link>\n\
+        <description>Compiler for Text::Amuse</description>\n<dc:creator>MELMOTHX</dc:creator>\n\
+        <dc:date>2018-07-17T16:45:55</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/CORION/Finance-Bank-Postbank_de-0.51\"\
+        >\n<title>Finance-Bank-Postbank_de-0.51</title>\n<link>https://metacpan.org/release/CORION/Finance-Bank-Postbank_de-0.51</link>\n\
+        <description>Check your Postbank.de bank account from Perl</description>\n\
+        <dc:creator>CORION</dc:creator>\n<dc:date>2018-07-17T16:35:30</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/MANWAR/Map-Tube-Madrid-0.13\"\
+        >\n<title>Map-Tube-Madrid-0.13</title>\n<link>https://metacpan.org/release/MANWAR/Map-Tube-Madrid-0.13</link>\n\
+        <description>Interface to the Madrid Metro Map.</description>\n<dc:creator>MANWAR</dc:creator>\n\
+        <dc:date>2018-07-17T15:59:47</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/JILLROWE/BioSAILs-Command-1.0\"\
+        >\n<title>BioSAILs-Command-1.0</title>\n<link>https://metacpan.org/release/JILLROWE/BioSAILs-Command-1.0</link>\n\
+        <description>Command line wrapper for the BioX-Workflow-Command and HPC-Runner-Command\
+        \ libraries.</description>\n<dc:creator>JILLROWE</dc:creator>\n<dc:date>2018-07-17T15:51:57</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/PAVELSR/Kayako-RestAPI-0.06\"\
+        >\n<title>Kayako-RestAPI-0.06</title>\n<link>https://metacpan.org/release/PAVELSR/Kayako-RestAPI-0.06</link>\n\
+        <description>Perl library for working with Kayako REST API. Tested with</description>\n\
+        <dc:creator>PAVELSR</dc:creator>\n<dc:date>2018-07-17T13:55:07</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/WILLBELL/EPFL-Net-ipv6Test-1.01\"\
+        >\n<title>EPFL-Net-ipv6Test-1.01</title>\n<link>https://metacpan.org/release/WILLBELL/EPFL-Net-ipv6Test-1.01</link>\n\
+        <description>Website IPv6 accessibility validator API</description>\n<dc:creator>WILLBELL</dc:creator>\n\
+        <dc:date>2018-07-17T12:59:21</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/EKAWAS/WSRF-Lite-0.8.3.2\"\
+        >\n<title>WSRF-Lite-0.8.3.2</title>\n<link>https://metacpan.org/release/EKAWAS/WSRF-Lite-0.8.3.2</link>\n\
+        <description>Implementation of WSRF</description>\n<dc:creator>EKAWAS</dc:creator>\n\
+        <dc:date>2018-07-17T12:16:49</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/TOBYINK/Object-Util-0.009\"\
+        >\n<title>Object-Util-0.009</title>\n<link>https://metacpan.org/release/TOBYINK/Object-Util-0.009</link>\n\
+        <description>a selection of utility methods that can be called on blessed\
+        \ objects</description>\n<dc:creator>TOBYINK</dc:creator>\n<dc:date>2018-07-17T11:51:13</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/PJDEVOPS/File-Tabular-Web-0.25\"\
+        >\n<title>File-Tabular-Web-0.25</title>\n<link>https://metacpan.org/release/PJDEVOPS/File-Tabular-Web-0.25</link>\n\
+        <description>turn tabular files into web applications</description>\n<dc:creator>PJDEVOPS</dc:creator>\n\
+        <dc:date>2018-07-17T11:51:02</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/MLAWREN/App-githook-perltidy-0.11.11_1\"\
+        >\n<title>App-githook-perltidy-0.11.11_1</title>\n<link>https://metacpan.org/release/MLAWREN/App-githook-perltidy-0.11.11_1</link>\n\
+        <description>run perltidy and podtidy before Git commits</description>\n<dc:creator>MLAWREN</dc:creator>\n\
+        <dc:date>2018-07-17T11:50:50</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/MEMOWE/EventStore-Tiny-0.4\"\
+        >\n<title>EventStore-Tiny-0.4</title>\n<link>https://metacpan.org/release/MEMOWE/EventStore-Tiny-0.4</link>\n\
+        <description>A minimal event sourcing framework.</description>\n<dc:creator>MEMOWE</dc:creator>\n\
+        <dc:date>2018-07-17T11:35:19</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/VKON/Tcl-1.17\"\
+        >\n<title>Tcl-1.17</title>\n<link>https://metacpan.org/release/VKON/Tcl-1.17</link>\n\
+        <description>Tcl extension module for Perl</description>\n<dc:creator>VKON</dc:creator>\n\
+        <dc:date>2018-07-17T11:29:52</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/TOBYINK/Exporter-Tiny-1.002001\"\
+        >\n<title>Exporter-Tiny-1.002001</title>\n<link>https://metacpan.org/release/TOBYINK/Exporter-Tiny-1.002001</link>\n\
+        <description>an exporter with the features of Sub::Exporter but only core\
+        \ dependencies</description>\n<dc:creator>TOBYINK</dc:creator>\n<dc:date>2018-07-17T11:01:49</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/TOBYINK/Exporter-Tiny-1.002000\"\
+        >\n<title>Exporter-Tiny-1.002000</title>\n<link>https://metacpan.org/release/TOBYINK/Exporter-Tiny-1.002000</link>\n\
+        <description>an exporter with the features of Sub::Exporter but only core\
+        \ dependencies</description>\n<dc:creator>TOBYINK</dc:creator>\n<dc:date>2018-07-17T10:56:32</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/MARTINGO/MikroTik-API-1.0.5\"\
+        >\n<title>MikroTik-API-1.0.5</title>\n<link>https://metacpan.org/release/MARTINGO/MikroTik-API-1.0.5</link>\n\
+        <description>Client to MikroTik RouterOS API</description>\n<dc:creator>MARTINGO</dc:creator>\n\
+        <dc:date>2018-07-17T10:55:04</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/PAVELSR/Kayako-RestAPI-0.05\"\
+        >\n<title>Kayako-RestAPI-0.05</title>\n<link>https://metacpan.org/release/PAVELSR/Kayako-RestAPI-0.05</link>\n\
+        <description>Perl library for working with Kayako REST API. Tested with</description>\n\
+        <dc:creator>PAVELSR</dc:creator>\n<dc:date>2018-07-17T10:47:13</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/PEVANS/Devel-MAT-0.36\"\
+        >\n<title>Devel-MAT-0.36</title>\n<link>https://metacpan.org/release/PEVANS/Devel-MAT-0.36</link>\n\
+        <description>Perl Memory Analysis Tool</description>\n<dc:creator>PEVANS</dc:creator>\n\
+        <dc:date>2018-07-17T10:20:44</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/NALOBIN/Net-Whois-Raw-2.99016\"\
+        >\n<title>Net-Whois-Raw-2.99016</title>\n<link>https://metacpan.org/release/NALOBIN/Net-Whois-Raw-2.99016</link>\n\
+        <description>Get Whois information of domains and IP addresses.</description>\n\
+        <dc:creator>NALOBIN</dc:creator>\n<dc:date>2018-07-17T09:49:46</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/PEVANS/Devel-MAT-Dumper-0.36\"\
+        >\n<title>Devel-MAT-Dumper-0.36</title>\n<link>https://metacpan.org/release/PEVANS/Devel-MAT-Dumper-0.36</link>\n\
+        <description>write a heap dump file for later analysis</description>\n<dc:creator>PEVANS</dc:creator>\n\
+        <dc:date>2018-07-17T09:48:19</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/SGRAY/Apache-Defaults-1.01\"\
+        >\n<title>Apache-Defaults-1.01</title>\n<link>https://metacpan.org/release/SGRAY/Apache-Defaults-1.01</link>\n\
+        <description>Get default settings for Apache httpd daemon</description>\n\
+        <dc:creator>SGRAY</dc:creator>\n<dc:date>2018-07-17T07:46:53</dc:date>\n</item>\n\
+        <item rdf:about=\"https://metacpan.org/release/WILLBELL/EPFL-Net-ipv6Test-1.00\"\
+        >\n<title>EPFL-Net-ipv6Test-1.00</title>\n<link>https://metacpan.org/release/WILLBELL/EPFL-Net-ipv6Test-1.00</link>\n\
+        <description>Website IPv6 accessibility validator API</description>\n<dc:creator>WILLBELL</dc:creator>\n\
+        <dc:date>2018-07-17T07:31:28</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/NML/Danga-Socket-1.62_01-TRIAL\"\
+        >\n<title>Danga-Socket-1.62_01-TRIAL</title>\n<link>https://metacpan.org/release/NML/Danga-Socket-1.62_01-TRIAL</link>\n\
+        <description>Async socket class</description>\n<dc:creator>NML</dc:creator>\n\
+        <dc:date>2018-07-17T04:33:28</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/JMASLAK/File-ByLine-1.181981-TRIAL\"\
+        >\n<title>File-ByLine-1.181981-TRIAL</title>\n<link>https://metacpan.org/release/JMASLAK/File-ByLine-1.181981-TRIAL</link>\n\
+        <description>Line-by-line file access loops</description>\n<dc:creator>JMASLAK</dc:creator>\n\
+        <dc:date>2018-07-17T03:35:15</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/OALDERS/lazy-0.000006\"\
+        >\n<title>lazy-0.000006</title>\n<link>https://metacpan.org/release/OALDERS/lazy-0.000006</link>\n\
+        <description>Lazily install missing Perl modules</description>\n<dc:creator>OALDERS</dc:creator>\n\
+        <dc:date>2018-07-17T02:50:50</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/WYANT/Astro-satpass-0.099_01\"\
+        >\n<title>Astro-satpass-0.099_01</title>\n<link>https://metacpan.org/release/WYANT/Astro-satpass-0.099_01</link>\n\
+        <description>Classes and app to compute satellite visibility</description>\n\
+        <dc:creator>WYANT</dc:creator>\n<dc:date>2018-07-17T01:57:39</dc:date>\n</item>\n\
+        <item rdf:about=\"https://metacpan.org/release/BINARY/Math-Business-BlackscholesMerton-1.24\"\
+        >\n<title>Math-Business-BlackscholesMerton-1.24</title>\n<link>https://metacpan.org/release/BINARY/Math-Business-BlackscholesMerton-1.24</link>\n\
+        <description>Algorithm of Math::Business::BlackScholesMerton for binary and\
+        \ non-binary options</description>\n<dc:creator>BINARY</dc:creator>\n<dc:date>2018-07-17T01:52:11</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/JMASLAK/File-ByLine-1.181980-TRIAL\"\
+        >\n<title>File-ByLine-1.181980-TRIAL</title>\n<link>https://metacpan.org/release/JMASLAK/File-ByLine-1.181980-TRIAL</link>\n\
+        <description>Line-by-line file access loops</description>\n<dc:creator>JMASLAK</dc:creator>\n\
+        <dc:date>2018-07-17T01:02:46</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/ROMM/Sport-Analytics-NHL-1.10\"\
+        >\n<title>Sport-Analytics-NHL-1.10</title>\n<link>https://metacpan.org/release/ROMM/Sport-Analytics-NHL-1.10</link>\n\
+        <description>Interface to the National Hockey League data</description>\n\
+        <dc:creator>ROMM</dc:creator>\n<dc:date>2018-07-16T23:33:46</dc:date>\n</item>\n\
+        <item rdf:about=\"https://metacpan.org/release/AMIRI/Elasticsearch-Model-0.1.4\"\
+        >\n<title>Elasticsearch-Model-0.1.4</title>\n<link>https://metacpan.org/release/AMIRI/Elasticsearch-Model-0.1.4</link>\n\
+        <description>Does one thing only: helps to deploy a Moose model and accompanying\
+        \ document classes to Elasticsearch.</description>\n<dc:creator>AMIRI</dc:creator>\n\
+        <dc:date>2018-07-16T22:17:17</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/JEFFOBER/URI-Fast-0.38_02\"\
+        >\n<title>URI-Fast-0.38_02</title>\n<link>https://metacpan.org/release/JEFFOBER/URI-Fast-0.38_02</link>\n\
+        <description>A fast(er) URI parser</description>\n<dc:creator>JEFFOBER</dc:creator>\n\
+        <dc:date>2018-07-16T20:37:50</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/TURNERJW/Tk-HListbox-2.1\"\
+        >\n<title>Tk-HListbox-2.1</title>\n<link>https://metacpan.org/release/TURNERJW/Tk-HListbox-2.1</link>\n\
+        <description>Tk Listbox widget supporting images and text entries, Tk::HList\
+        \ based drop-in replacement for Tk::Listbox.</description>\n<dc:creator>TURNERJW</dc:creator>\n\
+        <dc:date>2018-07-16T20:04:46</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/BYTERAZOR/Git-LowLevel-0.1\"\
+        >\n<title>Git-LowLevel-0.1</title>\n<link>https://metacpan.org/release/BYTERAZOR/Git-LowLevel-0.1</link>\n\
+        <description>LowLevel Blob/Tree/Commit operations on a GIT Repository</description>\n\
+        <dc:creator>BYTERAZOR</dc:creator>\n<dc:date>2018-07-16T19:59:19</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/BLHOTSKY/App-ElasticSearch-Utilities-5.8\"\
+        >\n<title>App-ElasticSearch-Utilities-5.8</title>\n<link>https://metacpan.org/release/BLHOTSKY/App-ElasticSearch-Utilities-5.8</link>\n\
+        <description>Utilities for Monitoring ElasticSearch</description>\n<dc:creator>BLHOTSKY</dc:creator>\n\
+        <dc:date>2018-07-16T19:20:53</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/CORION/Finance-Bank-Postbank_de-0.50\"\
+        >\n<title>Finance-Bank-Postbank_de-0.50</title>\n<link>https://metacpan.org/release/CORION/Finance-Bank-Postbank_de-0.50</link>\n\
+        <description>Check your Postbank.de bank account from Perl</description>\n\
+        <dc:creator>CORION</dc:creator>\n<dc:date>2018-07-16T19:09:12</dc:date>\n\
+        </item>\n<item rdf:about=\"https://metacpan.org/release/MANWAR/BankAccount-Validator-UK-0.41\"\
+        >\n<title>BankAccount-Validator-UK-0.41</title>\n<link>https://metacpan.org/release/MANWAR/BankAccount-Validator-UK-0.41</link>\n\
+        <description>Interface to validate UK bank account.</description>\n<dc:creator>MANWAR</dc:creator>\n\
+        <dc:date>2018-07-16T18:03:47</dc:date>\n</item>\n<item rdf:about=\"https://metacpan.org/release/LLAP/Net-Amazon-S3-0.84\"\
+        >\n<title>Net-Amazon-S3-0.84</title>\n<link>https://metacpan.org/release/LLAP/Net-Amazon-S3-0.84</link>\n\
+        <description>Use the Amazon S3 - Simple Storage Service</description>\n<dc:creator>LLAP</dc:creator>\n\
+        <dc:date>2018-07-16T17:18:18</dc:date>\n</item>\n</rdf:RDF>"}
     headers:
-      accept-ranges: [bytes]
-      cache-control: [max-age=86400]
-      content-length: ['49238']
-      content-type: [application/rdf+xml]
-      date: ['Wed, 11 May 2016 04:09:11 GMT']
-      etag: ['"102af8f-c056-53288c0ce3f81"']
-      expires: ['Thu, 12 May 2016 04:09:11 GMT']
-      last-modified: ['Wed, 11 May 2016 03:36:55 GMT']
-      server: [Apache/2.2.15 (Red Hat)]
-      x-proxy: [proxy1]
+      Accept-Ranges: [bytes]
+      Age: ['90']
+      Cache-Control: [max-age=60]
+      Connection: [keep-alive]
+      Content-Length: ['43238']
+      Content-Type: [application/rss+xml; charset=UTF-8]
+      Date: ['Thu, 19 Jul 2018 17:57:07 GMT']
+      Server: [nginx]
+      Via: [1.1 varnish, 1.1 varnish]
+      X-Cache: ['HIT, MISS']
+      X-Cache-Hits: ['1, 0']
+      X-Runtime: ['0.473060']
+      X-Served-By: ['cache-lax8642-LAX, cache-dca17740-DCA']
+      X-Timer: ['S1532023028.573810,VS0,VE60']
     status: {code: 200, message: OK}
 version: 1

--- a/anitya/tests/request-data/anitya.tests.lib.backends.test_cpan.CpanBackendtests.test_cpan_get_version
+++ b/anitya/tests/request-data/anitya.tests.lib.backends.test_cpan.CpanBackendtests.test_cpan_get_version
@@ -6,164 +6,180 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       From: [admin@fedoraproject.org]
-      User-Agent: [Anitya 0.5.0 at upstream-monitoring.org]
+      User-Agent: [Anitya 0.12.1 at upstream-monitoring.org]
     method: GET
-    uri: http://search.cpan.org/dist/SOAP/
+    uri: https://metacpan.org/release/SOAP/
   response:
-    body: {string: !!python/unicode "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01
-        Transitional//EN\">\n<html>\n <head>\n  <link rel=\"stylesheet\" href=\"http://st.pimg.net/tucs/style.css?3\"
-        type=\"text/css\" />\n<style>\n.styleswitch {\n  text-align: right;\n}\n</style>\n\n\n<script
-        type=\"text/javascript\" src=\"http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js\"></script>\n<script
-        type=\"text/javascript\" src=\"http://st.pimg.net/tucs/js/jquery.cookie.js\"></script>\n<script
-        type=\"text/javascript\" src=\"http://st.pimg.net/tucs/js/sh_main.min.js\"></script>\n<script
-        type=\"text/javascript\" src=\"http://st.pimg.net/tucs/js/sh_perl.min.js\"></script>\n<script
-        type=\"text/javascript\" src=\"http://st.pimg.net/tucs/js/jquery.styleswitch.js\"></script>\n\n<link
-        rel=\"stylesheet\" href=\"http://st.pimg.net/tucs/print.css\" type=\"text/css\"
-        media=\"print\" />\n  <link rel=\"alternate\" type=\"application/rss+xml\"
-        title=\"RSS 1.0\" href=\"http://search.cpan.org/uploads.rdf\" />\n  <link
-        rel=\"search\" href=\"http://st.pimg.net/tucs/opensearch.xml\" type=\"application/opensearchdescription+xml\"
-        title=\"SearchCPAN\" />\n  <title>Keith Brown / SOAP - search.cpan.org</title>\n
-        <script type=\"text/javascript\">\n    var _gaq = _gaq || [];\n    _gaq.push(['_setAccount',
-        'UA-3528438-1']);\n    _gaq.push([\"_setCustomVar\",2,\"Distribution\",\"SOAP\",3]);\n
-        \   _gaq.push([\"_setCustomVar\",5,\"Release\",\"SOAP-0.28\",3]);\n    _gaq.push([\"_setCustomVar\",1,\"Author\",\"KBROWN\",3]);\n
-        \   _gaq.push(['_trackPageview']);\n  </script>\n </head>\n <body id=\"cpansearch\">\n
-        \  <div class=\"header\">\n<center><div class=\"logo\"><a href=\"/\"><img
-        src=\"http://st.pimg.net/tucs/img/cpan_banner.png\" alt=\"CPAN\"></a></div></center>\n<div
-        class=\"menubar\">\n <a href=\"/\">Home</a>\n&middot; <a href=\"/author/\">Authors</a>\n&middot;
-        <a href=\"/recent\">Recent</a>\n&middot; <a href=\"http://log.perl.org/cpansearch/\">News</a>\n&middot;
-        <a href=\"/mirror\">Mirrors</a>\n&middot; <a href=\"/faq.html\">FAQ</a>\n&middot;
-        <a href=\"/feedback\">Feedback</a>\n</div>\n<form method=\"get\" action=\"/search\"
-        name=\"f\" class=\"searchbox\">\n<input type=\"text\" name=\"query\" value=\"\"
-        size=\"35\">\n<br>in <select name=\"mode\">\n <option value=\"all\">All</option>\n
-        <option value=\"module\" >Modules</option>\n <option value=\"dist\" >Distributions</option>\n
-        <option value=\"author\" >Authors</option>\n</select>&nbsp;<input type=\"submit\"
-        value=\"CPAN Search\">\n</form>\n</div>\n\n\n  <div class=path>\n<div id=permalink
-        class=\"noprint\"><a href=\"/dist/SOAP/\">permalink</a></div>\n  <a href=\"/~kbrown/\">Keith
-        Brown</a> &gt;\n  SOAP\n </div>\n\n <div class=box>\n  <h1 class=t1>SOAP</h1>\n<a
-        href=\"http://hexten.net/cpan-faces/\"><img src=\"http://www.gravatar.com/avatar/58b29a24803bb9bd2a0b5c31340a531f?r=g&s=80&d=http%3A%2F%2Fst.pimg.net%2Ftucs%2Fimg%2Fwho.png\"
-        width=80 height=80 \nstyle=\"float:right\"\n/></a>\n\n  <table>\n   <tr>\n
-        \   <td class=label>This Release</td>\n    <td class=cell>SOAP-0.28</td>\n
-        \   <td><small>&nbsp;[<a href=\"/CPAN/authors/id/K/KB/KBROWN/SOAP-0.28.tar.gz\">Download</a>]\n
-        \   [<a href=\"/src/KBROWN/SOAP-0.28/\">Browse</a>]&nbsp;</small></td>\n    <td><small>05
-        Sep 2000</small>\n    </td>\n   </tr>\n\n\n\n   <tr>\n    <td class=label>Other
-        Releases</td>\n    <td class=cell colspan=3>\n     <form action=\"/redirect\">\n
-        \     <select name=\"url\">\n       <option value=\"/~kbrown/SOAP-0.26/\">SOAP-0.26&nbsp;&nbsp;--&nbsp;&nbsp;31
-        Aug 2000</option>\n       <option value=\"/~kbrown/SOAP-0.25/\">SOAP-0.25&nbsp;&nbsp;--&nbsp;&nbsp;16
-        Aug 2000</option>\n       <option value=\"/~kbrown/SOAP-0.23/\">SOAP-0.23&nbsp;&nbsp;--&nbsp;&nbsp;09
-        Jan 2000</option>\n       <option value=\"/~kbrown/SOAP-0.22/\">SOAP-0.22&nbsp;&nbsp;--&nbsp;&nbsp;03
-        Jan 2000</option>\n      </select><input type=submit value=\"Goto\">\n     </form></td></tr>\n\n
-        \  <tr>\n    <td class=label>Links</td>\n    <td class=cell colspan=3><small>\n
-        \    [&nbsp;<a href=\"http://www.cpanforum.com/dist/SOAP\">Discussion&nbsp;Forum</a>&nbsp;]\n
-        \    [&nbsp;<a href=\"https://rt.cpan.org/Public/Dist/Display.html?Name=SOAP\">View/Report&nbsp;Bugs
-        (3)</a>&nbsp;]\n     [&nbsp;<a href=\"http://deps.cpantesters.org/?module=SOAP;perl=latest\">Dependencies</a>&nbsp;]\n
-        \    [&nbsp;<a href=\"/tools/SOAP-0.28\">Other&nbsp;Tools</a>&nbsp;]\n    </small></td></tr>\n\n\n<tr>\n
-        \   <td class=label>CPAN Testers</td>\n    <td class=cell colspan=3><small>\nPASS
-        (72)&nbsp;&nbsp;\nFAIL (10)&nbsp;&nbsp;\nNA (3)&nbsp;&nbsp;\nUNKNOWN (3)&nbsp;&nbsp;\n
-        \    [&nbsp;<a href=\"http://www.cpantesters.org/distro/S/SOAP.html#SOAP-0.28\">View&nbsp;Reports</a>&nbsp;]\n
-        \    [&nbsp;<a href=\"http://matrix.cpantesters.org/?dist=SOAP+0.28\">Perl/Platform&nbsp;Version&nbsp;Matrix</a>&nbsp;]\n
-        \   </small></td></tr>\n\n\n   <tr>\n    <td class=label>Rating</td>\n    <td
-        class=cell colspan=3 nowrap><small>\n<img src=\"http://st.pimg.net/tucs/img/stars-1.0.gif\"
-        alt=\"*    \">\n     (<a href=\"http://cpanratings.perl.org/d/SOAP\">1 Reviews</a>)\n
-        \    [&nbsp;<a href=\"http://cpanratings.perl.org/rate/?distribution=SOAP\">Rate&nbsp;this&nbsp;distribution</a>&nbsp;]\n\n
-        \   </small></td></tr>\n\n   <tr>\n    <td class=label>License</td>\n    <td
-        class=cell colspan=3>\nUnknown\n</td>\n   </tr>\n   <tr>\n    <td class=label>Special
-        Files</td>\n    <td class=cell colspan=3><table><tr class=distfiles>\n     <td>\n
-        \     <a href=\"/src/KBROWN/SOAP-0.28/Changes\">Changes</a><br>\n     </td>\n
-        \    <td>\n      <a href=\"/src/KBROWN/SOAP-0.28/Makefile.PL\">Makefile.PL</a><br>\n
-        \    </td>\n     <td>\n      <a href=\"MANIFEST\">MANIFEST</a><br>\n     </td>\n
-        \    <td>\n      <a href=\"/src/KBROWN/SOAP-0.28/README\">README</a><br>\n
-        \    </td>\n    </tr></table></td>\n   </tr>\n  </table>\n </div>\n\n <div
-        class=box>\n  <h2 class=t2>Modules</h2>\n  <table width=\"100%\">\n   <tr
-        class=r>\n    <td>\n     <a href=\"lib/SOAP.pm\">SOAP</a>\n    </td>\n    <td
-        width=\"99%\">\n     <small>Library for SOAP clients and servers in Perl&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \  <tr class=s>\n    <td>\n     <a href=\"lib/SOAP/Defs.pm\">SOAP::Defs</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Spec-defined constants&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \  <tr class=r>\n    <td>\n     <a href=\"lib/SOAP/Envelope.pm\">SOAP::Envelope</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Creates SOAP streams&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \  <tr class=s>\n    <td>\n     <a href=\"lib/SOAP/EnvelopeMaker.pm\">SOAP::EnvelopeMaker</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Creates SOAP envelopes&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \  <tr class=r>\n    <td>\n     <a href=\"lib/SOAP/GenericHashSerializer.pm\">SOAP::GenericHashSerializer</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Generic serializer for Perl
-        hashes&nbsp;</small>\n    </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n
-        \  </tr>\n   <tr class=s>\n    <td>\n     <a href=\"lib/SOAP/GenericInputStream.pm\">SOAP::GenericInputStream</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Default handler for SOAP::Parser
-        output&nbsp;</small>\n    </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n
-        \  </tr>\n   <tr class=r>\n    <td>\n     <a href=\"lib/SOAP/GenericScalarSerializer.pm\">SOAP::GenericScalarSerializer</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Generic serializer for Perl
-        scalar references&nbsp;</small>\n    </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n
-        \  </tr>\n   <tr class=s>\n    <td>\n     <a href=\"lib/SOAP/OutputStream.pm\">SOAP::OutputStream</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Writes SOAP fragments&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \  <tr class=r>\n    <td>\n     <a href=\"lib/SOAP/Packager.pm\">SOAP::Packager</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>SOAP internal helper class&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \  <tr class=s>\n    <td>\n     <a href=\"lib/SOAP/Parser.pm\">SOAP::Parser</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Parses SOAP documents&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \  <tr class=r>\n    <td>\n     <a href=\"lib/SOAP/Serializer.pm\">SOAP::Serializer</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>serialization utilities&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \  <tr class=s>\n    <td>\n     <a href=\"lib/SOAP/SimpleTypeWrapper.pm\">SOAP::SimpleTypeWrapper</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>deprecated&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \  <tr class=r>\n    <td>\n     <a href=\"lib/SOAP/Struct.pm\">SOAP::Struct</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>support for ordered hashes&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \  <tr class=s>\n    <td>\n     <a href=\"lib/SOAP/StructSerializer.pm\">SOAP::StructSerializer</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>(internal) serializer for SOAP
-        structs&nbsp;</small>\n    </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n
-        \  </tr>\n   <tr class=r>\n    <td>\n     <a href=\"lib/SOAP/Transport/HTTP/Apache.pm\">SOAP::Transport::HTTP::Apache</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>SOAP mod_perl handler&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \  <tr class=s>\n    <td>\n     <a href=\"lib/SOAP/Transport/HTTP/CGI.pm\">SOAP::Transport::HTTP::CGI</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Generic SOAP CGI handler&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \  <tr class=r>\n    <td>\n     <a href=\"lib/SOAP/Transport/HTTP/Client.pm\">SOAP::Transport::HTTP::Client</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Client side HTTP support for
-        SOAP/Perl&nbsp;</small>\n    </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n
-        \  </tr>\n   <tr class=s>\n    <td>\n     <a href=\"lib/SOAP/Transport/HTTP/Server.pm\">SOAP::Transport::HTTP::Server</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Server side HTTP support for
-        SOAP/Perl&nbsp;</small>\n    </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n
-        \  </tr>\n   <tr class=r>\n    <td>\n     <a href=\"lib/SOAP/TypeMapper.pm\">SOAP::TypeMapper</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Maps Perl types to their serializer/deserializer
-        classes&nbsp;</small>\n    </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n
-        \  </tr>\n   <tr class=s>\n    <td>\n     <a href=\"lib/SOAP/TypedPrimitive.pm\">SOAP::TypedPrimitive</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Wrapper for xsd primitives
-        that need explicit SOAP type attributes&nbsp;</small>\n    </td>\n    <td>&nbsp;</td>\n
-        \   <td class=\"version\">0.28</td>\n   </tr>\n   <tr class=r>\n    <td>\n
-        \    <a href=\"lib/SOAP/TypedPrimitiveSerializer.pm\">SOAP::TypedPrimitiveSerializer</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>serializer for xsd scalars&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \ </table>\n </div>\n\n\n<div class=\"footer\"><div class=\"cpanstats\">110152
-        Uploads, 31875 Distributions\n150558 Modules, 12210 Uploaders\n</div>\n<div
-        class=\"sponsor\">\nhosted by <a href=\"http://www.yellowbot.com\">YellowBot</a><br/>\n<a
-        href=\"http://www.yellowbot.com\"><img alt=\"do. tag. write. share.\" src=\"http://st.pimg.net/tucs/img/yellowbot_logo.gif\"></a>\n</div>\n</div>\n<script
-        type=\"text/javascript\">\nvar gaJsHost = ((\"https:\" == document.location.protocol)
-        ? \"https://ssl.\" : \"http://www.\");\ndocument.write(unescape(\"%3Cscript
-        src='\" + gaJsHost + \"google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E\"));\n</script>\n<script
-        type=\"text/javascript\" src=\"http://ipv4.v6test.develooper.com/js/v1/v6test.js\"></script>\n\n<script
-        type=\"text/javascript\">\n   // v6.target = '';\n   if (!v6.target) { v6.only_once
-        = true }\n   v6.site = '7A0D89A6-2B82-11DF-B9DA-F61CBD13F020';\n   v6.api_server
-        = 'http://ipv4.v6test.develooper.com';\n   try {\n     v6.test();\n   } catch(err)
-        {}\n</script>\n<script type=\"text/javascript\">\n  $(document).ready(function(){\n
-        \   $(\"a[href^=http:]\").click(function(){\n      var href = $(this).attr('href');\n
-        \     var m = href.match('\\/\\/([^\\/:]+)');\n      _gaq.push(['_trackEvent','External',m[1],'Distribution']);\n
-        \   });\n    $(\"a[href^=/CPAN/]\").click(function(){\n      var href = $(this).attr('href');\n
-        \     _gaq.push(['_trackEvent','Download',href,'Distribution']);\n    });\n
-        \ });\n</script>\n<!-- Thu May 28 19:28:33 2015 GMT (0.037510871887207) @cpansearch2
-        -->\n </body>\n</html>\n"}
+    body: {string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n\
+        <body bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\
+        \n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n"}
     headers:
-      cache-control: [max-age=3599]
-      content-length: ['12357']
-      content-type: [text/html]
-      date: ['Thu, 28 May 2015 19:28:33 GMT']
-      expires: ['Thu, 28 May 2015 20:28:33 GMT']
-      last-modified: ['Thu, 28 May 2015 19:28:33 GMT']
-      server: [Plack/Starman (Perl)]
+      Accept-Ranges: [bytes, bytes, bytes, bytes]
+      Age: ['0', '0', '0', '0']
+      Connection: [keep-alive]
+      Content-Length: ['178']
+      Content-Type: [text/html]
+      Date: ['Thu, 19 Jul 2018 16:48:00 GMT']
+      Location: ['https://metacpan.org/release/SOAP']
+      Server: [nginx]
+      Via: [1.1 varnish, 1.1 varnish]
+      X-Cache: ['MISS, MISS']
+      X-Cache-Hits: ['0, 0']
+      X-Served-By: ['cache-lax8629-LAX, cache-dca17746-DCA']
+      X-Timer: ['S1532018880.368581,VS0,VE204']
+    status: {code: 301, message: Moved Permanently}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      From: [admin@fedoraproject.org]
+      User-Agent: [Anitya 0.12.1 at upstream-monitoring.org]
+    method: GET
+    uri: https://metacpan.org/release/SOAP
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+09a3PbOJLf8yswys3YvrFEPaz4EclZT5zXTR6+2LNbW6lUCiIhiWOKZAjStmZn
+        //t1NwASfMiy4iS7W3WsjEXi0ehuNBrdjSZn9MPpu6cXfz97xl5evHl9/GA0TxfB8QMG12guuKdu
+        6XEhUs5CvhDj1pUvruMoSVvMjcJUhOm4de176XzsiSvfFW162GV+6Kc+D9rS5YEY93bZgt/4i2xh
+        CloW9NRPA3F8/u7krN3t9A9Ym732JwlPlmwaJQzLmRv4MJRkPPSYFMmVSCQMwc5EEkBzRM+NediJ
+        ktnIUeAK8IEfXrJEBOMWD1KRhDwVLZYuYyCGx3Hguzz1o9BJpPz5ZhFAFfYft96fn7fYPBHTccuZ
+        CuE5ni/TxJ9k1BqxajGnOoxu/4lLKVLp8IOp98gbTgZ8MjiYTA+n+3x/6O5398TBXm+wx/emPa87
+        FbzjStlSOMp0GQg5FyI1SKbiJnWwQXUw1V7wxJ3nmMoUqHGdKBahqukommrkFi08Id3Ej7G0xIA3
+        wNWnZydvm8d1eRiFACwwQ8/TNJZHjmNPhgNNBZeigV2WSFkIWFK1iQw0zIRizhwk1c1S5rsIu8wj
+        LJPOlF/hTQf+NBOKTBPtNMrceVuBkf4fQo5bvWH/Bv5rBlvt1YnDmQ1fUcxk4tri0jt4dDg97B8O
+        9/uDYa/X6/LD3n4fREgI7u4NXfdg8uhgOu38LkvC8Tu/4gpg63jkqLvaWEUBY9vTLHSR39v+rtyN
+        dme7yS7fXez8w/+w9SKKZoE4CXmwBHLku8nvwk23Po6Tx/6H5OMY//z5Z95/5x82WKzsfKY2nc9/
+        /vnh404nzuR8myezbIGTt/PPXaoMxr3/DsU1O4XFuL3zmI9lx00EPDwLBDbcjnZ2LcALqJ+JVFfK
+        X5YXfPYWZAeafeh+fMw7XC5Dd9yDO+To7PGiE/MEmr6NPNHxQdCT9BcBkiS2kUwL8j93tq/90Iuu
+        d73IJRx3txS/tna3HOf6+rozI4a0ueFIx40WTvH0u4SWM7618/iBBXfGt7cURVu7bOu3k3Z//6B/
+        uLe/1+5Bgc00vKSfivMYlMw5X4DcvIdu7Ij1ut0Spo8r8KUIPYQe85lAtYwomPq6GNRv7DWYXvsp
+        KMcjlydeyzTI16LMFgtYi7TMmnpluARrve6mEZrgkQYyEHN4t3b5SkqkCTTOTp0nhirqVmbuyCn2
+        z9Ek8pbWYgz5FSABC37cgtsJT5j6aXtiyrMAtH4SofaFUn9GqtpSGwTB83MIiAz3Q5G0p0Hme5WW
+        1DoLrOHMWPDT1DbwTdsrX/oTEPobe9fJ23Gt8h62mMdTDmpuNkOcZeB7AlgiAlMBC18ArzpWTR0e
+        QMwHnnI25W3AUeJv/4Y0d9vuPnL8RhAS6g0U6gRASB1C+b+iw8jhTYVBBftaE7ysmWjkl7ryeXAA
+        C38x07tJaR8yUlpsQiCuVUD29TJaiGqZuRpJwqtOlrk2pMSojFki4o6tN5DCsoxow4fkoQrPvhDU
+        0RHCqdaY69uTBVrPBaVRJ2IONmUEinUtFe8JQLXUXPejYO57ngib17q5ClL4JMoaKPHDabSejBPs
+        XC0013enAoy/z3VKPmdCKr27jprnJ/9bLTLXd6QlXzN+Os8mZJ2YlVMs/2sxcXwpgbQ6wapjG7yj
+        9SS/8NOX2YS9IlDVSnN9R+IdsCIbSMLSmMewMd5BKN9C42qZub4nKWkUBQ20XIMhexdFd4Hdq4Xm
+        +o50GHmcctiJYn+NGkc7YQIG4Xr6Ts5eVYvMtSF1IyfTgY5S6SpTydwm/myeruDACCzMBePkFK2w
+        fLnrRlmYOkE0Qw2KUYt55I1bZ+/OL1rM9wqTsq2bAEsQ7IoRi+nxkigGFyZk0G8mvE8+OqkYR4Aq
+        X8YBXx4x8NbF4xXI42UbdRWw2r6rGHum9haYJ4rilfWjiRkK3A5B9E5WQ1s5yXhZk5ejDd5cdgt2
+        eAETj61NQc8QGJshuCA+KstX+T2O3yxP9tUMMU6iqQ8sPD5TN/eBNeVXUQIuCXSXwLPn+nED/G5t
+        gJctDFEIPpN7OW791/bWw4qEbu10ZDZZ+Cn48AxmMEtCWNMBrubX1ODWOcPrdoSbFypeq/vdsi5o
+        2f07LIxzfxaC27my/t9jYdzaAK87qXwn4lk67zv4FwT1D/FE+eCfQOPZ7X7ii/ixO498V4yn3BWT
+        KLq0pE9LF8zkq/Ds5LfzZ9spGM87a8jAq7rjGOB0f632nbVAnutOaxveOhl4rZZcc/1rea+swW/C
+        eQV6I74re3Nts/94rutY0zdhu4a9Ed8vVJ+17f7jGa+iu9+E7wr0RmxXwfe1zb4719Fo9dWhUWOY
+        sXpVWaE6bsSKd9Dl1enaZvdkxaYWRr39yPH8q6Jo5IC3YAWEbw/XWpDshhhxBn9cJCns1VLymWDq
+        SUVZToGVyyhjPEn8K8HmIhHsyudMn/gZMX9SXzV4ngFecaDOMJLUdwPhSL70wxmKqzdZ4qGVjq21
+        ydLDddViJpL7aRLw8BKsTj/0GMZyrudLnIKOZkNOkE1aJcppU5pE10x7l/EcLLEG2bKbY1y9LRc8
+        CMgCZW4UtBdee9DQDa9CfnPbreiMctggO5X5zItL80ijHq4ateQLOuaE1iCgeEtt8E+bVBVKRnNs
+        XF328NRrlkRZfEsHvOxOfhhn6Z164TWi5tYZY0ufiXxWx5/j1l5P+ayaHGqf00gYorQnUdBiVzzI
+        xK2BUnOVQ+wFxu1Jeps5bV+jSZamUQ4EOuplQTA0RcppaR2fUw0Y19Rn/QCrYv32tUJ+zHVL9Spv
+        v6FLQ1F5wVXWWAPz7BYL0Eo0Xxhj1tLd6zd0wuuBvmwAkwQWpptki4kKEamJZAoArELlIV2K5STi
+        CaxgfS4/bs0Y14kPatPOT9PVo/PrL+/f/e1tnpOQS5iqbqNQwjrWo/0qwMBkvwC9oZ4pvcKLeaOm
+        xz+FExk/dtSPVWkzTZ1TMjxNyWQ74OBhp2wBD+BsL9u62uyFJcEtHMBGP84WopEEOG5qWsFCE6FH
+        xsichzN0JvWpdCeIVOJGh/iDJkmH1pXaREYRnXwyBU54Zs3lx62Kj3TqSkk2Gm+81ZO8rZrA2Kzf
+        7Xbb3cN2d2iOyomHaozSeOvGeVSM82jVOAftQe++4wyLcYarx+nt33ccs9Hg7apxeu1e977jmLWH
+        t6vH6e41jgMCRmKgQOgWJQnVo+rlkwuFLZnmT65pRj+02/DzWxj4l2COhAyPHI936S6iJJFjNkv4
+        NJUsnQt2/tcXzAgv88M0otLTd292wWTw3TmAWggeSjaB5SrxGP7aDwKmwzLUWCeGMaHTPlg0NaA7
+        jP2dL3940G4DuSXKwCBK2jOezYT6q9eHvJoxlafW6u/FNy3NFbCdMKiLyTxWIWYF0N7d6/TywptF
+        EEplSWlD6npATgfOhgPwyy2PbjCFqKl97/Dw0KFahRtgNzOaVjNZXRdk2PmSSTyTRQ0yzQLGU9TS
+        KEQTEYD1pDmbCJkFKdhxyF7QVTF3Cz8CZgX8v1QsYtRjOB0iiaOAFMouE6EEpQY90zlPCRieRKR+
+        DE5QdCkZGoYgdjm0SQRa9uk8Qawwj+K5D5hFNx12plSmF4VbKePe7xloTD9lkwDUsgiWuzhAeCl/
+        0JBw8tSdnun3OHmoccHe/UMkEfvpYa/7+G3EPAHOAAZiZZ7eZzGMDRkmDOyyvRucxl3Wi28Yj8G8
+        3cXNLEpAHz4Ue6Iv+ixK2MN9wQfTvj18gjr4Ztzqthhb0o+Wlb2WJSEtNgURHbc0LCvpLAcwvC+A
+        HnS9H4DhPQH0vwiDkUMyPMKFcIzGgVYlJtFtRbYadHkjVJphZ8qv5Kc0+uTOhXv5YQu10tZHNma9
+        xwhNZzMpqwMNT9Ja0Cc3CYrDDxi2bILXQufc8+qRYB9UW0ihAGUf5rEA6HZqJX+WAgIlS1l5MsZW
+        TsQiuhK5/du9Sw9aQXmX6nZ9S1djPume2m5a281Oai0Na7pqc7pkN+dmvmantsCMZcN+/rkwqY1R
+        q/cR28SyovJQYVw1KxRDPu/2llYrUgXNUeHB9OGkqHOPrerZQx09tUeU8OM5Svnvg/IJYBvPV1gt
+        c8k6X6hlSSF1+q7RBzSLrTIlFQ/R9p5IFWOiETmMLQaS6op5FHgigXnS/Yxrtgp8eda0AJh1W5oe
+        XWYiHxatyBD0vgWmPFVsCdhH/gAud4fsXMRknbDewVF376g/ZC/eXOS2uAXWOteSUZa4NQsIRL4a
+        RJpe018iniJKsLNw91LFk9Dql3SuxrZrYQ+ZdjAnKtZhwhUjOq3jhF8jiJ0yruqG3+LEuLnfogx3
+        2ZAtvoIeN5pJm5CnCoCWUBz9gY2DmY4ojmJw5fNhUVxouHDWTqNbR4wDcGhcP3EDYQ/8UhkTTw0k
+        YmYTCqvZ4FeTwZM0j0Y5ZxkYAq6DmhT/oM7t4CsHTzCTd3wbwhj1akBYJaHkQZxtsIYVtjmyBuMC
+        KTyU50DfDeGFPh3YeoTeE5wxQuNnEr88DZ6ar0KNNqsG3C4U5Bw5tWQ0yO0Y4DAH+vsB/IQcNpO6
+        0KLJWEWSpApml+ZXcQ+0JTQa9yiojfVAn34ydizSQwVgn3ti3M+3PrKOjtjD7iFsTvsHtHqc5qjh
+        N8FkUMPksAuY9LrfHZM9UF965WvDpSxJVSEiJCThonZehcsKd26lMkODA2QITFVbeH695mAyi9oC
+        bIYx41cisLu/9l18t+OIZeFlSLEQgvBAa/dmnX4CW9WVny4rWtrarnEzwxZt4Fis9jIr69TUPgFH
+        ZLwAHTLPmW/UoFrjxqzs7XcLw7JvLEkaEKifhejLUb7NiEK2Bgs3WqAz2Dru7zEaBiYM64+NgWF+
+        LDKa6KVsqfokV+SNlFc5i0fNtuN7zq8wzbWZ7qQ86cz+yC2v8oxhWCiIuD4JsSft1NRsm2jWoN/Z
+        3/91ogVyJ1clt4omIi1uYnR6kjLiT7IkGN8ioI34ogmEiYF1fI3Zzp7p0VT/QmI1fsU+H4tk4Utc
+        fE2bY+PwsMnURz7L4UiEXxvRHnPFi1vNoyVStuXnDPzs+qDn2QRdkAn6xhikyAGuIJs1BaLhP1zx
+        l5WEkUXk4WtUpYz5h34IfnAQtPE3yciOlG3P52A053ZelYAUORPyoI7+KwWN4a+BpjEvDPUy+psY
+        sGWf4nPuSCCjjiyO1zoayzfv2GDfltidbxikRY5YbziIb+5iOa9CQNvGVV8Qs4JqJvItDDJrr5a4
+        vhnnvCYfbE0nZc3mHc3gVudNeI4EfG2Ob8zylTzX4fK18fGtXNFt/WzFyjfCWsdqj/8nW8S46rXl
+        UMRZrUZlt9sOf+PfeuyWYt6lyPA6UEMCNWwC1dvfDNSAQA3qoChyvRGoPoHqN4Hq7tVA5XHpFdNa
+        CYLcYZY9fzp1MKHSeaI1Z3Vjc8gMUWtkvMV+ZiJ0I0/89v7V02gRg8iFKcVzlITsfJmInAIaYNek
+        8/8XkgZQ9xISlJIm+w2tAI6baYMRpzf/1bbOBUx4MVUNe3duCJbfVzx+rY4B610fqMSQB2bXxwgl
+        2a/tGGNHeaZoYQ1oSyAPdqkWZ9h6e4u6VgNbj9EWRttQA1GQTTjnfB5dm0hLvZUOVbWOX/qeMHGw
+        9zgKoyEtO8AEWC30c7zjDEwSkwdfOgCOblR5NZuDAvTPo4Rh1IHOeTDuXj491oe5se9ih3z+ykfA
+        ODOFv2E7hOCPXHE0uymphW4db7i/vy/EwcF+Xzx65E33Dnj3cLI36A+mgh8Mek/kuDfoKhdlTMB+
+        HJz82H8O/6ogoUg9wM3wYNI/5P29g+5gMjmceH3enQzdQW+w1+XDQW/64+A5ADoF0D/2H3lwp1LJ
+        XXqLU4kLOquhCpbzO5x8H6tfLWqmcymc0Go4+DZ+EIXilUfUENxsnrX8uMWlDHi1IppX4anVsuI5
+        5u3T1I/zaIq3BCXvu5+AI1N/BsqYg1R6rePcVfWrccJ5Ap5huazQvxWvHBBXPnkpsAP2dRaYCFPR
+        t2r9i/RaiAZPh7wcHc9hr4FtRVCnhFUNKdAdnzM/aQoGPpFRko4/fOjv9j5+bBVdKzjJeaMz8l6g
+        AirPUwUprY5yMSinL1GiR0vFBPL1DpUpxiIw+pgv+GuBrncUBDy2sh2autBmSdltNpPnfWp4Peep
+        DMV1y4Q36Y1srUYpC4G1rbSDkTPvW0Bs3Kl7W2CMMhdOc6GM18S1ojQtAEtMY7sRHqxC8I2WLADz
+        g02yGR4ynJOb1IkX7JpOYV+xay5Zyi/VOSmet04Fvpgl8FT6L5/oIBRtaKz3U3PiCg0X9JqPVuTC
+        s8/YCWdC154zU2Pl+Ni31gZTYv/6HQZf4LC7bO10VKen2GV7K5/mho3nQzmBANSFaC/A7Vf7DguE
+        lE2bj4RKux3emt3no+175srKmmu061T+F+pJSlhQS1nnGGnZysveqBsjPFoYGgyDOPL0fo5/Kda4
+        2TdnCB7C1grgljGOjk7FVKqR1L0e7zwWLr70DyvGw68KgIMOo20E+Vl4JYIo1ikcxbMe4Sl9f0Iq
+        akABCb74Mvhv+CWu6obCppGEbrDZWC8EaA7ffcnl/BxuwLT7oxizsVKPretwinQFTSF9GmgOHb4M
+        j1fosJ4TzypIWDUag1P15QYYLfQCPbzqcsZBTSeYJwt9vgSNc5cHPFnJkGr1HViC31/iSaG+NuPO
+        O6KkzBe7TCPwNzqYVeIwTfiM0nc2GugMNjs+Kwg2z2bxIGRKY8Fw11wEMdBIamPDUXB+ijHwSY9A
+        D5oE435uBrw+a7WJMhNEPi0D8yCgNw03G8bHT8ZcLGPxt4THsTVatUIPClZDIsCNFt5m49COmAOn
+        J0NGFuMnwUjIogQMQ9BoX7D0FMwGtlXK9ajbZv53qoJOk6YCnZthcJHwUCIpR0cvLy6g4CTm7jzX
+        ryuqbZmEzegTJtgbZXC/4Z++eLVybKirLHdCAIq/0ti0/a0enqqN/qcHJsEqYFhdkggE4Gy8a9YG
+        PKcteCU+qtpMBT18XXyWuOXZ66so0aPCg1RKFgOdUmfm+YklnuChWLJKCmvDRYKjemeJvwBNcVVI
+        Zqk018KEHRF9Iz0Wm3rM0OQpCwWsUzws8l2wWEl6EHHMMFQJAPfBrL6MV9VXdKGFsNqr6liQnVzY
+        jOuMxghmIWljRdlwpPLW8Tv8wbS2mumoCC5oXZU3on2a3LlBigyyd4Xx5uTtq+fPzi/AjNV3XwQF
+        jDKkpHP2GgAVD18C6/2zk9M3z1rH6teGUJ4Agmg8wtuOrcwU0XkXeBZefsJizR9VVg+6mpoUXqxp
+        09zOhCpKzaip9qTUqYR6yHF0gwhD0HQmB947HjjmB3UcBFWH3cYtoBLI+Cn1F0I+Xv0myWi+V0ZL
+        feJM+yx0Llc9nwNh3KsQV7iBeVGNXvzeWBO18fFFxPT0aPN01YrcBc0JtsMS3JJ4Sf5PDG6jYBhl
+        QnNWpWHjSTzUkVMEqm4JYsTMCeTIiRtRKOuNUljkJI7phTPon0ln4od0+A5WJv0o8WsEmlgf+7Qv
+        6reGUgDZ1L2GqfoOJkWCwKwJgi9Ah6yC9huC0RYKTGPDu83Raswx2Ip+NsO0qWShbEv4p/xkA14V
+        xyq1EqPDaaHUq9k2FEbTbrbz6u35xcnr15Ro0zpGQfBEykHNeIxoaxpmllHUmV4TrDDtTjI9jaK0
+        eQ0blM2n6KprVYOh98ee4ppGLG5DoB51yUNolr6zryYKGpraVOFbj6tpshrmH94xAVq5MO9n9Vv6
+        NaaG8atgsMuNbPepr1y0e/lLXvkxLKZmtzkm3hwx/NRYI2p41aSk6U3s1vHJGZmnNRB3x3ZosB0U
+        JH85tua7ZeoLZCZ75UtRLOZF46hYe18cF36SRAkaEriS3qinr4bjV+Fjnuiw5mtjLdRDl5VPM38l
+        Qr6q+OavRKOSo3NFur0rsndY6jmSMfcwPnzEht34huG7KmwAdzVMVxOP7zozolUdwlUh9/E1pio4
+        VovdFgd0tfzLw8PW8ctI0ptEM3Qso0yCJRAn0RXocI9NlkfVELYeo86bMiV6WR/mhNwZ+6YpmyxT
+        seDJJUhgJ7t0kvK3tuovrNegMnWaaF4Kwxdvyt/PXHDM4wYnM5SY8GcG/ITvjlc+55xDrAvNV2AL
+        vZtWBUFsqRDZwKbA/wx7L6xHWqkNUMpsoKTMW9mQA/xEIvNvwog64bgrBUtFdZVPdRCaC7dSriAW
+        06951ut1TRrrsFeHfDdONBVVlEgNSp11vQPiHdxF06kUaaHxH1V5CW4COCqLI9ZvUkCMnUjGVToH
+        Gv9JCopAOQKgDzwTTlG+gNlLd9k5sO1SJH+PMuYrr92+5jwGbwI8BUAOobFe90fMNKNXs9BARaO3
+        cS6lggseBs0n4OBhaM9xMwk0tHW1dAaDYcNkP6VWBjnaTu1vi6tro3EnmfRDIfGt8IkIpPNoOKwP
+        +4tuxF5TIxqWvY+ARlVQx+GvfriEWoEf3kH1C3a8xv1UuDyQnQqagGXBccSwjkS5vkEWGb5fSq4b
+        7AbAySgGzySifLcFvxSqytDLiCGdGojfJHqDnmAmueHNs4sTFAlM5NdFjKeMXpZA8wtf4YrRwSTw
+        RgaqgJsWRbmo+mgtCSvIAFwBd9ITN+MWWgzq+9omJoFBi9q7LOWD5RrYeniiuVlziKKp5eogxYq4
+        wa8aZXZuUK6HC2r80YW10TFkwJp0TF3LkC7BZqMUMzdMlXpYycdRav8PRUZpYs1ZOgdPGv6USl4E
+        0QSjCEU53OteWFp8Xj21v69egewZ9ACxypReTrxjYBn+FB2c1H6Ch+cRqBj9/RB8x9huUSC06bhP
+        1o77C63/DJYhJqrh8RZTIteMANwZLsAtTgUZpN94iujLbN94imaKVeohXsu3FxGqFkxSY5h7IyS9
+        MN7AsXvh4a/FY0Z46M/dqc8us+0oBIXnT4ti2EzxFBZPyxIRR9LHT4HvNCPcNMXG9fgXrdGzd6ff
+        c/b5Wq6r2Vfpc81cvBcC7h0R0Nk13wCD9YKnMFAS9w0Q8O6IAAZ2v8HwyR2HL1aTc/70zTdAZP3O
+        oRBRRyvfAIHJHRHA4x/9hZU6FvQwukWxGHim052MCRPXbGheK6rab8XjyFFYgVVD/1ey/wPiVy9N
+        rWwAAA==
+    headers:
+      Accept-Ranges: [bytes]
+      Age: ['0']
+      Cache-Control: [max-age=3600]
+      Connection: [keep-alive]
+      Content-Encoding: [gzip]
+      Content-Length: ['6844']
+      Content-Type: [text/html; charset=utf-8]
+      Date: ['Thu, 19 Jul 2018 16:48:01 GMT']
+      Last-Modified: ['Tue, 05 Sep 2000 18:04:25 GMT']
+      Server: [nginx]
+      Vary: [Accept-Encoding]
+      Via: [1.1 varnish, 1.1 varnish]
+      X-Cache: ['MISS, MISS']
+      X-Cache-Hits: ['0, 0']
+      X-Runtime: ['0.274922']
+      X-Served-By: ['cache-lax8645-LAX, cache-dca17746-DCA']
+      X-Timer: ['S1532018881.614394,VS0,VE993']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -172,99 +188,114 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       From: [admin@fedoraproject.org]
-      User-Agent: [Anitya 0.5.0 at upstream-monitoring.org]
+      User-Agent: [Anitya 0.12.1 at upstream-monitoring.org]
     method: GET
-    uri: http://search.cpan.org/dist/foo/
+    uri: https://metacpan.org/release/foo/
   response:
-    body: {string: !!python/unicode "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01
-        Transitional//EN\">\n<html>\n <head>\n  <link rel=\"stylesheet\" href=\"http://st.pimg.net/tucs/style.css?3\"
-        type=\"text/css\" />\n<style>\n.styleswitch {\n  text-align: right;\n}\n</style>\n\n\n<script
-        type=\"text/javascript\" src=\"http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js\"></script>\n<script
-        type=\"text/javascript\" src=\"http://st.pimg.net/tucs/js/jquery.cookie.js\"></script>\n<script
-        type=\"text/javascript\" src=\"http://st.pimg.net/tucs/js/sh_main.min.js\"></script>\n<script
-        type=\"text/javascript\" src=\"http://st.pimg.net/tucs/js/sh_perl.min.js\"></script>\n<script
-        type=\"text/javascript\" src=\"http://st.pimg.net/tucs/js/jquery.styleswitch.js\"></script>\n\n<link
-        rel=\"stylesheet\" href=\"http://st.pimg.net/tucs/print.css\" type=\"text/css\"
-        media=\"print\" />\n  <link rel=\"alternate\" type=\"application/rss+xml\"
-        title=\"RSS 1.0\" href=\"http://search.cpan.org/uploads.rdf\" />\n  <link
-        rel=\"search\" href=\"http://st.pimg.net/tucs/opensearch.xml\" type=\"application/opensearchdescription+xml\"
-        title=\"SearchCPAN\" />\n  <title>The CPAN Search Site - search.cpan.org</title>\n
-        <script type=\"text/javascript\">\n    var _gaq = _gaq || [];\n    _gaq.push(['_setAccount',
-        'UA-3528438-1']);\n    _gaq.push(['_trackPageview']);\n  </script>\n </head>\n
-        <body id=\"cpansearch\">\n   <div class=\"header\">\n<center><div class=\"logo\"><a
-        href=\"/\"><img src=\"http://st.pimg.net/tucs/img/cpan_banner.png\" alt=\"CPAN\"></a></div></center>\n<div
-        class=\"menubar\">\n <a href=\"/\">Home</a>\n&middot; <a href=\"/author/\">Authors</a>\n&middot;
-        <a href=\"/recent\">Recent</a>\n&middot; <a href=\"http://log.perl.org/cpansearch/\">News</a>\n&middot;
-        <a href=\"/mirror\">Mirrors</a>\n&middot; <a href=\"/faq.html\">FAQ</a>\n&middot;
-        <a href=\"/feedback\">Feedback</a>\n</div>\n<form method=\"get\" action=\"/search\"
-        name=\"f\" class=\"searchbox\">\n<input type=\"text\" name=\"query\" value=\"\"
-        size=\"35\">\n<br>in <select name=\"mode\">\n <option value=\"all\">All</option>\n
-        <option value=\"module\" >Modules</option>\n <option value=\"dist\" >Distributions</option>\n
-        <option value=\"author\" >Authors</option>\n</select>&nbsp;<input type=\"submit\"
-        value=\"CPAN Search\">\n</form>\n</div>\n\nThe distribution '<b>foo</b>' cannot
-        be found, did you mean one of these<br />\n\n\n<br><div class=t4>\n<small>\nResults
-        <b>1</b> - <b>10</b> of\n<b>10</b> Found</small></div>\n<!--results-->\n<!--item-->\n
-        \ <p><h2 class=sr><a href=\"/~miket/DBIx-Foo-0.03/\"><b>DBIx-Foo</b></a></h2>\n<small>Simple
-        Database Wrapper and Helper Functions. Easy DB integration without the need
-        for an ORM. </small><br/>\n<small>   <a href=\"/~miket/DBIx-Foo-0.03/\">DBIx-Foo-0.03</a>
-        -\n   <span class=date>22 Feb 2013</span> -\n   <a href=\"/~miket/\">Mike
-        Tonks</a>\n</small>\n<!--end item-->\n<!--item-->\n  <p><h2 class=sr><a href=\"/~fayland/Foorum-1.001000/\"><b>Foorum</b></a></h2>\n<small>forum
-        system based on Catalyst </small><br/>\n<small>   <a href=\"/~fayland/Foorum-1.001000/\">Foorum-1.001000</a>
-        -\n   <span class=date>27 Sep 2009</span> -\n   <a href=\"/~fayland/\">Fayland
-        &#x6797;</a>\n</small>\n<!--end item-->\n<!--item-->\n  <p><h2 class=sr><a
-        href=\"/~manwar/Food-ECodes-0.11/\"><b>Food-ECodes</b></a></h2>\n<small>Interface
-        to Food Additive ECodes.</small><br/>\n<small>   <a href=\"/~manwar/Food-ECodes-0.11/\">Food-ECodes-0.11</a><img
-        src=\"http://st.pimg.net/tucs/img/stars-4.0.gif\" alt=\"**** \">\n     (<a
-        href=\"http://cpanratings.perl.org/d/Food-ECodes\">1 Reviews</a>)\n\n -\n
-        \  <span class=date>16 Jan 2015</span> -\n   <a href=\"/~manwar/\">Mohammad
-        S Anwar</a>\n</small>\n<!--end item-->\n<!--item-->\n  <p><h2 class=sr><a
-        href=\"/~strytoast/Football-League-Match-0.01/\"><b>Football-League-Match</b></a></h2>\n<small>A
-        single footie match</small><br/>\n<small>   <a href=\"/~strytoast/Football-League-Match-0.01/\">Football-League-Match-0.01</a>
-        -\n   <span class=date>14 Apr 2003</span> -\n   <a href=\"/~strytoast/\">Stray
-        Taoist</a>\n</small>\n<!--end item-->\n<!--item-->\n  <p><h2 class=sr><a href=\"/~bpostle/I18NFool-0.31/\"><b>I18NFool</b></a></h2>\n<small>Internationalization
-        File Object Oriented Leech</small><br/>\n<small>   <a href=\"/~bpostle/I18NFool-0.31/\">I18NFool-0.31</a>
-        -\n   <span class=date>07 Oct 2004</span> -\n   <a href=\"/~bpostle/\">Bruno
-        Postle</a>\n</small>\n<!--end item-->\n<!--item-->\n  <p><h2 class=sr><a href=\"/~miyagawa/Kwiki-Footnote-0.01/\"><b>Kwiki-Footnote</b></a></h2>\n<small>Footnote
-        plugin for Kwiki</small><br/>\n<small>   <a href=\"/~miyagawa/Kwiki-Footnote-0.01/\">Kwiki-Footnote-0.01</a>
-        -\n   <span class=date>02 Apr 2005</span> -\n   <a href=\"/~miyagawa/\">Tatsuhiko
-        Miyagawa</a>\n</small>\n<!--end item-->\n<!--item-->\n  <p><h2 class=sr><a
-        href=\"/~spurkis/Scalar-Footnote-0.99_01/\"><b>Scalar-Footnote</b></a></h2>\n<small>Attach
-        hidden scalars to references</small><br/>\n<small>   <a href=\"/~spurkis/Scalar-Footnote-0.99_01/\">Scalar-Footnote-0.99_01</a>
-        -\n   <span class=date>30 May 2004</span> -\n   <a href=\"/~spurkis/\">Steve
-        Purkis</a>\n</small>\n<!--end item-->\n<!--item-->\n  <p><h2 class=sr><a href=\"/~plytle/WWW-WuFoo-0.007/\"><b>WWW-WuFoo</b></a></h2>\n<small>Interface
-        to WuFoo.com&#39;s online forms</small><br/>\n<small>   <a href=\"/~plytle/WWW-WuFoo-0.007/\">WWW-WuFoo-0.007</a>
-        -\n   <span class=date>13 Apr 2013</span> -\n   <a href=\"/~plytle/\">Peter
-        Lytle</a>\n</small>\n<!--end item-->\n<!--item-->\n  <p><h2 class=sr><a href=\"/~ikuta/Net-RabbitFoot-1.03/\"><b>Net-RabbitFoot</b></a></h2>\n<small>An
-        Asynchronous and multi channel Perl AMQP client.</small><br/>\n<small>   <a
-        href=\"/~ikuta/Net-RabbitFoot-1.03/\">Net-RabbitFoot-1.03</a> -\n   <span
-        class=date>07 Apr 2011</span> -\n   <a href=\"/~ikuta/\">Masahito Ikuta</a>\n</small>\n<!--end
-        item-->\n<!--item-->\n  <p><h2 class=sr><a href=\"/~barefoot/Dist-Zilla-PluginBundle-BAREFOOT-0.03/\"><b>Dist-Zilla-PluginBundle-BAREFOOT</b></a></h2>\n<small>Dist::Zilla
-        configuration the way BAREFOOT does it</small><br/>\n<small>   <a href=\"/~barefoot/Dist-Zilla-PluginBundle-BAREFOOT-0.03/\">Dist-Zilla-PluginBundle-BAREFOOT-0.03</a>
-        -\n   <span class=date>21 Feb 2013</span> -\n   <a href=\"/~barefoot/\">Buddy
-        Burden</a>\n</small>\n<!--end item-->\n<!--end results-->\n<br>\n\n\n<div
-        class=\"footer\"><div class=\"cpanstats\">110152 Uploads, 31875 Distributions\n150558
-        Modules, 12210 Uploaders\n</div>\n<div class=\"sponsor\">\nhosted by <a href=\"http://www.yellowbot.com\">YellowBot</a><br/>\n<a
-        href=\"http://www.yellowbot.com\"><img alt=\"do. tag. write. share.\" src=\"http://st.pimg.net/tucs/img/yellowbot_logo.gif\"></a>\n</div>\n</div>\n<script
-        type=\"text/javascript\">\nvar gaJsHost = ((\"https:\" == document.location.protocol)
-        ? \"https://ssl.\" : \"http://www.\");\ndocument.write(unescape(\"%3Cscript
-        src='\" + gaJsHost + \"google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E\"));\n</script>\n<script
-        type=\"text/javascript\" src=\"http://ipv4.v6test.develooper.com/js/v1/v6test.js\"></script>\n\n<script
-        type=\"text/javascript\">\n   // v6.target = '';\n   if (!v6.target) { v6.only_once
-        = true }\n   v6.site = '7A0D89A6-2B82-11DF-B9DA-F61CBD13F020';\n   v6.api_server
-        = 'http://ipv4.v6test.develooper.com';\n   try {\n     v6.test();\n   } catch(err)
-        {}\n</script>\n<script type=\"text/javascript\">\n  $(document).ready(function(){\n
-        \   $(\"a[href^=http:]\").click(function(){\n      var href = $(this).attr('href');\n
-        \     var m = href.match('\\/\\/([^\\/:]+)');\n      _gaq.push(['_trackEvent','External',m[1],'Other']);\n
-        \   });\n    $(\"a[href^=/CPAN/]\").click(function(){\n      var href = $(this).attr('href');\n
-        \     _gaq.push(['_trackEvent','Download',href,'Other']);\n    });\n  });\n</script>\n<!--
-        Thu May 28 19:28:33 2015 GMT (0.035491943359375) @cpansearch2 -->\n </body>\n</html>\n"}
+    body: {string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n\
+        <body bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\
+        \n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n"}
     headers:
-      cache-control: [max-age=3599]
-      content-length: ['7467']
-      content-type: [text/html]
-      date: ['Thu, 28 May 2015 19:28:33 GMT']
-      expires: ['Thu, 28 May 2015 20:28:33 GMT']
-      last-modified: ['Thu, 28 May 2015 19:28:33 GMT']
-      server: [Plack/Starman (Perl)]
-    status: {code: 410, message: Gone}
+      Accept-Ranges: [bytes, bytes, bytes, bytes]
+      Age: ['0', '0', '0', '0']
+      Connection: [keep-alive]
+      Content-Length: ['178']
+      Content-Type: [text/html]
+      Date: ['Thu, 19 Jul 2018 16:48:01 GMT']
+      Location: ['https://metacpan.org/release/foo']
+      Server: [nginx]
+      Via: [1.1 varnish, 1.1 varnish]
+      X-Cache: ['MISS, MISS']
+      X-Cache-Hits: ['0, 0']
+      X-Served-By: ['cache-lax8630-LAX, cache-dca17746-DCA']
+      X-Timer: ['S1532018882.667942,VS0,VE125']
+    status: {code: 301, message: Moved Permanently}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      From: [admin@fedoraproject.org]
+      User-Agent: [Anitya 0.12.1 at upstream-monitoring.org]
+    method: GET
+    uri: https://metacpan.org/release/foo
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA9Uba3PbNvJ7fgWOvavtO1G0bCt+Sco470ybxFe7N9PJZDwgCZKISYImQNtq0/9+
+        C4AQKZJ6uI7ddmcik+BisbvYXewCyOgfLz++OP/l9BV6e/7+x8mTUSSSePIEAYwign39qF4TIjBK
+        cULG1jUlNxnLhYU8lgqSirF1Q30RjX1yTT1iq5ceoikVFMc293BMxoMeSvAtTYrENFg16oKKmExe
+        5TnL0d72HrLRKQ4JSplAAStSHxokA16G0z7Lw5GjO1QEYppeoignwdhyLjDnRHAHHwT+U3/o7mJ3
+        98ANDoN9vD/09rf3yMHeYHcP7wUDfzsguO9xbqGcxGOLi2lMeEQICCemGQgryK1wJEJzMI1PcO5F
+        lhmZCyyo57CMpPpL/zaJDSWcZTH1AIGlNQyfcC+nmWz9j0aWko2t9yDui9OTDwvGjUD/XiEQhSlo
+        Di/buBPga/nQh59uGpIfYgtWeJGtyXD6K+FjazDcuYV/3WSbvfpZGtbpa2kQz736TAwOnh4GhzuH
+        w/2d3eFgMNjGh4P9HZgdQrC3N/S8A/fpQRD0v/A5vX/B11gTtCYjRz+1xqoaENoMitSTutykPd5j
+        vbCX93Av2fqNftp4w1gYk5MUx1MQh390vxBPbHwe58f0U/55LH++fp313/qtTlZ+7F8pnP7V16+f
+        Pm/1s4JHmzgPiwQ8gG/93lMf4/Hg3ym5QS+xIJtbx3jM+15O4OVVTCTiJtvq1Qgn8D0kovzIn0/P
+        cfgBnAzQPm1/PsZ9zKepNx7Ak9RoeJz0M5wD6gfmkz4FG8rFcxKwnGxKMWuUf9/avKGpz256PvMU
+        j70Nra+N3obj3Nzc9EOlEBsbjfQ9ljjV2xcOmCHe2Dp+UqMb4s0NLdFGD238fGLv7B/sHO7t79kD
+        aKgrTQKngpxlhPhnOAG7+Qm6oSM02N6e4/S4QZ+T1JfUM4gBMthIFsz3thnMP4ycKnCNXOZPa/aS
+        4mvkxWCTYwseXZwj/cf2SYCLGHw+Z9L3oJWGylFrlq0o+HRGQcY+TFOS20FcUL+BqbCLuDacGQv+
+        dOHG1OBeU05dmJfbesyZ4eHSK7+zkI8FBk8MQ8kzj6lPIDyS2HwA2yQQmvu1L216QHE2cIBRgG3g
+        kcu/O7cquNj17iOHdpLg8N1QUZ2AiPJYaP8zOowc3NUYN7hvoUiozUSnvjTM5sEBLmgSlgFvLlSa
+        FauKk8iZNAnV4S1LSLPNQKdIEtpiGbijJJEQGT9ynDAnWb++2koJ522kXPaUPTTp1UGSOjqSdJpf
+        DDy8WE5OPIh+bSEiygXLp6ul+EkRaLYauJ8EEfV9knb7uoFKFOyyokMSmgZstRgnsnOz0cCjSwH5
+        yVVbkquCcB13V0nz+uS/zSYDjyjLzGeoiApXLaDGcyr3vyGuQzkH0doC6442jlWGs1zkN1S8LVz0
+        TpFqfjTwiMI7kOh0iCRbM5zBwriGUX4A5GabgccURTAWd8hyA7nWOoHuXHZvNhp4RDmMPQYYVqKM
+        rgjjMk9wMSer5Ts5fddsMnBH6UZOUVaYc62LUiXzmNMwEgs0MIL8N0FY5e2VCuqiO9jzoIwUTsxC
+        GUFlMRkxf2ydfjw7txCFp5m3liigEkl2wYjV9Pg5yyDLThH0C4l/QWUdJatI+ER5FuPpEZSxKTle
+        wLyEelLXIFvmd41kz3xdQvNES7zw+8g1Q3lQUCh53cXUFk6yhNrkzdiGgqNYwp0EUOKktiiUMwTJ
+        ZgolMJXB8t3sWY7fbU916KaY5SygoMLJqX64Dy0oqlkONQ1056Cz1+XrHfhbiiChbgws9WLqXY6t
+        f25ufNew0I2tPi/chAooM6GgF0Wegk/H0pt/VAhL50zCcoa7HVXC4n5L/EK53V/BMc5omCKaLvz+
+        13CMpQgS1gr5DsOFiHYc+QuG+it5BvYEPnUBEa+O9z1U58dexKhHxgH2iMvYZc36SuuCmXyXnp78
+        fPZqU0DyvLVCDAnNFccQV883et1ZSeR12Wkl4tLJkLDYcg38ubrX2eCDaF6TvpPedb65Eu1vr3Vx
+        Q4Ug+YOovaR9J72f6z4r8f72itcbkA+id036TmrX+8Mr0R5d6zJppfrIoHObsQlNVeiOd1LFR+jy
+        7uVKtHuq4q4ZRht/5Pj0umoaOVAtTKrd6uXbtTVKdUS5ZQ31OMkFrNWcy2Mo/aZ3WV6CKqesQDjP
+        6TVBEckJuqYYlec9xsyftb1GbrlDVRzrbfZcUC8mDsdTmobSXH13Ks9Vyr01W2V60q8sZHZyL9wY
+        p5eQddLUR3Iv5yaayinol2qYCVQXrbHLWZc0ZzeorC6zCDKxDtuqo8t9dZsnOI5VBoo8FtuJb+92
+        dJNQ2e8sd6s6SzvssJ3GfM6a5+ZRjXq4aNS5WtAx53OGAa1bhSN/bBWqpGV0741rqA+veoU5K7Il
+        HSTUO9E0K8RavSSMFHrtGMwqz12v9And2Nob6Jq1FEfhz2RUHEprz1lsoWscF2TpRqmB+S32imPb
+        FcvS6TqM3EIINiMCHUu3UDRKiXTRYk3O1BdIrlWf1QMs2uuvwwL7MbDk86Jqv6NLR9O8wzV8rEN5
+        dYwEopKaL7nHXFr3YKejk4Qnqqec+5QJWx2Nl5jzOyi2rE9R6+SnVp91nDJJ2iVepxdVLM2ZaMPH
+        6vaH5LaaPKpRLmchqPo8ErHYJ/nY0gZQGfci8tpeZlFIBSwjTzlr9QBYrR01aaVKZPyCLG9yxuTu
+        D0RdlFDO4e+zuS41NhrzXNsOUDvYZfeLhPlFLPcrmoG5olSZjB5LL2W6IRpMPjCBXsvJHDnwVrZn
+        usOMyHlEoM7nrMg9opagnKjtcuKD2RSxr25LuERfmOhXfUdOVpIsfw1BM4IBPSFIwDjy5oGMkDWZ
+        9TQ/uxoHDMI3/DQkNOw2F6MKo+U2XajNBQoGkrn5fMcm4myP1KxnPDGuBJ70fery7Lhj/CYZ2eWW
+        2zuqL0/swcwfZ1sXMh5DdkDD9AjJU6FO1iS0lv+upNmanJy+u89KCNwODbe7lch/nFtzxKQPi94T
+        fQnlj7JYzUvJo1btfXlMqLwoBA6nzPS9fvtmPH4TPa57MARBg+WXjctN30iQb2q+s+xV5aST0/Jx
+        XWbXcPUZkxn2fYirR2i4nd2iwRB+duGpxeli4WVaipSs+tygSXln2EEOzadAc5mxIQDEWX6Evjs8
+        hAT0LeNCLiMhgbKCFTyeoixn17Dm+sidHnUnLB26mZekdOvDKr9el/uuKXOngiQ4vwQL7BeXTj5/
+        LNKuLVpUga683qAv+Fk7g22rcdUhgQqJg6gs5eCFjhnwQqb5jcthM4pto/kGapGG0jUYbgrZoaaY
+        XkFRCP6oPLWDyrwaBvur1DAjeKFM5i+iiLbgclWKp1rqpp7aJEotLJVcU6ymv9TZYLANxbL0xvFw
+        0Ka8nia6mhpBpEWlrbrBgdIdPLEg4ERUEf9pU5e2y6A6SY7QTlcAQuiEI6xrLB9lUNNDIEAYkkCI
+        A4WPeJHJe7LQxoLZWtpDZ6C2S5L/Aikc5S2SEc6yKSTO0CeQ1NBg+1/Ip1wdQCGorqCG7p5LrulC
+        aqjmE3jwC09wxys4yGCXn7mzuzvsmOwXCsswp5bT+k1FDXca1y0gPSac2zF2Scydp8Nhe9jnJRL6
+        USGpYdFPDGTUDW0e/kfTKXwlco9Uhl/IUkveXxIPx7zfYBO4rDQuOWwzMf+9wxYRzJTMuWEmUwKa
+        ZBniEfzANCX4UqXjOTLyIqWQfovEz5yAofkE1hkojtJw8v7V+Yk0icE2rBW6CWEoAiPiXcr0C6jL
+        67ZTTd7YQJNwl1PMNzVfay4BtQuOUQCVkdSKCwUMuR1bMmPQVyF9isGT9XbDJZm6DOe+bW4fz19J
+        aJG1y86LHVajlcVvy73amKaEa6l2FO3NY6pb1Nbkh5JldGZYhgprr9m/Q4Ndo8vbpKgrxrSjjIol
+        Em0ESo2J+aRfFupxJOqX7kcir82ZiCYjB37mWt7EzMVxvR2ey16ytboJK+pXYRuUfcMeMNaY0kvX
+        n4DK5J+qgyPqb/DymkGIKbd6EFT7dYyKobuO+2zluM+V/xfghhG4Z0TiDGmT62YAnowW4FFOhUpI
+        H3iK1CHaA09RqFWlX7KVenvDZGjJCgiy5R4C79bYvfigK/kIFR/lyaS+IYc2WQoBjwZVMyymBFbC
+        HJbYnGSMU3lrc6ub4a4pNqXHn+Sjpx9fPubs45Va17Ovz+m6tXgvBrw1GfAinIby5sw352C14WkO
+        tMU9AAP+mgzAii4eYPh8zeErb3LOXrx/AEZWrxyaEb2n+QAMuGsyIK+FIReWdt7BhXoZLQkshp7p
+        tFYyYfY1O9BbTc38rXodOZoryGrU/9z7PzPy4ofRNwAA
+    headers:
+      Accept-Ranges: [bytes, bytes, bytes, bytes]
+      Age: ['0', '0', '0', '0']
+      Cache-Control: [private]
+      Connection: [keep-alive]
+      Content-Encoding: [gzip]
+      Content-Type: [text/html; charset=utf-8]
+      Date: ['Thu, 19 Jul 2018 16:48:02 GMT']
+      Server: [nginx]
+      Vary: [Accept-Encoding]
+      Via: [1.1 varnish, 1.1 varnish]
+      X-Cache: ['MISS, MISS']
+      X-Cache-Hits: ['0, 0']
+      X-Runtime: ['0.196082']
+      X-Served-By: ['cache-lax8638-LAX, cache-dca17746-DCA']
+      X-Timer: ['S1532018882.869043,VS0,VE323']
+    status: {code: 404, message: Not Found}
 version: 1

--- a/anitya/tests/request-data/anitya.tests.lib.backends.test_cpan.CpanBackendtests.test_cpan_get_versions
+++ b/anitya/tests/request-data/anitya.tests.lib.backends.test_cpan.CpanBackendtests.test_cpan_get_versions
@@ -6,164 +6,180 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       From: [admin@fedoraproject.org]
-      User-Agent: [Anitya 0.5.0 at upstream-monitoring.org]
+      User-Agent: [Anitya 0.12.1 at upstream-monitoring.org]
     method: GET
-    uri: http://search.cpan.org/dist/SOAP/
+    uri: https://metacpan.org/release/SOAP/
   response:
-    body: {string: !!python/unicode "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01
-        Transitional//EN\">\n<html>\n <head>\n  <link rel=\"stylesheet\" href=\"http://st.pimg.net/tucs/style.css?3\"
-        type=\"text/css\" />\n<style>\n.styleswitch {\n  text-align: right;\n}\n</style>\n\n\n<script
-        type=\"text/javascript\" src=\"http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js\"></script>\n<script
-        type=\"text/javascript\" src=\"http://st.pimg.net/tucs/js/jquery.cookie.js\"></script>\n<script
-        type=\"text/javascript\" src=\"http://st.pimg.net/tucs/js/sh_main.min.js\"></script>\n<script
-        type=\"text/javascript\" src=\"http://st.pimg.net/tucs/js/sh_perl.min.js\"></script>\n<script
-        type=\"text/javascript\" src=\"http://st.pimg.net/tucs/js/jquery.styleswitch.js\"></script>\n\n<link
-        rel=\"stylesheet\" href=\"http://st.pimg.net/tucs/print.css\" type=\"text/css\"
-        media=\"print\" />\n  <link rel=\"alternate\" type=\"application/rss+xml\"
-        title=\"RSS 1.0\" href=\"http://search.cpan.org/uploads.rdf\" />\n  <link
-        rel=\"search\" href=\"http://st.pimg.net/tucs/opensearch.xml\" type=\"application/opensearchdescription+xml\"
-        title=\"SearchCPAN\" />\n  <title>Keith Brown / SOAP - search.cpan.org</title>\n
-        <script type=\"text/javascript\">\n    var _gaq = _gaq || [];\n    _gaq.push(['_setAccount',
-        'UA-3528438-1']);\n    _gaq.push([\"_setCustomVar\",2,\"Distribution\",\"SOAP\",3]);\n
-        \   _gaq.push([\"_setCustomVar\",5,\"Release\",\"SOAP-0.28\",3]);\n    _gaq.push([\"_setCustomVar\",1,\"Author\",\"KBROWN\",3]);\n
-        \   _gaq.push(['_trackPageview']);\n  </script>\n </head>\n <body id=\"cpansearch\">\n
-        \  <div class=\"header\">\n<center><div class=\"logo\"><a href=\"/\"><img
-        src=\"http://st.pimg.net/tucs/img/cpan_banner.png\" alt=\"CPAN\"></a></div></center>\n<div
-        class=\"menubar\">\n <a href=\"/\">Home</a>\n&middot; <a href=\"/author/\">Authors</a>\n&middot;
-        <a href=\"/recent\">Recent</a>\n&middot; <a href=\"http://log.perl.org/cpansearch/\">News</a>\n&middot;
-        <a href=\"/mirror\">Mirrors</a>\n&middot; <a href=\"/faq.html\">FAQ</a>\n&middot;
-        <a href=\"/feedback\">Feedback</a>\n</div>\n<form method=\"get\" action=\"/search\"
-        name=\"f\" class=\"searchbox\">\n<input type=\"text\" name=\"query\" value=\"\"
-        size=\"35\">\n<br>in <select name=\"mode\">\n <option value=\"all\">All</option>\n
-        <option value=\"module\" >Modules</option>\n <option value=\"dist\" >Distributions</option>\n
-        <option value=\"author\" >Authors</option>\n</select>&nbsp;<input type=\"submit\"
-        value=\"CPAN Search\">\n</form>\n</div>\n\n\n  <div class=path>\n<div id=permalink
-        class=\"noprint\"><a href=\"/dist/SOAP/\">permalink</a></div>\n  <a href=\"/~kbrown/\">Keith
-        Brown</a> &gt;\n  SOAP\n </div>\n\n <div class=box>\n  <h1 class=t1>SOAP</h1>\n<a
-        href=\"http://hexten.net/cpan-faces/\"><img src=\"http://www.gravatar.com/avatar/58b29a24803bb9bd2a0b5c31340a531f?r=g&s=80&d=http%3A%2F%2Fst.pimg.net%2Ftucs%2Fimg%2Fwho.png\"
-        width=80 height=80 \nstyle=\"float:right\"\n/></a>\n\n  <table>\n   <tr>\n
-        \   <td class=label>This Release</td>\n    <td class=cell>SOAP-0.28</td>\n
-        \   <td><small>&nbsp;[<a href=\"/CPAN/authors/id/K/KB/KBROWN/SOAP-0.28.tar.gz\">Download</a>]\n
-        \   [<a href=\"/src/KBROWN/SOAP-0.28/\">Browse</a>]&nbsp;</small></td>\n    <td><small>05
-        Sep 2000</small>\n    </td>\n   </tr>\n\n\n\n   <tr>\n    <td class=label>Other
-        Releases</td>\n    <td class=cell colspan=3>\n     <form action=\"/redirect\">\n
-        \     <select name=\"url\">\n       <option value=\"/~kbrown/SOAP-0.26/\">SOAP-0.26&nbsp;&nbsp;--&nbsp;&nbsp;31
-        Aug 2000</option>\n       <option value=\"/~kbrown/SOAP-0.25/\">SOAP-0.25&nbsp;&nbsp;--&nbsp;&nbsp;16
-        Aug 2000</option>\n       <option value=\"/~kbrown/SOAP-0.23/\">SOAP-0.23&nbsp;&nbsp;--&nbsp;&nbsp;09
-        Jan 2000</option>\n       <option value=\"/~kbrown/SOAP-0.22/\">SOAP-0.22&nbsp;&nbsp;--&nbsp;&nbsp;03
-        Jan 2000</option>\n      </select><input type=submit value=\"Goto\">\n     </form></td></tr>\n\n
-        \  <tr>\n    <td class=label>Links</td>\n    <td class=cell colspan=3><small>\n
-        \    [&nbsp;<a href=\"http://www.cpanforum.com/dist/SOAP\">Discussion&nbsp;Forum</a>&nbsp;]\n
-        \    [&nbsp;<a href=\"https://rt.cpan.org/Public/Dist/Display.html?Name=SOAP\">View/Report&nbsp;Bugs
-        (3)</a>&nbsp;]\n     [&nbsp;<a href=\"http://deps.cpantesters.org/?module=SOAP;perl=latest\">Dependencies</a>&nbsp;]\n
-        \    [&nbsp;<a href=\"/tools/SOAP-0.28\">Other&nbsp;Tools</a>&nbsp;]\n    </small></td></tr>\n\n\n<tr>\n
-        \   <td class=label>CPAN Testers</td>\n    <td class=cell colspan=3><small>\nPASS
-        (72)&nbsp;&nbsp;\nFAIL (10)&nbsp;&nbsp;\nNA (3)&nbsp;&nbsp;\nUNKNOWN (3)&nbsp;&nbsp;\n
-        \    [&nbsp;<a href=\"http://www.cpantesters.org/distro/S/SOAP.html#SOAP-0.28\">View&nbsp;Reports</a>&nbsp;]\n
-        \    [&nbsp;<a href=\"http://matrix.cpantesters.org/?dist=SOAP+0.28\">Perl/Platform&nbsp;Version&nbsp;Matrix</a>&nbsp;]\n
-        \   </small></td></tr>\n\n\n   <tr>\n    <td class=label>Rating</td>\n    <td
-        class=cell colspan=3 nowrap><small>\n<img src=\"http://st.pimg.net/tucs/img/stars-1.0.gif\"
-        alt=\"*    \">\n     (<a href=\"http://cpanratings.perl.org/d/SOAP\">1 Reviews</a>)\n
-        \    [&nbsp;<a href=\"http://cpanratings.perl.org/rate/?distribution=SOAP\">Rate&nbsp;this&nbsp;distribution</a>&nbsp;]\n\n
-        \   </small></td></tr>\n\n   <tr>\n    <td class=label>License</td>\n    <td
-        class=cell colspan=3>\nUnknown\n</td>\n   </tr>\n   <tr>\n    <td class=label>Special
-        Files</td>\n    <td class=cell colspan=3><table><tr class=distfiles>\n     <td>\n
-        \     <a href=\"/src/KBROWN/SOAP-0.28/Changes\">Changes</a><br>\n     </td>\n
-        \    <td>\n      <a href=\"/src/KBROWN/SOAP-0.28/Makefile.PL\">Makefile.PL</a><br>\n
-        \    </td>\n     <td>\n      <a href=\"MANIFEST\">MANIFEST</a><br>\n     </td>\n
-        \    <td>\n      <a href=\"/src/KBROWN/SOAP-0.28/README\">README</a><br>\n
-        \    </td>\n    </tr></table></td>\n   </tr>\n  </table>\n </div>\n\n <div
-        class=box>\n  <h2 class=t2>Modules</h2>\n  <table width=\"100%\">\n   <tr
-        class=r>\n    <td>\n     <a href=\"lib/SOAP.pm\">SOAP</a>\n    </td>\n    <td
-        width=\"99%\">\n     <small>Library for SOAP clients and servers in Perl&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \  <tr class=s>\n    <td>\n     <a href=\"lib/SOAP/Defs.pm\">SOAP::Defs</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Spec-defined constants&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \  <tr class=r>\n    <td>\n     <a href=\"lib/SOAP/Envelope.pm\">SOAP::Envelope</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Creates SOAP streams&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \  <tr class=s>\n    <td>\n     <a href=\"lib/SOAP/EnvelopeMaker.pm\">SOAP::EnvelopeMaker</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Creates SOAP envelopes&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \  <tr class=r>\n    <td>\n     <a href=\"lib/SOAP/GenericHashSerializer.pm\">SOAP::GenericHashSerializer</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Generic serializer for Perl
-        hashes&nbsp;</small>\n    </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n
-        \  </tr>\n   <tr class=s>\n    <td>\n     <a href=\"lib/SOAP/GenericInputStream.pm\">SOAP::GenericInputStream</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Default handler for SOAP::Parser
-        output&nbsp;</small>\n    </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n
-        \  </tr>\n   <tr class=r>\n    <td>\n     <a href=\"lib/SOAP/GenericScalarSerializer.pm\">SOAP::GenericScalarSerializer</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Generic serializer for Perl
-        scalar references&nbsp;</small>\n    </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n
-        \  </tr>\n   <tr class=s>\n    <td>\n     <a href=\"lib/SOAP/OutputStream.pm\">SOAP::OutputStream</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Writes SOAP fragments&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \  <tr class=r>\n    <td>\n     <a href=\"lib/SOAP/Packager.pm\">SOAP::Packager</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>SOAP internal helper class&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \  <tr class=s>\n    <td>\n     <a href=\"lib/SOAP/Parser.pm\">SOAP::Parser</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Parses SOAP documents&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \  <tr class=r>\n    <td>\n     <a href=\"lib/SOAP/Serializer.pm\">SOAP::Serializer</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>serialization utilities&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \  <tr class=s>\n    <td>\n     <a href=\"lib/SOAP/SimpleTypeWrapper.pm\">SOAP::SimpleTypeWrapper</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>deprecated&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \  <tr class=r>\n    <td>\n     <a href=\"lib/SOAP/Struct.pm\">SOAP::Struct</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>support for ordered hashes&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \  <tr class=s>\n    <td>\n     <a href=\"lib/SOAP/StructSerializer.pm\">SOAP::StructSerializer</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>(internal) serializer for SOAP
-        structs&nbsp;</small>\n    </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n
-        \  </tr>\n   <tr class=r>\n    <td>\n     <a href=\"lib/SOAP/Transport/HTTP/Apache.pm\">SOAP::Transport::HTTP::Apache</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>SOAP mod_perl handler&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \  <tr class=s>\n    <td>\n     <a href=\"lib/SOAP/Transport/HTTP/CGI.pm\">SOAP::Transport::HTTP::CGI</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Generic SOAP CGI handler&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \  <tr class=r>\n    <td>\n     <a href=\"lib/SOAP/Transport/HTTP/Client.pm\">SOAP::Transport::HTTP::Client</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Client side HTTP support for
-        SOAP/Perl&nbsp;</small>\n    </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n
-        \  </tr>\n   <tr class=s>\n    <td>\n     <a href=\"lib/SOAP/Transport/HTTP/Server.pm\">SOAP::Transport::HTTP::Server</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Server side HTTP support for
-        SOAP/Perl&nbsp;</small>\n    </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n
-        \  </tr>\n   <tr class=r>\n    <td>\n     <a href=\"lib/SOAP/TypeMapper.pm\">SOAP::TypeMapper</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Maps Perl types to their serializer/deserializer
-        classes&nbsp;</small>\n    </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n
-        \  </tr>\n   <tr class=s>\n    <td>\n     <a href=\"lib/SOAP/TypedPrimitive.pm\">SOAP::TypedPrimitive</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>Wrapper for xsd primitives
-        that need explicit SOAP type attributes&nbsp;</small>\n    </td>\n    <td>&nbsp;</td>\n
-        \   <td class=\"version\">0.28</td>\n   </tr>\n   <tr class=r>\n    <td>\n
-        \    <a href=\"lib/SOAP/TypedPrimitiveSerializer.pm\">SOAP::TypedPrimitiveSerializer</a>\n
-        \   </td>\n    <td width=\"99%\">\n     <small>serializer for xsd scalars&nbsp;</small>\n
-        \   </td>\n    <td>&nbsp;</td>\n    <td class=\"version\">0.28</td>\n   </tr>\n
-        \ </table>\n </div>\n\n\n<div class=\"footer\"><div class=\"cpanstats\">110152
-        Uploads, 31875 Distributions\n150558 Modules, 12210 Uploaders\n</div>\n<div
-        class=\"sponsor\">\nhosted by <a href=\"http://www.yellowbot.com\">YellowBot</a><br/>\n<a
-        href=\"http://www.yellowbot.com\"><img alt=\"do. tag. write. share.\" src=\"http://st.pimg.net/tucs/img/yellowbot_logo.gif\"></a>\n</div>\n</div>\n<script
-        type=\"text/javascript\">\nvar gaJsHost = ((\"https:\" == document.location.protocol)
-        ? \"https://ssl.\" : \"http://www.\");\ndocument.write(unescape(\"%3Cscript
-        src='\" + gaJsHost + \"google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E\"));\n</script>\n<script
-        type=\"text/javascript\" src=\"http://ipv4.v6test.develooper.com/js/v1/v6test.js\"></script>\n\n<script
-        type=\"text/javascript\">\n   // v6.target = '';\n   if (!v6.target) { v6.only_once
-        = true }\n   v6.site = '7A0D89A6-2B82-11DF-B9DA-F61CBD13F020';\n   v6.api_server
-        = 'http://ipv4.v6test.develooper.com';\n   try {\n     v6.test();\n   } catch(err)
-        {}\n</script>\n<script type=\"text/javascript\">\n  $(document).ready(function(){\n
-        \   $(\"a[href^=http:]\").click(function(){\n      var href = $(this).attr('href');\n
-        \     var m = href.match('\\/\\/([^\\/:]+)');\n      _gaq.push(['_trackEvent','External',m[1],'Distribution']);\n
-        \   });\n    $(\"a[href^=/CPAN/]\").click(function(){\n      var href = $(this).attr('href');\n
-        \     _gaq.push(['_trackEvent','Download',href,'Distribution']);\n    });\n
-        \ });\n</script>\n<!-- Thu May 28 19:28:33 2015 GMT (0.030505895614624) @cpansearch2
-        -->\n </body>\n</html>\n"}
+    body: {string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n\
+        <body bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\
+        \n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n"}
     headers:
-      cache-control: [max-age=3599]
-      content-length: ['12357']
-      content-type: [text/html]
-      date: ['Thu, 28 May 2015 19:28:33 GMT']
-      expires: ['Thu, 28 May 2015 20:28:33 GMT']
-      last-modified: ['Thu, 28 May 2015 19:28:33 GMT']
-      server: [Plack/Starman (Perl)]
+      Accept-Ranges: [bytes, bytes, bytes, bytes]
+      Age: ['0', '0']
+      Connection: [keep-alive]
+      Content-Length: ['178']
+      Content-Type: [text/html]
+      Date: ['Thu, 19 Jul 2018 16:48:02 GMT']
+      Location: ['https://metacpan.org/release/SOAP']
+      Server: [nginx]
+      Via: [1.1 varnish, 1.1 varnish]
+      X-Cache: ['MISS, MISS']
+      X-Cache-Hits: ['0, 0']
+      X-Served-By: ['cache-lax8635-LAX, cache-dca17744-DCA']
+      X-Timer: ['S1532018883.528559,VS0,VE125']
+    status: {code: 301, message: Moved Permanently}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      From: [admin@fedoraproject.org]
+      User-Agent: [Anitya 0.12.1 at upstream-monitoring.org]
+    method: GET
+    uri: https://metacpan.org/release/SOAP
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+09a3PbOJLf8yswys3YvrFEPaz4EclZT5zXTR6+2LNbW6lUCiIhiWOKZAjStmZn
+        //t1NwASfMiy4iS7W3WsjEXi0ehuNBrdjSZn9MPpu6cXfz97xl5evHl9/GA0TxfB8QMG12guuKdu
+        6XEhUs5CvhDj1pUvruMoSVvMjcJUhOm4de176XzsiSvfFW162GV+6Kc+D9rS5YEY93bZgt/4i2xh
+        CloW9NRPA3F8/u7krN3t9A9Ym732JwlPlmwaJQzLmRv4MJRkPPSYFMmVSCQMwc5EEkBzRM+NediJ
+        ktnIUeAK8IEfXrJEBOMWD1KRhDwVLZYuYyCGx3Hguzz1o9BJpPz5ZhFAFfYft96fn7fYPBHTccuZ
+        CuE5ni/TxJ9k1BqxajGnOoxu/4lLKVLp8IOp98gbTgZ8MjiYTA+n+3x/6O5398TBXm+wx/emPa87
+        FbzjStlSOMp0GQg5FyI1SKbiJnWwQXUw1V7wxJ3nmMoUqHGdKBahqukommrkFi08Id3Ej7G0xIA3
+        wNWnZydvm8d1eRiFACwwQ8/TNJZHjmNPhgNNBZeigV2WSFkIWFK1iQw0zIRizhwk1c1S5rsIu8wj
+        LJPOlF/hTQf+NBOKTBPtNMrceVuBkf4fQo5bvWH/Bv5rBlvt1YnDmQ1fUcxk4tri0jt4dDg97B8O
+        9/uDYa/X6/LD3n4fREgI7u4NXfdg8uhgOu38LkvC8Tu/4gpg63jkqLvaWEUBY9vTLHSR39v+rtyN
+        dme7yS7fXez8w/+w9SKKZoE4CXmwBHLku8nvwk23Po6Tx/6H5OMY//z5Z95/5x82WKzsfKY2nc9/
+        /vnh404nzuR8myezbIGTt/PPXaoMxr3/DsU1O4XFuL3zmI9lx00EPDwLBDbcjnZ2LcALqJ+JVFfK
+        X5YXfPYWZAeafeh+fMw7XC5Dd9yDO+To7PGiE/MEmr6NPNHxQdCT9BcBkiS2kUwL8j93tq/90Iuu
+        d73IJRx3txS/tna3HOf6+rozI4a0ueFIx40WTvH0u4SWM7618/iBBXfGt7cURVu7bOu3k3Z//6B/
+        uLe/1+5Bgc00vKSfivMYlMw5X4DcvIdu7Ij1ut0Spo8r8KUIPYQe85lAtYwomPq6GNRv7DWYXvsp
+        KMcjlydeyzTI16LMFgtYi7TMmnpluARrve6mEZrgkQYyEHN4t3b5SkqkCTTOTp0nhirqVmbuyCn2
+        z9Ek8pbWYgz5FSABC37cgtsJT5j6aXtiyrMAtH4SofaFUn9GqtpSGwTB83MIiAz3Q5G0p0Hme5WW
+        1DoLrOHMWPDT1DbwTdsrX/oTEPobe9fJ23Gt8h62mMdTDmpuNkOcZeB7AlgiAlMBC18ArzpWTR0e
+        QMwHnnI25W3AUeJv/4Y0d9vuPnL8RhAS6g0U6gRASB1C+b+iw8jhTYVBBftaE7ysmWjkl7ryeXAA
+        C38x07tJaR8yUlpsQiCuVUD29TJaiGqZuRpJwqtOlrk2pMSojFki4o6tN5DCsoxow4fkoQrPvhDU
+        0RHCqdaY69uTBVrPBaVRJ2IONmUEinUtFe8JQLXUXPejYO57ngib17q5ClL4JMoaKPHDabSejBPs
+        XC0013enAoy/z3VKPmdCKr27jprnJ/9bLTLXd6QlXzN+Os8mZJ2YlVMs/2sxcXwpgbQ6wapjG7yj
+        9SS/8NOX2YS9IlDVSnN9R+IdsCIbSMLSmMewMd5BKN9C42qZub4nKWkUBQ20XIMhexdFd4Hdq4Xm
+        +o50GHmcctiJYn+NGkc7YQIG4Xr6Ts5eVYvMtSF1IyfTgY5S6SpTydwm/myeruDACCzMBePkFK2w
+        fLnrRlmYOkE0Qw2KUYt55I1bZ+/OL1rM9wqTsq2bAEsQ7IoRi+nxkigGFyZk0G8mvE8+OqkYR4Aq
+        X8YBXx4x8NbF4xXI42UbdRWw2r6rGHum9haYJ4rilfWjiRkK3A5B9E5WQ1s5yXhZk5ejDd5cdgt2
+        eAETj61NQc8QGJshuCA+KstX+T2O3yxP9tUMMU6iqQ8sPD5TN/eBNeVXUQIuCXSXwLPn+nED/G5t
+        gJctDFEIPpN7OW791/bWw4qEbu10ZDZZ+Cn48AxmMEtCWNMBrubX1ODWOcPrdoSbFypeq/vdsi5o
+        2f07LIxzfxaC27my/t9jYdzaAK87qXwn4lk67zv4FwT1D/FE+eCfQOPZ7X7ii/ixO498V4yn3BWT
+        KLq0pE9LF8zkq/Ds5LfzZ9spGM87a8jAq7rjGOB0f632nbVAnutOaxveOhl4rZZcc/1rea+swW/C
+        eQV6I74re3Nts/94rutY0zdhu4a9Ed8vVJ+17f7jGa+iu9+E7wr0RmxXwfe1zb4719Fo9dWhUWOY
+        sXpVWaE6bsSKd9Dl1enaZvdkxaYWRr39yPH8q6Jo5IC3YAWEbw/XWpDshhhxBn9cJCns1VLymWDq
+        SUVZToGVyyhjPEn8K8HmIhHsyudMn/gZMX9SXzV4ngFecaDOMJLUdwPhSL70wxmKqzdZ4qGVjq21
+        ydLDddViJpL7aRLw8BKsTj/0GMZyrudLnIKOZkNOkE1aJcppU5pE10x7l/EcLLEG2bKbY1y9LRc8
+        CMgCZW4UtBdee9DQDa9CfnPbreiMctggO5X5zItL80ijHq4ateQLOuaE1iCgeEtt8E+bVBVKRnNs
+        XF328NRrlkRZfEsHvOxOfhhn6Z164TWi5tYZY0ufiXxWx5/j1l5P+ayaHGqf00gYorQnUdBiVzzI
+        xK2BUnOVQ+wFxu1Jeps5bV+jSZamUQ4EOuplQTA0RcppaR2fUw0Y19Rn/QCrYv32tUJ+zHVL9Spv
+        v6FLQ1F5wVXWWAPz7BYL0Eo0Xxhj1tLd6zd0wuuBvmwAkwQWpptki4kKEamJZAoArELlIV2K5STi
+        CaxgfS4/bs0Y14kPatPOT9PVo/PrL+/f/e1tnpOQS5iqbqNQwjrWo/0qwMBkvwC9oZ4pvcKLeaOm
+        xz+FExk/dtSPVWkzTZ1TMjxNyWQ74OBhp2wBD+BsL9u62uyFJcEtHMBGP84WopEEOG5qWsFCE6FH
+        xsichzN0JvWpdCeIVOJGh/iDJkmH1pXaREYRnXwyBU54Zs3lx62Kj3TqSkk2Gm+81ZO8rZrA2Kzf
+        7Xbb3cN2d2iOyomHaozSeOvGeVSM82jVOAftQe++4wyLcYarx+nt33ccs9Hg7apxeu1e977jmLWH
+        t6vH6e41jgMCRmKgQOgWJQnVo+rlkwuFLZnmT65pRj+02/DzWxj4l2COhAyPHI936S6iJJFjNkv4
+        NJUsnQt2/tcXzAgv88M0otLTd292wWTw3TmAWggeSjaB5SrxGP7aDwKmwzLUWCeGMaHTPlg0NaA7
+        jP2dL3940G4DuSXKwCBK2jOezYT6q9eHvJoxlafW6u/FNy3NFbCdMKiLyTxWIWYF0N7d6/TywptF
+        EEplSWlD6npATgfOhgPwyy2PbjCFqKl97/Dw0KFahRtgNzOaVjNZXRdk2PmSSTyTRQ0yzQLGU9TS
+        KEQTEYD1pDmbCJkFKdhxyF7QVTF3Cz8CZgX8v1QsYtRjOB0iiaOAFMouE6EEpQY90zlPCRieRKR+
+        DE5QdCkZGoYgdjm0SQRa9uk8Qawwj+K5D5hFNx12plSmF4VbKePe7xloTD9lkwDUsgiWuzhAeCl/
+        0JBw8tSdnun3OHmoccHe/UMkEfvpYa/7+G3EPAHOAAZiZZ7eZzGMDRkmDOyyvRucxl3Wi28Yj8G8
+        3cXNLEpAHz4Ue6Iv+ixK2MN9wQfTvj18gjr4Ztzqthhb0o+Wlb2WJSEtNgURHbc0LCvpLAcwvC+A
+        HnS9H4DhPQH0vwiDkUMyPMKFcIzGgVYlJtFtRbYadHkjVJphZ8qv5Kc0+uTOhXv5YQu10tZHNma9
+        xwhNZzMpqwMNT9Ja0Cc3CYrDDxi2bILXQufc8+qRYB9UW0ihAGUf5rEA6HZqJX+WAgIlS1l5MsZW
+        TsQiuhK5/du9Sw9aQXmX6nZ9S1djPume2m5a281Oai0Na7pqc7pkN+dmvmantsCMZcN+/rkwqY1R
+        q/cR28SyovJQYVw1KxRDPu/2llYrUgXNUeHB9OGkqHOPrerZQx09tUeU8OM5Svnvg/IJYBvPV1gt
+        c8k6X6hlSSF1+q7RBzSLrTIlFQ/R9p5IFWOiETmMLQaS6op5FHgigXnS/Yxrtgp8eda0AJh1W5oe
+        XWYiHxatyBD0vgWmPFVsCdhH/gAud4fsXMRknbDewVF376g/ZC/eXOS2uAXWOteSUZa4NQsIRL4a
+        RJpe018iniJKsLNw91LFk9Dql3SuxrZrYQ+ZdjAnKtZhwhUjOq3jhF8jiJ0yruqG3+LEuLnfogx3
+        2ZAtvoIeN5pJm5CnCoCWUBz9gY2DmY4ojmJw5fNhUVxouHDWTqNbR4wDcGhcP3EDYQ/8UhkTTw0k
+        YmYTCqvZ4FeTwZM0j0Y5ZxkYAq6DmhT/oM7t4CsHTzCTd3wbwhj1akBYJaHkQZxtsIYVtjmyBuMC
+        KTyU50DfDeGFPh3YeoTeE5wxQuNnEr88DZ6ar0KNNqsG3C4U5Bw5tWQ0yO0Y4DAH+vsB/IQcNpO6
+        0KLJWEWSpApml+ZXcQ+0JTQa9yiojfVAn34ydizSQwVgn3ti3M+3PrKOjtjD7iFsTvsHtHqc5qjh
+        N8FkUMPksAuY9LrfHZM9UF965WvDpSxJVSEiJCThonZehcsKd26lMkODA2QITFVbeH695mAyi9oC
+        bIYx41cisLu/9l18t+OIZeFlSLEQgvBAa/dmnX4CW9WVny4rWtrarnEzwxZt4Fis9jIr69TUPgFH
+        ZLwAHTLPmW/UoFrjxqzs7XcLw7JvLEkaEKifhejLUb7NiEK2Bgs3WqAz2Dru7zEaBiYM64+NgWF+
+        LDKa6KVsqfokV+SNlFc5i0fNtuN7zq8wzbWZ7qQ86cz+yC2v8oxhWCiIuD4JsSft1NRsm2jWoN/Z
+        3/91ogVyJ1clt4omIi1uYnR6kjLiT7IkGN8ioI34ogmEiYF1fI3Zzp7p0VT/QmI1fsU+H4tk4Utc
+        fE2bY+PwsMnURz7L4UiEXxvRHnPFi1vNoyVStuXnDPzs+qDn2QRdkAn6xhikyAGuIJs1BaLhP1zx
+        l5WEkUXk4WtUpYz5h34IfnAQtPE3yciOlG3P52A053ZelYAUORPyoI7+KwWN4a+BpjEvDPUy+psY
+        sGWf4nPuSCCjjiyO1zoayzfv2GDfltidbxikRY5YbziIb+5iOa9CQNvGVV8Qs4JqJvItDDJrr5a4
+        vhnnvCYfbE0nZc3mHc3gVudNeI4EfG2Ob8zylTzX4fK18fGtXNFt/WzFyjfCWsdqj/8nW8S46rXl
+        UMRZrUZlt9sOf+PfeuyWYt6lyPA6UEMCNWwC1dvfDNSAQA3qoChyvRGoPoHqN4Hq7tVA5XHpFdNa
+        CYLcYZY9fzp1MKHSeaI1Z3Vjc8gMUWtkvMV+ZiJ0I0/89v7V02gRg8iFKcVzlITsfJmInAIaYNek
+        8/8XkgZQ9xISlJIm+w2tAI6baYMRpzf/1bbOBUx4MVUNe3duCJbfVzx+rY4B610fqMSQB2bXxwgl
+        2a/tGGNHeaZoYQ1oSyAPdqkWZ9h6e4u6VgNbj9EWRttQA1GQTTjnfB5dm0hLvZUOVbWOX/qeMHGw
+        9zgKoyEtO8AEWC30c7zjDEwSkwdfOgCOblR5NZuDAvTPo4Rh1IHOeTDuXj491oe5se9ih3z+ykfA
+        ODOFv2E7hOCPXHE0uymphW4db7i/vy/EwcF+Xzx65E33Dnj3cLI36A+mgh8Mek/kuDfoKhdlTMB+
+        HJz82H8O/6ogoUg9wM3wYNI/5P29g+5gMjmceH3enQzdQW+w1+XDQW/64+A5ADoF0D/2H3lwp1LJ
+        XXqLU4kLOquhCpbzO5x8H6tfLWqmcymc0Go4+DZ+EIXilUfUENxsnrX8uMWlDHi1IppX4anVsuI5
+        5u3T1I/zaIq3BCXvu5+AI1N/BsqYg1R6rePcVfWrccJ5Ap5huazQvxWvHBBXPnkpsAP2dRaYCFPR
+        t2r9i/RaiAZPh7wcHc9hr4FtRVCnhFUNKdAdnzM/aQoGPpFRko4/fOjv9j5+bBVdKzjJeaMz8l6g
+        AirPUwUprY5yMSinL1GiR0vFBPL1DpUpxiIw+pgv+GuBrncUBDy2sh2autBmSdltNpPnfWp4Peep
+        DMV1y4Q36Y1srUYpC4G1rbSDkTPvW0Bs3Kl7W2CMMhdOc6GM18S1ojQtAEtMY7sRHqxC8I2WLADz
+        g02yGR4ynJOb1IkX7JpOYV+xay5Zyi/VOSmet04Fvpgl8FT6L5/oIBRtaKz3U3PiCg0X9JqPVuTC
+        s8/YCWdC154zU2Pl+Ni31gZTYv/6HQZf4LC7bO10VKen2GV7K5/mho3nQzmBANSFaC/A7Vf7DguE
+        lE2bj4RKux3emt3no+175srKmmu061T+F+pJSlhQS1nnGGnZysveqBsjPFoYGgyDOPL0fo5/Kda4
+        2TdnCB7C1grgljGOjk7FVKqR1L0e7zwWLr70DyvGw68KgIMOo20E+Vl4JYIo1ikcxbMe4Sl9f0Iq
+        akABCb74Mvhv+CWu6obCppGEbrDZWC8EaA7ffcnl/BxuwLT7oxizsVKPretwinQFTSF9GmgOHb4M
+        j1fosJ4TzypIWDUag1P15QYYLfQCPbzqcsZBTSeYJwt9vgSNc5cHPFnJkGr1HViC31/iSaG+NuPO
+        O6KkzBe7TCPwNzqYVeIwTfiM0nc2GugMNjs+Kwg2z2bxIGRKY8Fw11wEMdBIamPDUXB+ijHwSY9A
+        D5oE435uBrw+a7WJMhNEPi0D8yCgNw03G8bHT8ZcLGPxt4THsTVatUIPClZDIsCNFt5m49COmAOn
+        J0NGFuMnwUjIogQMQ9BoX7D0FMwGtlXK9ajbZv53qoJOk6YCnZthcJHwUCIpR0cvLy6g4CTm7jzX
+        ryuqbZmEzegTJtgbZXC/4Z++eLVybKirLHdCAIq/0ti0/a0enqqN/qcHJsEqYFhdkggE4Gy8a9YG
+        PKcteCU+qtpMBT18XXyWuOXZ66so0aPCg1RKFgOdUmfm+YklnuChWLJKCmvDRYKjemeJvwBNcVVI
+        Zqk018KEHRF9Iz0Wm3rM0OQpCwWsUzws8l2wWEl6EHHMMFQJAPfBrL6MV9VXdKGFsNqr6liQnVzY
+        jOuMxghmIWljRdlwpPLW8Tv8wbS2mumoCC5oXZU3on2a3LlBigyyd4Xx5uTtq+fPzi/AjNV3XwQF
+        jDKkpHP2GgAVD18C6/2zk9M3z1rH6teGUJ4Agmg8wtuOrcwU0XkXeBZefsJizR9VVg+6mpoUXqxp
+        09zOhCpKzaip9qTUqYR6yHF0gwhD0HQmB947HjjmB3UcBFWH3cYtoBLI+Cn1F0I+Xv0myWi+V0ZL
+        feJM+yx0Llc9nwNh3KsQV7iBeVGNXvzeWBO18fFFxPT0aPN01YrcBc0JtsMS3JJ4Sf5PDG6jYBhl
+        QnNWpWHjSTzUkVMEqm4JYsTMCeTIiRtRKOuNUljkJI7phTPon0ln4od0+A5WJv0o8WsEmlgf+7Qv
+        6reGUgDZ1L2GqfoOJkWCwKwJgi9Ah6yC9huC0RYKTGPDu83Raswx2Ip+NsO0qWShbEv4p/xkA14V
+        xyq1EqPDaaHUq9k2FEbTbrbz6u35xcnr15Ro0zpGQfBEykHNeIxoaxpmllHUmV4TrDDtTjI9jaK0
+        eQ0blM2n6KprVYOh98ee4ppGLG5DoB51yUNolr6zryYKGpraVOFbj6tpshrmH94xAVq5MO9n9Vv6
+        NaaG8atgsMuNbPepr1y0e/lLXvkxLKZmtzkm3hwx/NRYI2p41aSk6U3s1vHJGZmnNRB3x3ZosB0U
+        JH85tua7ZeoLZCZ75UtRLOZF46hYe18cF36SRAkaEriS3qinr4bjV+Fjnuiw5mtjLdRDl5VPM38l
+        Qr6q+OavRKOSo3NFur0rsndY6jmSMfcwPnzEht34huG7KmwAdzVMVxOP7zozolUdwlUh9/E1pio4
+        VovdFgd0tfzLw8PW8ctI0ptEM3Qso0yCJRAn0RXocI9NlkfVELYeo86bMiV6WR/mhNwZ+6YpmyxT
+        seDJJUhgJ7t0kvK3tuovrNegMnWaaF4Kwxdvyt/PXHDM4wYnM5SY8GcG/ITvjlc+55xDrAvNV2AL
+        vZtWBUFsqRDZwKbA/wx7L6xHWqkNUMpsoKTMW9mQA/xEIvNvwog64bgrBUtFdZVPdRCaC7dSriAW
+        06951ut1TRrrsFeHfDdONBVVlEgNSp11vQPiHdxF06kUaaHxH1V5CW4COCqLI9ZvUkCMnUjGVToH
+        Gv9JCopAOQKgDzwTTlG+gNlLd9k5sO1SJH+PMuYrr92+5jwGbwI8BUAOobFe90fMNKNXs9BARaO3
+        cS6lggseBs0n4OBhaM9xMwk0tHW1dAaDYcNkP6VWBjnaTu1vi6tro3EnmfRDIfGt8IkIpPNoOKwP
+        +4tuxF5TIxqWvY+ARlVQx+GvfriEWoEf3kH1C3a8xv1UuDyQnQqagGXBccSwjkS5vkEWGb5fSq4b
+        7AbAySgGzySifLcFvxSqytDLiCGdGojfJHqDnmAmueHNs4sTFAlM5NdFjKeMXpZA8wtf4YrRwSTw
+        RgaqgJsWRbmo+mgtCSvIAFwBd9ITN+MWWgzq+9omJoFBi9q7LOWD5RrYeniiuVlziKKp5eogxYq4
+        wa8aZXZuUK6HC2r80YW10TFkwJp0TF3LkC7BZqMUMzdMlXpYycdRav8PRUZpYs1ZOgdPGv6USl4E
+        0QSjCEU53OteWFp8Xj21v69egewZ9ACxypReTrxjYBn+FB2c1H6Ch+cRqBj9/RB8x9huUSC06bhP
+        1o77C63/DJYhJqrh8RZTIteMANwZLsAtTgUZpN94iujLbN94imaKVeohXsu3FxGqFkxSY5h7IyS9
+        MN7AsXvh4a/FY0Z46M/dqc8us+0oBIXnT4ti2EzxFBZPyxIRR9LHT4HvNCPcNMXG9fgXrdGzd6ff
+        c/b5Wq6r2Vfpc81cvBcC7h0R0Nk13wCD9YKnMFAS9w0Q8O6IAAZ2v8HwyR2HL1aTc/70zTdAZP3O
+        oRBRRyvfAIHJHRHA4x/9hZU6FvQwukWxGHim052MCRPXbGheK6rab8XjyFFYgVVD/1ey/wPiVy9N
+        rWwAAA==
+    headers:
+      Accept-Ranges: [bytes]
+      Age: ['1']
+      Cache-Control: [max-age=3600]
+      Connection: [keep-alive]
+      Content-Encoding: [gzip]
+      Content-Length: ['6844']
+      Content-Type: [text/html; charset=utf-8]
+      Date: ['Thu, 19 Jul 2018 16:48:02 GMT']
+      Last-Modified: ['Tue, 05 Sep 2000 18:04:25 GMT']
+      Server: [nginx]
+      Vary: [Accept-Encoding]
+      Via: [1.1 varnish, 1.1 varnish]
+      X-Cache: ['MISS, HIT']
+      X-Cache-Hits: ['0, 1']
+      X-Runtime: ['0.274922']
+      X-Served-By: ['cache-lax8645-LAX, cache-dca17744-DCA']
+      X-Timer: ['S1532018883.698961,VS0,VE1']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -172,100 +188,114 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       From: [admin@fedoraproject.org]
-      User-Agent: [Anitya 0.5.0 at upstream-monitoring.org]
+      User-Agent: [Anitya 0.12.1 at upstream-monitoring.org]
     method: GET
-    uri: http://search.cpan.org/dist/foo/
+    uri: https://metacpan.org/release/foo/
   response:
-    body: {string: !!python/unicode "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01
-        Transitional//EN\">\n<html>\n <head>\n  <link rel=\"stylesheet\" href=\"http://st.pimg.net/tucs/style.css?3\"
-        type=\"text/css\" />\n<style>\n.styleswitch {\n  text-align: right;\n}\n</style>\n\n\n<script
-        type=\"text/javascript\" src=\"http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js\"></script>\n<script
-        type=\"text/javascript\" src=\"http://st.pimg.net/tucs/js/jquery.cookie.js\"></script>\n<script
-        type=\"text/javascript\" src=\"http://st.pimg.net/tucs/js/sh_main.min.js\"></script>\n<script
-        type=\"text/javascript\" src=\"http://st.pimg.net/tucs/js/sh_perl.min.js\"></script>\n<script
-        type=\"text/javascript\" src=\"http://st.pimg.net/tucs/js/jquery.styleswitch.js\"></script>\n\n<link
-        rel=\"stylesheet\" href=\"http://st.pimg.net/tucs/print.css\" type=\"text/css\"
-        media=\"print\" />\n  <link rel=\"alternate\" type=\"application/rss+xml\"
-        title=\"RSS 1.0\" href=\"http://search.cpan.org/uploads.rdf\" />\n  <link
-        rel=\"search\" href=\"http://st.pimg.net/tucs/opensearch.xml\" type=\"application/opensearchdescription+xml\"
-        title=\"SearchCPAN\" />\n  <title>The CPAN Search Site - search.cpan.org</title>\n
-        <script type=\"text/javascript\">\n    var _gaq = _gaq || [];\n    _gaq.push(['_setAccount',
-        'UA-3528438-1']);\n    _gaq.push(['_trackPageview']);\n  </script>\n </head>\n
-        <body id=\"cpansearch\">\n   <div class=\"header\">\n<center><div class=\"logo\"><a
-        href=\"/\"><img src=\"http://st.pimg.net/tucs/img/cpan_banner.png\" alt=\"CPAN\"></a></div></center>\n<div
-        class=\"menubar\">\n <a href=\"/\">Home</a>\n&middot; <a href=\"/author/\">Authors</a>\n&middot;
-        <a href=\"/recent\">Recent</a>\n&middot; <a href=\"http://log.perl.org/cpansearch/\">News</a>\n&middot;
-        <a href=\"/mirror\">Mirrors</a>\n&middot; <a href=\"/faq.html\">FAQ</a>\n&middot;
-        <a href=\"/feedback\">Feedback</a>\n</div>\n<form method=\"get\" action=\"/search\"
-        name=\"f\" class=\"searchbox\">\n<input type=\"text\" name=\"query\" value=\"\"
-        size=\"35\">\n<br>in <select name=\"mode\">\n <option value=\"all\">All</option>\n
-        <option value=\"module\" >Modules</option>\n <option value=\"dist\" >Distributions</option>\n
-        <option value=\"author\" >Authors</option>\n</select>&nbsp;<input type=\"submit\"
-        value=\"CPAN Search\">\n</form>\n</div>\n\nThe distribution '<b>foo</b>' cannot
-        be found, did you mean one of these<br />\n\n\n<br><div class=t4>\n<small>\nResults
-        <b>1</b> - <b>10</b> of\n<b>10</b> Found</small></div>\n<!--results-->\n<!--item-->\n
-        \ <p><h2 class=sr><a href=\"/~miket/DBIx-Foo-0.03/\"><b>DBIx-Foo</b></a></h2>\n<small>Simple
-        Database Wrapper and Helper Functions. Easy DB integration without the need
-        for an ORM. </small><br/>\n<small>   <a href=\"/~miket/DBIx-Foo-0.03/\">DBIx-Foo-0.03</a>
-        -\n   <span class=date>22 Feb 2013</span> -\n   <a href=\"/~miket/\">Mike
-        Tonks</a>\n</small>\n<!--end item-->\n<!--item-->\n  <p><h2 class=sr><a href=\"/~fayland/Foorum-1.001000/\"><b>Foorum</b></a></h2>\n<small>forum
-        system based on Catalyst </small><br/>\n<small>   <a href=\"/~fayland/Foorum-1.001000/\">Foorum-1.001000</a>
-        -\n   <span class=date>27 Sep 2009</span> -\n   <a href=\"/~fayland/\">Fayland
-        &#x6797;</a>\n</small>\n<!--end item-->\n<!--item-->\n  <p><h2 class=sr><a
-        href=\"/~manwar/Food-ECodes-0.11/\"><b>Food-ECodes</b></a></h2>\n<small>Interface
-        to Food Additive ECodes.</small><br/>\n<small>   <a href=\"/~manwar/Food-ECodes-0.11/\">Food-ECodes-0.11</a><img
-        src=\"http://st.pimg.net/tucs/img/stars-4.0.gif\" alt=\"**** \">\n     (<a
-        href=\"http://cpanratings.perl.org/d/Food-ECodes\">1 Reviews</a>)\n\n -\n
-        \  <span class=date>16 Jan 2015</span> -\n   <a href=\"/~manwar/\">Mohammad
-        S Anwar</a>\n</small>\n<!--end item-->\n<!--item-->\n  <p><h2 class=sr><a
-        href=\"/~strytoast/Football-League-Match-0.01/\"><b>Football-League-Match</b></a></h2>\n<small>A
-        single footie match</small><br/>\n<small>   <a href=\"/~strytoast/Football-League-Match-0.01/\">Football-League-Match-0.01</a>
-        -\n   <span class=date>14 Apr 2003</span> -\n   <a href=\"/~strytoast/\">Stray
-        Taoist</a>\n</small>\n<!--end item-->\n<!--item-->\n  <p><h2 class=sr><a href=\"/~bpostle/I18NFool-0.31/\"><b>I18NFool</b></a></h2>\n<small>Internationalization
-        File Object Oriented Leech</small><br/>\n<small>   <a href=\"/~bpostle/I18NFool-0.31/\">I18NFool-0.31</a>
-        -\n   <span class=date>07 Oct 2004</span> -\n   <a href=\"/~bpostle/\">Bruno
-        Postle</a>\n</small>\n<!--end item-->\n<!--item-->\n  <p><h2 class=sr><a href=\"/~miyagawa/Kwiki-Footnote-0.01/\"><b>Kwiki-Footnote</b></a></h2>\n<small>Footnote
-        plugin for Kwiki</small><br/>\n<small>   <a href=\"/~miyagawa/Kwiki-Footnote-0.01/\">Kwiki-Footnote-0.01</a>
-        -\n   <span class=date>02 Apr 2005</span> -\n   <a href=\"/~miyagawa/\">Tatsuhiko
-        Miyagawa</a>\n</small>\n<!--end item-->\n<!--item-->\n  <p><h2 class=sr><a
-        href=\"/~spurkis/Scalar-Footnote-0.99_01/\"><b>Scalar-Footnote</b></a></h2>\n<small>Attach
-        hidden scalars to references</small><br/>\n<small>   <a href=\"/~spurkis/Scalar-Footnote-0.99_01/\">Scalar-Footnote-0.99_01</a>
-        -\n   <span class=date>30 May 2004</span> -\n   <a href=\"/~spurkis/\">Steve
-        Purkis</a>\n</small>\n<!--end item-->\n<!--item-->\n  <p><h2 class=sr><a href=\"/~plytle/WWW-WuFoo-0.007/\"><b>WWW-WuFoo</b></a></h2>\n<small>Interface
-        to WuFoo.com&#39;s online forms</small><br/>\n<small>   <a href=\"/~plytle/WWW-WuFoo-0.007/\">WWW-WuFoo-0.007</a>
-        -\n   <span class=date>13 Apr 2013</span> -\n   <a href=\"/~plytle/\">Peter
-        Lytle</a>\n</small>\n<!--end item-->\n<!--item-->\n  <p><h2 class=sr><a href=\"/~ikuta/Net-RabbitFoot-1.03/\"><b>Net-RabbitFoot</b></a></h2>\n<small>An
-        Asynchronous and multi channel Perl AMQP client.</small><br/>\n<small>   <a
-        href=\"/~ikuta/Net-RabbitFoot-1.03/\">Net-RabbitFoot-1.03</a> -\n   <span
-        class=date>07 Apr 2011</span> -\n   <a href=\"/~ikuta/\">Masahito Ikuta</a>\n</small>\n<!--end
-        item-->\n<!--item-->\n  <p><h2 class=sr><a href=\"/~barefoot/Dist-Zilla-PluginBundle-BAREFOOT-0.03/\"><b>Dist-Zilla-PluginBundle-BAREFOOT</b></a></h2>\n<small>Dist::Zilla
-        configuration the way BAREFOOT does it</small><br/>\n<small>   <a href=\"/~barefoot/Dist-Zilla-PluginBundle-BAREFOOT-0.03/\">Dist-Zilla-PluginBundle-BAREFOOT-0.03</a>
-        -\n   <span class=date>21 Feb 2013</span> -\n   <a href=\"/~barefoot/\">Buddy
-        Burden</a>\n</small>\n<!--end item-->\n<!--end results-->\n<br>\n\n\n<div
-        class=\"footer\"><div class=\"cpanstats\">110139 Uploads, 31875 Distributions\n150559
-        Modules, 12210 Uploaders\n</div>\n<div class=\"sponsor\">\nhosted by <a href=\"http://www.yellowbot.com\">YellowBot</a><br/>\n<a
-        href=\"http://www.yellowbot.com\"><img alt=\"do. tag. write. share.\" src=\"http://st.pimg.net/tucs/img/yellowbot_logo.gif\"></a>\n</div>\n</div>\n<script
-        type=\"text/javascript\">\nvar gaJsHost = ((\"https:\" == document.location.protocol)
-        ? \"https://ssl.\" : \"http://www.\");\ndocument.write(unescape(\"%3Cscript
-        src='\" + gaJsHost + \"google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E\"));\n</script>\n<script
-        type=\"text/javascript\" src=\"http://ipv4.v6test.develooper.com/js/v1/v6test.js\"></script>\n\n<script
-        type=\"text/javascript\">\n   // v6.target = '';\n   if (!v6.target) { v6.only_once
-        = true }\n   v6.site = '7A0D89A6-2B82-11DF-B9DA-F61CBD13F020';\n   v6.api_server
-        = 'http://ipv4.v6test.develooper.com';\n   try {\n     v6.test();\n   } catch(err)
-        {}\n</script>\n<script type=\"text/javascript\">\n  $(document).ready(function(){\n
-        \   $(\"a[href^=http:]\").click(function(){\n      var href = $(this).attr('href');\n
-        \     var m = href.match('\\/\\/([^\\/:]+)');\n      _gaq.push(['_trackEvent','External',m[1],'Other']);\n
-        \   });\n    $(\"a[href^=/CPAN/]\").click(function(){\n      var href = $(this).attr('href');\n
-        \     _gaq.push(['_trackEvent','Download',href,'Other']);\n    });\n  });\n</script>\n<!--
-        Thu May 28 19:28:33 2015 GMT (0.0527300834655762) @cpansearch2 -->\n </body>\n</html>\n"}
+    body: {string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n\
+        <body bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\
+        \n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n"}
     headers:
-      cache-control: [max-age=3599]
-      content-length: ['7468']
-      content-type: [text/html]
-      date: ['Thu, 28 May 2015 19:28:33 GMT']
-      expires: ['Thu, 28 May 2015 20:28:33 GMT']
-      last-modified: ['Thu, 28 May 2015 19:28:33 GMT']
-      server: [Plack/Starman (Perl)]
-      x-proxy: [proxy1]
-    status: {code: 410, message: Gone}
+      Accept-Ranges: [bytes, bytes, bytes, bytes]
+      Age: ['0', '0']
+      Connection: [keep-alive]
+      Content-Length: ['178']
+      Content-Type: [text/html]
+      Date: ['Thu, 19 Jul 2018 16:48:02 GMT']
+      Location: ['https://metacpan.org/release/foo']
+      Server: [nginx]
+      Via: [1.1 varnish, 1.1 varnish]
+      X-Cache: ['MISS, MISS']
+      X-Cache-Hits: ['0, 0']
+      X-Served-By: ['cache-lax8632-LAX, cache-dca17744-DCA']
+      X-Timer: ['S1532018883.742271,VS0,VE204']
+    status: {code: 301, message: Moved Permanently}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      From: [admin@fedoraproject.org]
+      User-Agent: [Anitya 0.12.1 at upstream-monitoring.org]
+    method: GET
+    uri: https://metacpan.org/release/foo
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA9Uba3PbNvJ7fgWOvavtO1G0bCt+Sco470ybxFe7N9PJZDwgCZKISYImQNtq0/9+
+        C4AQKZJ6uI7ddmcik+BisbvYXewCyOgfLz++OP/l9BV6e/7+x8mTUSSSePIEAYwign39qF4TIjBK
+        cULG1jUlNxnLhYU8lgqSirF1Q30RjX1yTT1iq5ceoikVFMc293BMxoMeSvAtTYrENFg16oKKmExe
+        5TnL0d72HrLRKQ4JSplAAStSHxokA16G0z7Lw5GjO1QEYppeoignwdhyLjDnRHAHHwT+U3/o7mJ3
+        98ANDoN9vD/09rf3yMHeYHcP7wUDfzsguO9xbqGcxGOLi2lMeEQICCemGQgryK1wJEJzMI1PcO5F
+        lhmZCyyo57CMpPpL/zaJDSWcZTH1AIGlNQyfcC+nmWz9j0aWko2t9yDui9OTDwvGjUD/XiEQhSlo
+        Di/buBPga/nQh59uGpIfYgtWeJGtyXD6K+FjazDcuYV/3WSbvfpZGtbpa2kQz736TAwOnh4GhzuH
+        w/2d3eFgMNjGh4P9HZgdQrC3N/S8A/fpQRD0v/A5vX/B11gTtCYjRz+1xqoaENoMitSTutykPd5j
+        vbCX93Av2fqNftp4w1gYk5MUx1MQh390vxBPbHwe58f0U/55LH++fp313/qtTlZ+7F8pnP7V16+f
+        Pm/1s4JHmzgPiwQ8gG/93lMf4/Hg3ym5QS+xIJtbx3jM+15O4OVVTCTiJtvq1Qgn8D0kovzIn0/P
+        cfgBnAzQPm1/PsZ9zKepNx7Ak9RoeJz0M5wD6gfmkz4FG8rFcxKwnGxKMWuUf9/avKGpz256PvMU
+        j70Nra+N3obj3Nzc9EOlEBsbjfQ9ljjV2xcOmCHe2Dp+UqMb4s0NLdFGD238fGLv7B/sHO7t79kD
+        aKgrTQKngpxlhPhnOAG7+Qm6oSM02N6e4/S4QZ+T1JfUM4gBMthIFsz3thnMP4ycKnCNXOZPa/aS
+        4mvkxWCTYwseXZwj/cf2SYCLGHw+Z9L3oJWGylFrlq0o+HRGQcY+TFOS20FcUL+BqbCLuDacGQv+
+        dOHG1OBeU05dmJfbesyZ4eHSK7+zkI8FBk8MQ8kzj6lPIDyS2HwA2yQQmvu1L216QHE2cIBRgG3g
+        kcu/O7cquNj17iOHdpLg8N1QUZ2AiPJYaP8zOowc3NUYN7hvoUiozUSnvjTM5sEBLmgSlgFvLlSa
+        FauKk8iZNAnV4S1LSLPNQKdIEtpiGbijJJEQGT9ynDAnWb++2koJ522kXPaUPTTp1UGSOjqSdJpf
+        DDy8WE5OPIh+bSEiygXLp6ul+EkRaLYauJ8EEfV9knb7uoFKFOyyokMSmgZstRgnsnOz0cCjSwH5
+        yVVbkquCcB13V0nz+uS/zSYDjyjLzGeoiApXLaDGcyr3vyGuQzkH0doC6442jlWGs1zkN1S8LVz0
+        TpFqfjTwiMI7kOh0iCRbM5zBwriGUX4A5GabgccURTAWd8hyA7nWOoHuXHZvNhp4RDmMPQYYVqKM
+        rgjjMk9wMSer5Ts5fddsMnBH6UZOUVaYc62LUiXzmNMwEgs0MIL8N0FY5e2VCuqiO9jzoIwUTsxC
+        GUFlMRkxf2ydfjw7txCFp5m3liigEkl2wYjV9Pg5yyDLThH0C4l/QWUdJatI+ER5FuPpEZSxKTle
+        wLyEelLXIFvmd41kz3xdQvNES7zw+8g1Q3lQUCh53cXUFk6yhNrkzdiGgqNYwp0EUOKktiiUMwTJ
+        ZgolMJXB8t3sWY7fbU916KaY5SygoMLJqX64Dy0oqlkONQ1056Cz1+XrHfhbiiChbgws9WLqXY6t
+        f25ufNew0I2tPi/chAooM6GgF0Wegk/H0pt/VAhL50zCcoa7HVXC4n5L/EK53V/BMc5omCKaLvz+
+        13CMpQgS1gr5DsOFiHYc+QuG+it5BvYEPnUBEa+O9z1U58dexKhHxgH2iMvYZc36SuuCmXyXnp78
+        fPZqU0DyvLVCDAnNFccQV883et1ZSeR12Wkl4tLJkLDYcg38ubrX2eCDaF6TvpPedb65Eu1vr3Vx
+        Q4Ug+YOovaR9J72f6z4r8f72itcbkA+id036TmrX+8Mr0R5d6zJppfrIoHObsQlNVeiOd1LFR+jy
+        7uVKtHuq4q4ZRht/5Pj0umoaOVAtTKrd6uXbtTVKdUS5ZQ31OMkFrNWcy2Mo/aZ3WV6CKqesQDjP
+        6TVBEckJuqYYlec9xsyftb1GbrlDVRzrbfZcUC8mDsdTmobSXH13Ks9Vyr01W2V60q8sZHZyL9wY
+        p5eQddLUR3Iv5yaayinol2qYCVQXrbHLWZc0ZzeorC6zCDKxDtuqo8t9dZsnOI5VBoo8FtuJb+92
+        dJNQ2e8sd6s6SzvssJ3GfM6a5+ZRjXq4aNS5WtAx53OGAa1bhSN/bBWqpGV0741rqA+veoU5K7Il
+        HSTUO9E0K8RavSSMFHrtGMwqz12v9And2Nob6Jq1FEfhz2RUHEprz1lsoWscF2TpRqmB+S32imPb
+        FcvS6TqM3EIINiMCHUu3UDRKiXTRYk3O1BdIrlWf1QMs2uuvwwL7MbDk86Jqv6NLR9O8wzV8rEN5
+        dYwEopKaL7nHXFr3YKejk4Qnqqec+5QJWx2Nl5jzOyi2rE9R6+SnVp91nDJJ2iVepxdVLM2ZaMPH
+        6vaH5LaaPKpRLmchqPo8ErHYJ/nY0gZQGfci8tpeZlFIBSwjTzlr9QBYrR01aaVKZPyCLG9yxuTu
+        D0RdlFDO4e+zuS41NhrzXNsOUDvYZfeLhPlFLPcrmoG5olSZjB5LL2W6IRpMPjCBXsvJHDnwVrZn
+        usOMyHlEoM7nrMg9opagnKjtcuKD2RSxr25LuERfmOhXfUdOVpIsfw1BM4IBPSFIwDjy5oGMkDWZ
+        9TQ/uxoHDMI3/DQkNOw2F6MKo+U2XajNBQoGkrn5fMcm4myP1KxnPDGuBJ70fery7Lhj/CYZ2eWW
+        2zuqL0/swcwfZ1sXMh5DdkDD9AjJU6FO1iS0lv+upNmanJy+u89KCNwODbe7lch/nFtzxKQPi94T
+        fQnlj7JYzUvJo1btfXlMqLwoBA6nzPS9fvtmPH4TPa57MARBg+WXjctN30iQb2q+s+xV5aST0/Jx
+        XWbXcPUZkxn2fYirR2i4nd2iwRB+duGpxeli4WVaipSs+tygSXln2EEOzadAc5mxIQDEWX6Evjs8
+        hAT0LeNCLiMhgbKCFTyeoixn17Dm+sidHnUnLB26mZekdOvDKr9el/uuKXOngiQ4vwQL7BeXTj5/
+        LNKuLVpUga683qAv+Fk7g22rcdUhgQqJg6gs5eCFjhnwQqb5jcthM4pto/kGapGG0jUYbgrZoaaY
+        XkFRCP6oPLWDyrwaBvur1DAjeKFM5i+iiLbgclWKp1rqpp7aJEotLJVcU6ymv9TZYLANxbL0xvFw
+        0Ka8nia6mhpBpEWlrbrBgdIdPLEg4ERUEf9pU5e2y6A6SY7QTlcAQuiEI6xrLB9lUNNDIEAYkkCI
+        A4WPeJHJe7LQxoLZWtpDZ6C2S5L/Aikc5S2SEc6yKSTO0CeQ1NBg+1/Ip1wdQCGorqCG7p5LrulC
+        aqjmE3jwC09wxys4yGCXn7mzuzvsmOwXCsswp5bT+k1FDXca1y0gPSac2zF2Scydp8Nhe9jnJRL6
+        USGpYdFPDGTUDW0e/kfTKXwlco9Uhl/IUkveXxIPx7zfYBO4rDQuOWwzMf+9wxYRzJTMuWEmUwKa
+        ZBniEfzANCX4UqXjOTLyIqWQfovEz5yAofkE1hkojtJw8v7V+Yk0icE2rBW6CWEoAiPiXcr0C6jL
+        67ZTTd7YQJNwl1PMNzVfay4BtQuOUQCVkdSKCwUMuR1bMmPQVyF9isGT9XbDJZm6DOe+bW4fz19J
+        aJG1y86LHVajlcVvy73amKaEa6l2FO3NY6pb1Nbkh5JldGZYhgprr9m/Q4Ndo8vbpKgrxrSjjIol
+        Em0ESo2J+aRfFupxJOqX7kcir82ZiCYjB37mWt7EzMVxvR2ey16ytboJK+pXYRuUfcMeMNaY0kvX
+        n4DK5J+qgyPqb/DymkGIKbd6EFT7dYyKobuO+2zluM+V/xfghhG4Z0TiDGmT62YAnowW4FFOhUpI
+        H3iK1CHaA09RqFWlX7KVenvDZGjJCgiy5R4C79bYvfigK/kIFR/lyaS+IYc2WQoBjwZVMyymBFbC
+        HJbYnGSMU3lrc6ub4a4pNqXHn+Sjpx9fPubs45Va17Ovz+m6tXgvBrw1GfAinIby5sw352C14WkO
+        tMU9AAP+mgzAii4eYPh8zeErb3LOXrx/AEZWrxyaEb2n+QAMuGsyIK+FIReWdt7BhXoZLQkshp7p
+        tFYyYfY1O9BbTc38rXodOZoryGrU/9z7PzPy4ofRNwAA
+    headers:
+      Accept-Ranges: [bytes, bytes, bytes, bytes]
+      Age: ['0', '0']
+      Cache-Control: [private]
+      Connection: [keep-alive]
+      Content-Encoding: [gzip]
+      Content-Type: [text/html; charset=utf-8]
+      Date: ['Thu, 19 Jul 2018 16:48:03 GMT']
+      Server: [nginx]
+      Vary: [Accept-Encoding]
+      Via: [1.1 varnish, 1.1 varnish]
+      X-Cache: ['MISS, MISS']
+      X-Cache-Hits: ['0, 0']
+      X-Runtime: ['0.053375']
+      X-Served-By: ['cache-lax8648-LAX, cache-dca17744-DCA']
+      X-Timer: ['S1532018883.013912,VS0,VE267']
+    status: {code: 404, message: Not Found}
 version: 1

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -2,6 +2,24 @@
 Release Notes
 =============
 
+master
+======
+
+Dependencies
+------------
+
+* Explicitly depend on ``defusedxml``
+
+Features
+========
+
+* Update CPAN backend to use metacpan.org (`#569
+  <https://github.com/release-monitoring/anitya/pull/569>`_).
+
+* Parse XML from CPAN with defusedxml (`#569
+  <https://github.com/release-monitoring/anitya/pull/569>`_).
+
+
 v0.12.1
 =======
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 alembic
 blinker
+defusedxml
 python-dateutil
 fedmsg[commands,consumers]
 flask-login


### PR DESCRIPTION
While there is likely no practical issue, I suspect we should be cautious
and not parse XML download in cleartext, given the rather large
amount of issues with XML parsing in the past:

   https://www.owasp.org/index.php/XML_Security_Cheat_Sheet