### PR TITLE
Remove deprecations warnings

### DIFF
--- a/anitya/config.py
+++ b/anitya/config.py
@@ -93,7 +93,7 @@ DEFAULTS = dict(
     SOCIAL_AUTH_LOGIN_REDIRECT_URL='/',
     SOCIAL_AUTH_LOGIN_ERROR_URL='/login-error/',
     LIBRARIESIO_PLATFORM_WHITELIST=[],
-    DEFAULT_REGEX='%(name)s(?:[-_]?(?:minsrc|src|source))?[-_]([^-/_\s]+?)(?i)(?:[-_]'\
+    DEFAULT_REGEX='(?i)%(name)s(?:[-_]?(?:minsrc|src|source))?[-_]([^-/_\s]+?)(?:[-_]'\
                   '(?:minsrc|src|source|asc|release))?\.(?:tar|t[bglx]z|tbz2|zip)',
     # Token for GitHub API
     GITHUB_ACCESS_TOKEN=None,

--- a/anitya/forms.py
+++ b/anitya/forms.py
@@ -2,7 +2,7 @@
 
 """ Forms used in anitya. """
 
-from wtforms import TextField, TextAreaField, validators, SelectField
+from wtforms import StringField, TextAreaField, validators, SelectField
 from wtforms import BooleanField
 
 from anitya.compat import FlaskForm
@@ -13,29 +13,29 @@ class TokenForm(FlaskForm):
     Form for API tokens.
 
     Attributes:
-        description (TextField): The human-readable API token description, useful
+        description (StringField): The human-readable API token description, useful
             for users to describe the token's purpose.
     """
-    description = TextField('Token description', [validators.optional()])
+    description = StringField('Token description', [validators.optional()])
 
 
 class ProjectForm(FlaskForm):
-    name = TextField('Project name', [validators.Required()])
-    homepage = TextField(
-        'Homepage', [validators.Required(), validators.URL()])
+    name = StringField('Project name', [validators.DataRequired()])
+    homepage = StringField(
+        'Homepage', [validators.DataRequired(), validators.URL()])
     backend = SelectField(
         'Backend',
-        [validators.Required()],
+        [validators.DataRequired()],
         choices=[(item, item) for item in []]
     )
-    version_url = TextField('Version URL', [validators.optional()])
-    version_prefix = TextField('Version prefix', [validators.optional()])
-    regex = TextField('Regex', [validators.optional()])
+    version_url = StringField('Version URL', [validators.optional()])
+    version_prefix = StringField('Version prefix', [validators.optional()])
+    regex = StringField('Regex', [validators.optional()])
     insecure = BooleanField(
         'Use insecure connection', [validators.optional()])
 
-    distro = TextField('Distro (optional)', [validators.optional()])
-    package_name = TextField('Package (optional)', [validators.optional()])
+    distro = StringField('Distro (optional)', [validators.optional()])
+    package_name = StringField('Package (optional)', [validators.optional()])
     check_release = BooleanField(
         'Check latest release on submit', [validators.optional()])
 
@@ -52,12 +52,12 @@ class ProjectForm(FlaskForm):
 
 
 class FlagProjectForm(FlaskForm):
-    reason = TextAreaField('Reason for flagging', [validators.Required()])
+    reason = TextAreaField('Reason for flagging', [validators.DataRequired()])
 
 
 class MappingForm(FlaskForm):
-    distro = TextField('Distribution', [validators.Required()])
-    package_name = TextField('Package name', [validators.Required()])
+    distro = StringField('Distribution', [validators.DataRequired()])
+    package_name = StringField('Package name', [validators.DataRequired()])
 
     def __init__(self, *args, **kwargs):
         """ Calls the default constructor and fill in additional information.
@@ -77,4 +77,4 @@ class ConfirmationForm(FlaskForm):
 
 
 class DistroForm(FlaskForm):
-    name = TextField('Distribution name', [validators.Required()])
+    name = StringField('Distribution name', [validators.DataRequired()])

--- a/anitya/lib/backends/debian.py
+++ b/anitya/lib/backends/debian.py
@@ -15,8 +15,8 @@ from anitya.lib.backends import BaseBackend, get_versions_by_regex
 # <name>_<version>.orig.<compression format>. So, for example,
 # reprepro_4.13.1.orig.tar.gz.
 DEBIAN_REGEX = (
-    '%(name)s(?:[-_]?(?:minsrc|src|source))?[-_]([^-/_\s]+?)(?i)(?:[-_]'
-    '(?:minsrc|src|source|asc))?\.(?:orig\.)?(?:tar|t[bglx]z|tbz2|zip)'
+    r'(?i)%(name)s(?:[-_]?(?:minsrc|src|source))?[-_]([^-/_\s]+?)(?:[-_]'
+    r'(?:minsrc|src|source|asc))?\.(?:orig\.)?(?:tar|t[bglx]z|tbz2|zip)'
 )
 
 

--- a/anitya/lib/xml2dict.py
+++ b/anitya/lib/xml2dict.py
@@ -53,7 +53,7 @@ class XML2Dict(object):
             k, v = self._namespace_split(k, object_dict({'value': v}))
             node_tree[k] = v
         # Save childrens
-        for child in node.getchildren():
+        for child in list(node):
             tag, tree = self._namespace_split(
                 child.tag, self._parse_node(child))
             # the first time, so store it in dict

--- a/files/anitya.toml.sample
+++ b/files/anitya.toml.sample
@@ -53,7 +53,7 @@ librariesio_platform_whitelist = []
 
 # Default regular expression used for backend
 default_regex = """\
-                %(name)s(?:[-_]?(?:minsrc|src|source))?[-_]([^-/_\\s]+?)(?i)(?:[-_]\
+                (?i)%(name)s(?:[-_]?(?:minsrc|src|source))?[-_]([^-/_\\s]+?)(?:[-_]\
                 (?:minsrc|src|source|asc|release))?\\.(?:tar|t[bglx]z|tbz2|zip)\
 # Github access token
 # This is used by GitHub API for github backend


### PR DESCRIPTION
Remove deprecations warnings from tests.

WTForms:
* TextField alias
* Required field option

Python 3.6:
* regular expression warnings (using escape sequence within utf string, using flag inside regex)

XML2Dict:
* getchildren method

What remains:
* fedmsg related warnings - these are inside fedmsg