### PR TITLE
Add GDPR script

### DIFF
--- a/anitya/db/models.py
+++ b/anitya/db/models.py
@@ -983,6 +983,31 @@ class User(Base):
         """
         return six.text_type(self.id)
 
+    def to_dict(self):
+        """
+        Creates json compatible dict from `User`.
+
+        Returns:
+            dict: `User` object transformed to dictionary.
+        """
+        social_auth = []
+        for soc_auth in self.social_auth.all():
+            social_auth.append(
+                dict(
+                    provider=soc_auth.provider,
+                    extra_data=soc_auth.extra_data,
+                    uid=soc_auth.uid,
+                )
+            )
+
+        return dict(
+            id=str(self.id),
+            email=self.email,
+            username=self.username,
+            active=self.active,
+            social_auth=social_auth,
+        )
+
 
 def _api_token_generator(charset=string.ascii_letters + string.digits, length=40):
     """

--- a/anitya/sar.py
+++ b/anitya/sar.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions
+# of the GNU General Public License v.2, or (at your option) any later
+# version.  This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.  You
+# should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# Any Red Hat trademarks that are incorporated in the source
+# code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission
+# of Red Hat, Inc.
+#
+"""
+This script is used for GDPR SAR (General Data Protection Regulation
+Subject Access Requests).
+It returns information about specific user saved by Anitya.
+It reads SAR_USERNAME and SAR_EMAIL environment variables as keys for
+getting data from database.
+
+ Authors:
+   Michal Konecny <mkonecny@redhat.com>
+"""
+
+import logging
+import os
+import json
+import sys
+
+from anitya.config import config
+from anitya import db
+
+_log = logging.getLogger('anitya')
+
+
+def main():
+    '''
+    Retrieve database entry for user.
+    '''
+    db.initialize(config)
+    _log.setLevel(logging.DEBUG)
+    sar_username = os.getenv('SAR_USERNAME')
+    sar_email = os.getenv('SAR_EMAIL')
+
+    users = []
+
+    if sar_email:
+        _log.debug('Find users by e-mail {}'.format(sar_email))
+        users = users + db.User.query.filter_by(email=sar_email).all()
+
+    if sar_username:
+        _log.debug('Find users by username {}'.format(sar_username))
+        users = users + db.User.query.filter_by(username=sar_username).all()
+
+    users_list = []
+    for user in users:
+        users_list.append(user.to_dict())
+
+    json.dump(users_list, sys.stdout)
+
+
+if __name__ == '__main__':
+    _log.info('SAR script start')
+    main()
+    _log.info('SAR script end')

--- a/anitya/tests/db/test_models.py
+++ b/anitya/tests/db/test_models.py
@@ -1077,6 +1077,37 @@ class UserTests(DatabaseTestCase):
             self.assertTrue(user.is_admin)
             self.assertTrue(user.admin)
 
+    def test_to_dict(self):
+        """ Assert the correct dictionary is returned. """
+        user = models.User(
+            email='user@fedoraproject.org',
+            username='user',
+        )
+        user_social_auth = social_models.UserSocialAuth(
+            user_id=user.id,
+            user=user,
+            provider='FAS',
+        )
+        user_social_auth.set_extra_data({'wookie': 'too hairy'})
+        self.session.add(user_social_auth)
+        self.session.add(user)
+        self.session.commit()
+
+        expected = {
+            "id": str(user.id),
+            "email": user.email,
+            "username": user.username,
+            "active": user.active,
+            "social_auth": [{
+                "provider": user_social_auth.provider,
+                "extra_data": user_social_auth.extra_data,
+                "uid": user_social_auth.uid,
+                }],
+        }
+
+        json = user.to_dict()
+        self.assertEqual(json, expected)
+
 
 class ApiTokenTests(DatabaseTestCase):
 

--- a/anitya/tests/test_sar.py
+++ b/anitya/tests/test_sar.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions
+# of the GNU General Public License v.2, or (at your option) any later
+# version.  This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.  You
+# should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# Any Red Hat trademarks that are incorporated in the source
+# code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission
+# of Red Hat, Inc.
+#
+
+'''
+anitya tests for GDPR SAR script.
+'''
+
+import pytest
+import mock
+import json
+
+from social_flask_sqlalchemy import models as social_models
+
+import anitya.sar as sar
+from anitya.db import models
+from anitya.tests.base import DatabaseTestCase
+
+
+class SARTests(DatabaseTestCase):
+    """ SAR script tests. """
+
+    @pytest.fixture(autouse=True)
+    def capsys(self, capsys):
+        """ Use capsys fixture as part of this class. """
+        self.capsys = capsys
+
+    @mock.patch.dict('os.environ', {'SAR_EMAIL': 'user@fedoraproject.org'})
+    def test_main_email(self):
+        """
+        Assert that correct user data are dumped when providing
+        e-mail.
+        """
+        user = models.User(
+            email='user@fedoraproject.org',
+            username='user',
+            active=True,
+        )
+        user_social_auth = social_models.UserSocialAuth(
+            user_id=user.id,
+            user=user
+        )
+
+        self.session.add(user_social_auth)
+        self.session.add(user)
+
+        user2 = models.User(
+            email='user2@email.org',
+            username='user2',
+            active=True,
+        )
+        user_social_auth = social_models.UserSocialAuth(
+            user_id=user2.id,
+            user=user2
+        )
+
+        self.session.add(user_social_auth)
+        self.session.add(user2)
+        self.session.commit()
+
+        exp = [{
+            'id': str(user.id),
+            'username': user.username,
+            'email': user.email,
+            'active': user.active,
+            'social_auth': [{
+                'uid': None,
+                'provider': None,
+                'extra_data': None
+            }]
+        }]
+
+        sar.main()
+
+        out, err = self.capsys.readouterr()
+
+        obs = json.loads(out)
+
+        self.assertEqual(exp, obs)
+
+    @mock.patch.dict('os.environ', {'SAR_USERNAME': 'user'})
+    def test_main_username(self):
+        """
+        Assert that correct user data are dumped when providing
+        username.
+        """
+        user = models.User(
+            email='user@fedoraproject.org',
+            username='user',
+            active=True,
+        )
+        user_social_auth = social_models.UserSocialAuth(
+            user_id=user.id,
+            user=user
+        )
+
+        self.session.add(user_social_auth)
+        self.session.add(user)
+
+        user2 = models.User(
+            email='user2@email.org',
+            username='user2',
+            active=True,
+        )
+        user_social_auth = social_models.UserSocialAuth(
+            user_id=user2.id,
+            user=user2
+        )
+
+        self.session.add(user_social_auth)
+        self.session.add(user2)
+        self.session.commit()
+
+        exp = [{
+            'id': str(user.id),
+            'username': user.username,
+            'email': user.email,
+            'active': user.active,
+            'social_auth': [{
+                'uid': None,
+                'provider': None,
+                'extra_data': None
+            }]
+            }
+        ]
+
+        sar.main()
+
+        out, err = self.capsys.readouterr()
+
+        obs = json.loads(out)
+
+        self.assertEqual(exp, obs)
+
+    def test_main_no_env_set(self):
+        """
+        Assert that correct user data are dumped when nothing is provided.
+        """
+        user = models.User(
+            email='user@fedoraproject.org',
+            username='user',
+            active=True,
+        )
+        user_social_auth = social_models.UserSocialAuth(
+            user_id=user.id,
+            user=user
+        )
+
+        self.session.add(user_social_auth)
+        self.session.add(user)
+
+        user2 = models.User(
+            email='user2@email.org',
+            username='user2',
+            active=True,
+        )
+        user_social_auth = social_models.UserSocialAuth(
+            user_id=user2.id,
+            user=user2
+        )
+
+        self.session.add(user_social_auth)
+        self.session.add(user2)
+        self.session.commit()
+
+        sar.main()
+
+        out, err = self.capsys.readouterr()
+
+        self.assertEqual('[]', out)

--- a/news/PR649.other
+++ b/news/PR649.other
@@ -1,0 +1,1 @@
+Add GDPR SAR script

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     ],
     packages=find_packages(exclude=['anitya.tests', 'anitya.tests.*']),
     include_package_data=True,
-    scripts=['files/anitya_cron.py'],
+    scripts=['files/anitya_cron.py', 'anitya/sar.py'],
     install_requires=get_requirements(),
     test_suite='anitya.tests',
     entry_points="""


### PR DESCRIPTION
Add SAR (Subject Access Requests) GDPR (General Data Protection Regulation)
script that could be used to gather user data from database.
This script currently takes data from users and
social_auth_usersocialauth table and saves them in json format.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>