### PR TITLE
Retrieve more versions instead of only latest

### DIFF
--- a/anitya/db/models.py
+++ b/anitya/db/models.py
@@ -381,7 +381,7 @@ class Project(Base):
             )
             for v_obj in self.versions_obj
         ]
-        sorted_versions = reversed(sorted(versions))
+        sorted_versions = list(reversed(sorted(versions)))
         return sorted_versions
 
     def get_version_class(self):

--- a/anitya/templates/project.html
+++ b/anitya/templates/project.html
@@ -273,7 +273,7 @@
         dataType: 'json',
         success: function(res) {
           if (test) {
-              alert('Version found: ' + res.version);
+              alert('Versions found: \n' + res.version.join(', '));
           } else {
             if (res.version) {
               output = res.version;

--- a/anitya/tests/db/test_models.py
+++ b/anitya/tests/db/test_models.py
@@ -107,6 +107,36 @@ class ProjectTests(DatabaseTestCase):
         )
         self.assertEqual('pypi', project.__json__()['ecosystem'])
 
+    def get_sorted_version_objects(self):
+        """ Assert that sorted versions are included in the list returned from
+        :data:`Project.get_sorted_version_objects`.
+        """
+        project = models.Project(
+            name='test',
+            homepage='https://example.com',
+            backend='custom',
+            ecosystem_name='pypi',
+            version_scheme='Date'
+        )
+        version_first = models.ProjectVersion(
+            project_id=project.id,
+            version='1.0',
+        )
+        version_second = models.ProjectVersion(
+            project_id=project.id,
+            version='0.8',
+        )
+        self.session.add(project)
+        self.session.add(version_first)
+        self.session.add(version_second)
+        self.session.commit()
+
+        versions = project.get_sorted_version_objects()
+
+        self.assertEqual(len(versions), 2)
+        self.assertEqual(versions[0].version, version_second.version)
+        self.assertEqual(versions[1].version, version_first.version)
+
     def test_get_version_class(self):
         project = models.Project(
             name='test',

--- a/news/595.feature
+++ b/news/595.feature
@@ -1,0 +1,1 @@
+Retrieve all versions, not only the newest one


### PR DESCRIPTION
This implements #595.

This PR is modifying `utilities.check_project_release` to obtain more than only the latest version.
It is now calling `get_versions()` from backend instead of `get_version()`. After that it adds every version missing to current project and compares if any of the versions is newer than `latest_version` using current `version_scheme`.
This also removes odd version error, because this is no longer relevant.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>