### PR TITLE
Upgrade vagrant to Fedora 29

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -4,7 +4,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
- config.vm.box = "fedora/28-cloud-base"
+ config.vm.box = "fedora/29-cloud-base"
 
  # Forward traffic on the host to the development server on the guest
  config.vm.network "forwarded_port", guest: 5000, host: 5000
@@ -20,7 +20,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  # If you would prefer to use NFS to share the directory uncomment this and configure NFS
  # config.vm.synced_folder ".", "/vagrant", type: "nfs", nfs_version: 4, nfs_udp: false
  config.vm.synced_folder ".", "/vagrant", disabled: true
- config.vm.synced_folder ".", "/home/vagrant/devel", type: "sshfs", sshfs_opts_append: "-o nonempty"
+ config.vm.synced_folder ".", "/home/vagrant/devel", type: "sshfs"
 
  # To cache update packages (which is helpful if frequently doing `vagrant destroy && vagrant up`)
  # you can create a local directory and share it to the guest's DNF cache. The directory needs to

--- a/anitya/tests/test_alembic.py
+++ b/anitya/tests/test_alembic.py
@@ -1,0 +1,48 @@
+# (c) 2017 - Copyright Red Hat Inc
+
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# Authors:
+#   Pierre-Yves Chibon <pingou@pingoured.fr>
+"""This test module contains tests for the migration system."""
+
+import os
+import subprocess
+import unittest
+
+
+REPO_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', '..'))
+
+
+class TestAlembic(unittest.TestCase):
+    """This test class contains tests pertaining to alembic."""
+
+    def test_alembic_history(self):
+        """Enforce a linear alembic history.
+
+        This test runs the `alembic history | grep ' (head), '` command,
+        and ensure it returns only one line.
+        """
+        proc1 = subprocess.Popen(
+            ['alembic', 'history'],
+            cwd=REPO_PATH, stdout=subprocess.PIPE)
+        proc2 = subprocess.Popen(
+            ['grep', ' (head), '],
+            stdin=proc1.stdout, stdout=subprocess.PIPE)
+
+        stdout = proc2.communicate()[0]
+        stdout = stdout.strip().split(b'\n')
+        self.assertEqual(len(stdout), 1)
+        proc1.communicate()

--- a/ansible/roles/anitya-dev/tasks/main.yml
+++ b/ansible/roles/anitya-dev/tasks/main.yml
@@ -37,7 +37,7 @@
   become_user: "{{ ansible_env.SUDO_USER }}"
   shell: >
       source ~/.bashrc && mkvirtualenv anitya -a ~/devel/ &&
-      virtualenv-3 --system-site-packages ~/.virtualenvs/anitya/
+      virtualenv --python=/usr/bin/python3 --system-site-packages ~/.virtualenvs/anitya/
   args:
     creates: /home/{{ ansible_env.SUDO_USER }}/.virtualenvs/anitya
 

--- a/news/PR653.dev
+++ b/news/PR653.dev
@@ -1,0 +1,1 @@
+Update Vagrantfile to use Fedora 29 image

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -15,6 +15,6 @@ requests-oauthlib
 contextlib2
 
 # Required to test building the docs
-sphinx==1.5.6
+sphinx
 sphinxcontrib-httpdomain
 sqlalchemy_schemadisplay


### PR DESCRIPTION
Some things were changed:
* virtualenv-3 is now virtualenv
* sphinx version restriction was removed - 1.5.6 not working on python
3.7
* run alembic with heads instead of head, this will fix issue when
more migrations should be applied at once

Signed-off-by: Michal Konečný <mkonecny@redhat.com>