### PR TITLE
Fix for failing lint test

### DIFF
--- a/anitya/config.py
+++ b/anitya/config.py
@@ -93,8 +93,8 @@ DEFAULTS = dict(
     SOCIAL_AUTH_LOGIN_REDIRECT_URL='/',
     SOCIAL_AUTH_LOGIN_ERROR_URL='/login-error/',
     LIBRARIESIO_PLATFORM_WHITELIST=[],
-    DEFAULT_REGEX='(?i)%(name)s(?:[-_]?(?:minsrc|src|source))?[-_]([^-/_\s]+?)(?:[-_]'\
-                  '(?:minsrc|src|source|asc|release))?\.(?:tar|t[bglx]z|tbz2|zip)',
+    DEFAULT_REGEX=r'(?i)%(name)s(?:[-_]?(?:minsrc|src|source))?[-_]([^-/_\s]+?)(?:[-_]'\
+                  r'(?:minsrc|src|source|asc|release))?\.(?:tar|t[bglx]z|tbz2|zip)',
     # Token for GitHub API
     GITHUB_ACCESS_TOKEN=None,
 )

--- a/anitya/db/models.py
+++ b/anitya/db/models.py
@@ -605,7 +605,7 @@ class Project(Base):
         )
 
         if pattern:
-            pattern = pattern.replace('_', '\_')
+            pattern = pattern.replace('_', r'\_')
             if '*' in pattern:
                 pattern = pattern.replace('*', '%')
             if '%' in pattern:

--- a/anitya/lib/backends/custom.py
+++ b/anitya/lib/backends/custom.py
@@ -71,7 +71,7 @@ class CustomBackend(BaseBackend):
             regex = REGEX_ALIASES.get(project.regex, project.regex)
 
         if '%(name)' in regex:
-            regex = regex % {'name': project.name.replace('+', '\+')}
+            regex = regex % {'name': project.name.replace('+', r'\+')}
 
         return get_versions_by_regex(
             url, regex, project, insecure=project.insecure)

--- a/anitya/lib/backends/drupal6.py
+++ b/anitya/lib/backends/drupal6.py
@@ -12,7 +12,7 @@ from anitya.lib.backends import BaseBackend, get_versions_by_regex
 from anitya.lib.exceptions import AnityaPluginException
 
 
-REGEX = '<version>6\.x-([^<]+)</version>'
+REGEX = r'<version>6\.x-([^<]+)</version>'
 
 
 class Drupal6Backend(BaseBackend):

--- a/anitya/lib/backends/drupal7.py
+++ b/anitya/lib/backends/drupal7.py
@@ -12,7 +12,7 @@ from anitya.lib.backends import BaseBackend, get_versions_by_regex
 from anitya.lib.exceptions import AnityaPluginException
 
 
-REGEX = '<version>7\.x-([^<]+)</version>'
+REGEX = r'<version>7\.x-([^<]+)</version>'
 
 
 class Drupal7Backend(BaseBackend):

--- a/anitya/lib/backends/folder.py
+++ b/anitya/lib/backends/folder.py
@@ -74,7 +74,7 @@ class FolderBackend(BaseBackend):
             req = req.text
 
         try:
-            regex = REGEX % {'name': project.name.replace('+', '\+')}
+            regex = REGEX % {'name': project.name.replace('+', r'\+')}
             versions = get_versions_by_regex_for_text(
                 req, url, regex, project)
         except AnityaPluginException:

--- a/anitya/lib/backends/sourceforge.py
+++ b/anitya/lib/backends/sourceforge.py
@@ -58,10 +58,10 @@ class SourceforgeBackend(BaseBackend):
         url_template = 'https://sourceforge.net/projects/%(name)s/rss?limit=200'
 
         url = url_template % {
-            'name': (project.version_url or project.name).replace('+', '\+')
+            'name': (project.version_url or project.name).replace('+', r'\+')
         }
         regex = REGEX % {
-            'name': project.name.replace('+', '\+')
+            'name': project.name.replace('+', r'\+')
         }
 
         return get_versions_by_regex(url, regex, project)

--- a/anitya/lib/backends/stackage.py
+++ b/anitya/lib/backends/stackage.py
@@ -52,7 +52,7 @@ class StackageBackend(BaseBackend):
         url = 'https://www.stackage.org/package/%(name)s' % {
             'name': project.name}
 
-        regex = '<span class="version"><a href="https://www.stackage.org/'\
-            'lts-[\d.]*/package/%s">([\d.]*)</a></span>' % project.name
+        regex = r'<span class="version"><a href="https://www.stackage.org/'\
+            r'lts-[\d.]*/package/%s">([\d.]*)</a></span>' % project.name
 
         return get_versions_by_regex(url, regex, project)

--- a/anitya/lib/utilities.py
+++ b/anitya/lib/utilities.py
@@ -390,7 +390,7 @@ def map_project(
         session.add(distro_obj)
         try:
             session.flush()
-        except SQLAlchemyError as err:  # pragma: no cover
+        except SQLAlchemyError:  # pragma: no cover
             # We cannot test this situation
             session.rollback()
             raise exceptions.AnityaException(

--- a/anitya/lib/versions/rpm.py
+++ b/anitya/lib/versions/rpm.py
@@ -115,7 +115,7 @@ class RpmVersion(Version):
     name = u'RPM'
 
     _rc_upstream_regex = re.compile(
-        "(.*?)\.?(-?(rc|pre|beta|alpha|dev)([0-9]*))", re.I)
+        r"(.*?)\.?(-?(rc|pre|beta|alpha|dev)([0-9]*))", re.I)
 
     @classmethod
     def split_rc(cls, version):

--- a/anitya/lib/xml2dict.py
+++ b/anitya/lib/xml2dict.py
@@ -75,7 +75,7 @@ class XML2Dict(object):
              ns = http://cs.sfsu.edu/csc867/myscheduler
              name = patients
         """
-        result = re.compile("\{(.*)\}(.*)").search(tag)
+        result = re.compile(r"\{(.*)\}(.*)").search(tag)
         if result:
             value.namespace, tag = result.groups()
         return (tag, value)


### PR DESCRIPTION
This PR should fix the failing lint test.

There was new version of flake that started checking things that are deprecated in newer versions of python. Unfortunately I still had old version in my tox env, so I didn't noticed this.