### PR TITLE
Hide "Project edited" message when no edit is done

### DIFF
--- a/anitya/lib/utilities.py
+++ b/anitya/lib/utilities.py
@@ -347,6 +347,8 @@ def edit_project(
             'Could not edit this project. Is there already a project '
             'with these name and homepage?')
 
+    return changes
+
 
 def map_project(
         session, project, package_name, distribution, user_id,

--- a/anitya/tests/test_flask.py
+++ b/anitya/tests/test_flask.py
@@ -583,6 +583,32 @@ class EditProjectTests(DatabaseTestCase):
                 self.assertTrue(
                     b'<h1>Project: repo_manager</h1>' in output.data)
 
+    def test_edit_project_no_change(self):
+        """ Test the edit_project function. """
+        with login_user(self.flask_app, self.user):
+            with self.flask_app.test_client() as c:
+                output = c.get('/project/1/edit', follow_redirects=False)
+                self.assertEqual(output.status_code, 200)
+
+                self.assertTrue(b'<h1>Edit project</h1>' in output.data)
+                self.assertTrue(
+                    b'<td><label for="regex">Regex</label></td>' in output.data)
+
+                csrf_token = output.data.split(
+                    b'name="csrf_token" type="hidden" value="')[1].split(b'">')[0]
+                data = {
+                    'csrf_token': csrf_token,
+                }
+
+                output = c.post(
+                    '/project/1/edit', data=data, follow_redirects=True)
+                self.assertEqual(output.status_code, 200)
+                self.assertFalse(
+                    b'<li class="list-group-item list-group-item-default">'
+                    b'Project edited</li>' in output.data)
+                self.assertFalse(
+                    b'<h1>Project: repo_manager</h1>' in output.data)
+
     def test_edit_to_duplicate_project(self):
         """Assert trying to edit a project to make a duplicate fails."""
         with login_user(self.flask_app, self.user):

--- a/anitya/tests/test_flask.py
+++ b/anitya/tests/test_flask.py
@@ -603,11 +603,9 @@ class EditProjectTests(DatabaseTestCase):
                 output = c.post(
                     '/project/1/edit', data=data, follow_redirects=True)
                 self.assertEqual(output.status_code, 200)
-                self.assertFalse(
+                self.assertTrue(
                     b'<li class="list-group-item list-group-item-default">'
-                    b'Project edited</li>' in output.data)
-                self.assertFalse(
-                    b'<h1>Project: repo_manager</h1>' in output.data)
+                    b'Project edited - No changes were made</li>' in output.data)
 
     def test_edit_to_duplicate_project(self):
         """Assert trying to edit a project to make a duplicate fails."""

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -499,6 +499,8 @@ def edit_project(project_id):
             )
             if changes:
                 flask.flash('Project edited')
+            else:
+                flask.flash('Project edited - No changes were made')
             flask.session['justedit'] = True
         except exceptions.AnityaException as err:
             flask.flash(str(err), 'errors')

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -484,7 +484,7 @@ def edit_project(project_id):
 
     if form.validate_on_submit():
         try:
-            utilities.edit_project(
+            changes = utilities.edit_project(
                 Session,
                 project=project,
                 name=form.name.data.strip(),
@@ -497,7 +497,8 @@ def edit_project(project_id):
                 user_id=flask.g.user.username,
                 check_release=form.check_release.data,
             )
-            flask.flash('Project edited')
+            if changes:
+                flask.flash('Project edited')
             flask.session['justedit'] = True
         except exceptions.AnityaException as err:
             flask.flash(str(err), 'errors')


### PR DESCRIPTION
This should fix the issue https://github.com/release-monitoring/anitya/issues/573