### PR TITLE
Default custom regex enhancement

### DIFF
--- a/anitya/config.py
+++ b/anitya/config.py
@@ -93,6 +93,9 @@ DEFAULTS = dict(
     SOCIAL_AUTH_LOGIN_REDIRECT_URL='/',
     SOCIAL_AUTH_LOGIN_ERROR_URL='/login-error/',
     LIBRARIESIO_PLATFORM_WHITELIST=[],
+    DEFAULT_REGEX='%(name)s(?:[-_]?(?:minsrc|src|source))?[-_]([^-/_\s]+?)(?i)(?:[-_]'\
+                  '(?:minsrc|src|source|asc|release))?\.(?:tar|t[bglx]z|tbz2|zip)',
+
 )
 
 # Start with a basic logging configuration, which will be replaced by any user-

--- a/anitya/lib/backends/__init__.py
+++ b/anitya/lib/backends/__init__.py
@@ -34,9 +34,7 @@ from anitya.lib.exceptions import AnityaPluginException
 from anitya.lib.versions import RpmVersion
 import six
 
-
-REGEX = '%(name)s(?:[-_]?(?:minsrc|src|source))?[-_]([^-/_\s]+?)(?i)(?:[-_]'\
-        '(?:minsrc|src|source|asc))?\.(?:tar|t[bglx]z|tbz2|zip)'
+REGEX = anitya_config.get('DEFAULT_REGEX')
 
 _log = logging.getLogger(__name__)
 

--- a/anitya/lib/backends/__init__.py
+++ b/anitya/lib/backends/__init__.py
@@ -34,7 +34,7 @@ from anitya.lib.exceptions import AnityaPluginException
 from anitya.lib.versions import RpmVersion
 import six
 
-REGEX = anitya_config.get('DEFAULT_REGEX')
+REGEX = anitya_config['DEFAULT_REGEX']
 
 _log = logging.getLogger(__name__)
 

--- a/anitya/lib/backends/__init__.py
+++ b/anitya/lib/backends/__init__.py
@@ -55,7 +55,6 @@ class BaseBackend(object):
             indicate example project URLs.
         default_regex (str): A regular expression to use by default with the
             backend.
-        default_regex_html (str): default_regex modified for HTML rendering
         more_info (str): A string that provides more detailed information to
             the user about the backend.
         default_version_scheme (str): The default version scheme for this
@@ -68,7 +67,6 @@ class BaseBackend(object):
     name = None
     examples = None
     default_regex = None
-    default_regex_html = None
     more_info = None
     default_version_scheme = None
 

--- a/anitya/lib/backends/__init__.py
+++ b/anitya/lib/backends/__init__.py
@@ -55,6 +55,7 @@ class BaseBackend(object):
             indicate example project URLs.
         default_regex (str): A regular expression to use by default with the
             backend.
+        default_regex_html (str): default_regex modified for HTML rendering
         more_info (str): A string that provides more detailed information to
             the user about the backend.
         default_version_scheme (str): The default version scheme for this
@@ -67,6 +68,7 @@ class BaseBackend(object):
     name = None
     examples = None
     default_regex = None
+    default_regex_html = None
     more_info = None
     default_version_scheme = None
 

--- a/anitya/lib/backends/custom.py
+++ b/anitya/lib/backends/custom.py
@@ -31,7 +31,6 @@ class CustomBackend(BaseBackend):
     more_info = 'More information in the '\
         '<a href=\'/about#test-your-regex\'>about#test-your-regex</a>'
     default_regex = REGEX % {'name': '{project name}'}
-    default_regex_html = default_regex.replace('\\', '\\\\')
 
     @classmethod
     def get_version(cls, project):

--- a/anitya/lib/backends/custom.py
+++ b/anitya/lib/backends/custom.py
@@ -31,6 +31,7 @@ class CustomBackend(BaseBackend):
     more_info = 'More information in the '\
         '<a href=\'/about#test-your-regex\'>about#test-your-regex</a>'
     default_regex = REGEX % {'name': '{project name}'}
+    default_regex_html = default_regex.replace('\\', '\\\\')
 
     @classmethod
     def get_version(cls, project):

--- a/anitya/templates/project_new.html
+++ b/anitya/templates/project_new.html
@@ -109,7 +109,7 @@
 
         examples["{{ plugin.name }}"]="{{ plugin.examples | format_examples }}";
         more_info["{{ plugin.name }}"]="{{ plugin.more_info}}";
-        default_regex["{{ plugin.name }}"]="{{ plugin.default_regex }}";
+        default_regex["{{ plugin.name }}"]="{{ plugin.default_regex_html }}";
 
       {%- endautoescape -%}
     {%- endfor %}

--- a/anitya/templates/project_new.html
+++ b/anitya/templates/project_new.html
@@ -109,7 +109,11 @@
 
         examples["{{ plugin.name }}"]="{{ plugin.examples | format_examples }}";
         more_info["{{ plugin.name }}"]="{{ plugin.more_info}}";
-        default_regex["{{ plugin.name }}"]="{{ plugin.default_regex_html }}";
+        {% if plugin.default_regex -%}
+        default_regex["{{ plugin.name }}"]="{{ plugin.default_regex.replace('\\', '\\\\') }}";
+        {% else %}
+        default_regex["{{ plugin.name }}"]="{{ plugin.default_regex }}";
+        {% endif -%}
 
       {%- endautoescape -%}
     {%- endfor %}

--- a/anitya/tests/test_config.py
+++ b/anitya/tests/test_config.py
@@ -52,7 +52,7 @@ social_auth_login_error_url = "/login-error/"
 
 librariesio_platform_whitelist = ['pypi', 'rubygems']
 
-default_regex = '%(name)s(?:[-_]?(?:minsrc|src|source))?[-_]([^-/_\s]+?)(?i)(?:[-_](?:minsrc|src|source|asc|release))?\.(?:tar|t[bglx]z|tbz2|zip)'
+default_regex = "a*b*"
 
 [anitya_log_config]
     version = 1
@@ -168,8 +168,7 @@ class LoadTests(unittest.TestCase):
             'SOCIAL_AUTH_LOGIN_REDIRECT_URL': '/',
             'SOCIAL_AUTH_LOGIN_ERROR_URL': '/login-error/',
             'LIBRARIESIO_PLATFORM_WHITELIST': ['pypi', 'rubygems'],
-            'DEFAULT_REGEX': '%(name)s(?:[-_]?(?:minsrc|src|source))?[-_]([^-/_\s]+?)(?i)(?:[-_]'\
-                             '(?:minsrc|src|source|asc|release))?\.(?:tar|t[bglx]z|tbz2|zip)',
+            'DEFAULT_REGEX': 'a*b*',
         }
         config = anitya_config.load()
         self.assertEqual(sorted(expected_config.keys()), sorted(config.keys()))

--- a/anitya/tests/test_config.py
+++ b/anitya/tests/test_config.py
@@ -52,6 +52,8 @@ social_auth_login_error_url = "/login-error/"
 
 librariesio_platform_whitelist = ['pypi', 'rubygems']
 
+default_regex = '%(name)s(?:[-_]?(?:minsrc|src|source))?[-_]([^-/_\s]+?)(?i)(?:[-_](?:minsrc|src|source|asc|release))?\.(?:tar|t[bglx]z|tbz2|zip)'
+
 [anitya_log_config]
     version = 1
     disable_existing_loggers = true
@@ -166,6 +168,8 @@ class LoadTests(unittest.TestCase):
             'SOCIAL_AUTH_LOGIN_REDIRECT_URL': '/',
             'SOCIAL_AUTH_LOGIN_ERROR_URL': '/login-error/',
             'LIBRARIESIO_PLATFORM_WHITELIST': ['pypi', 'rubygems'],
+            'DEFAULT_REGEX': '%(name)s(?:[-_]?(?:minsrc|src|source))?[-_]([^-/_\s]+?)(?i)(?:[-_]'\
+                             '(?:minsrc|src|source|asc|release))?\.(?:tar|t[bglx]z|tbz2|zip)',
         }
         config = anitya_config.load()
         self.assertEqual(sorted(expected_config.keys()), sorted(config.keys()))

--- a/files/anitya.toml.sample
+++ b/files/anitya.toml.sample
@@ -52,7 +52,7 @@ social_auth_redirect_is_https = true
 librariesio_platform_whitelist = []
 
 # Default regular expression used for backend
-default_regex = '%(name)s(?:[-_]?(?:minsrc|src|source))?[-_]([^-/_\s]+?)(?i)(?:[-_](?:minsrc|src|source|asc|release))?\.(?:tar|t[bglx]z|tbz2|zip)'
+default_regex = "%(name)s(?:[-_]?(?:minsrc|src|source))?[-_]([^-/_\s]+?)(?i)(?:[-_](?:minsrc|src|source|asc|release))?\.(?:tar|t[bglx]z|tbz2|zip)"
 
 # The logging configuration, in Python dictConfig format.
 [anitya_log_config]

--- a/files/anitya.toml.sample
+++ b/files/anitya.toml.sample
@@ -51,6 +51,9 @@ social_auth_redirect_is_https = true
 # via Libraries.io.
 librariesio_platform_whitelist = []
 
+# Default regular expression used for backend
+default_regex = '%(name)s(?:[-_]?(?:minsrc|src|source))?[-_]([^-/_\s]+?)(?i)(?:[-_](?:minsrc|src|source|asc|release))?\.(?:tar|t[bglx]z|tbz2|zip)'
+
 # The logging configuration, in Python dictConfig format.
 [anitya_log_config]
     version = 1

--- a/files/anitya.toml.sample
+++ b/files/anitya.toml.sample
@@ -52,7 +52,10 @@ social_auth_redirect_is_https = true
 librariesio_platform_whitelist = []
 
 # Default regular expression used for backend
-default_regex = "%(name)s(?:[-_]?(?:minsrc|src|source))?[-_]([^-/_\s]+?)(?i)(?:[-_](?:minsrc|src|source|asc|release))?\.(?:tar|t[bglx]z|tbz2|zip)"
+default_regex = """\
+                %(name)s(?:[-_]?(?:minsrc|src|source))?[-_]([^-/_\\s]+?)(?i)(?:[-_]\
+                (?:minsrc|src|source|asc|release))?\\.(?:tar|t[bglx]z|tbz2|zip)\
+                """
 
 # The logging configuration, in Python dictConfig format.
 [anitya_log_config]


### PR DESCRIPTION
This should solve the issue https://github.com/release-monitoring/anitya/issues/482

The lint test fails because `pytoml` can't parse multiline string.