### PR TITLE
Fix the vagrant environment

### DIFF
--- a/ansible/roles/anitya-dev/tasks/main.yml
+++ b/ansible/roles/anitya-dev/tasks/main.yml
@@ -11,6 +11,7 @@
   dnf: name={{ item }} state=present
   with_items:
     - gcc
+    - graphviz
     - make
     - libffi-devel
     - openssl-devel


### PR DESCRIPTION
Docs now require graphviz to build, install it.

Signed-off-by: Jeremy Cline <jcline@redhat.com>