### PR TITLE
Add basic user management

### DIFF
--- a/anitya/db/migrations/versions/b13662e5d288_add_admin_flag.py
+++ b/anitya/db/migrations/versions/b13662e5d288_add_admin_flag.py
@@ -1,0 +1,30 @@
+"""Add admin flag
+
+Revision ID: b13662e5d288
+Revises: ac10bf3f974c
+Create Date: 2018-11-14 10:02:06.593605
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b13662e5d288'
+down_revision = 'ac10bf3f974c'
+
+
+def upgrade():
+    """ Add 'admin' flag to users table. """
+    op.add_column(
+        'users',
+        sa.Column(
+            'admin',
+            sa.Boolean,
+            default=False)
+    )
+
+
+def downgrade():
+    """ Drop 'admin' flag from users table. """
+    op.drop_column('users', 'admin')

--- a/anitya/db/models.py
+++ b/anitya/db/models.py
@@ -907,6 +907,8 @@ class User(Base):
         username (str): The user's username, as retrieved from third-party authentication.
         active (bool): Indicates whether the user is active. If false, users will not be
             able to log in.
+        admin (bool): Determine if this user is an administrator. If True the user is
+            administrator.
         social_auth (sqlalchemy.orm.dynamic.AppenderQuery): The list of
             :class:`social_flask_sqlalchemy.models.UserSocialAuth` entries for this user.
     """
@@ -918,16 +920,21 @@ class User(Base):
     email = sa.Column(sa.String(256), nullable=False, index=True, unique=True)
     username = sa.Column(sa.String(256), nullable=False, index=True, unique=True)
     active = sa.Column(sa.Boolean, default=True)
+    admin = sa.Column(sa.Boolean, default=False)
 
     @property
-    def admin(self):
+    def is_admin(self):
         """
-        Determine if this user is an administrator.
+        Determine if this user is an administrator. Set admin flag
+        if the user is preconfigured.
 
         Returns:
             bool: True if the user is an administrator.
         """
-        return six.text_type(self.id) in anitya_config.get('ANITYA_WEB_ADMINS', [])
+        if not self.admin:
+            if six.text_type(self.id) in anitya_config.get('ANITYA_WEB_ADMINS', []):
+                self.admin = True
+        return self.admin
 
     @property
     def is_active(self):

--- a/anitya/templates/master.html
+++ b/anitya/templates/master.html
@@ -127,6 +127,15 @@
                <a href="{{url_for('anitya_ui.browse_flags')}}">
                   flags</a>
                </li>
+              {%- if current == 'users' -%}
+              <li class="active">
+              {%- else -%}
+              <li>
+              {%- endif -%}
+                <a href="{{url_for('anitya_ui.browse_users')}}">
+                  users
+                </a>
+              </li>
             {%- endif -%}
             <li><a href="{{url_for('anitya_ui.settings')}}">Settings</a></li>
             <li>

--- a/anitya/templates/users.html
+++ b/anitya/templates/users.html
@@ -1,0 +1,141 @@
+{% extends "master.html" %}
+
+{% block title %}Users · Anitya{% endblock %}
+
+{% block body %}
+
+<div class="page-header">
+    <h1>Users</h1>
+</div>
+
+<div class="row show-grid">
+    <div class="col-sm-4">
+        {% if total_page > 1 %}
+        <ul class="pagination pagination-sm">
+            <li>
+                {% if page > 1%}
+                <a href="{{ url_for('anitya_ui.browse_users', page=page-1) }}">
+                    «
+                </a>
+                {% else %}
+                <a> « </a>
+                {% endif %}
+            </li>
+            <li>
+                <a> {{ page }} / {{ total_page }} </a>
+            </li>
+            <li>
+                {% if page < total_page %}
+                <a href="{{ url_for('anitya_ui.browse_users', page=page+1) }}">
+                    »
+                </a>
+                {% else %}
+                <a> » </a>
+                {% endif %}
+            </li>
+        </ul>
+        {% endif %}
+    </div>
+
+    <div class="col-xs-10">
+        <form action="{{ url_for('anitya_ui.browse_users') }}" class="form-inline"
+              role="form" action="GET" id="users_form">
+            <div class="form-group col-xs-6 col-sm-3">
+                <input type="text" name="user_id" placeholder="User Id"
+                       class="form-control" value="{{ user_id }}" />
+            </div>
+            <div class="form-group col-xs-6 col-sm-3">
+                <input type="text" name="username" placeholder="Username"
+                       class="form-control" value="{{ username }}"/>
+            </div>
+            <div class="form-group col-xs-6 col-sm-3">
+                <input type="text" name="email" placeholder="User e-mail"
+                       class="form-control" value="{{ email }}"/>
+            </div>
+            <div class="form-group col-xs-6 col-sm-2">
+                <select name="admin" class="form-control">
+                    <option value="True" {% if admin %}selected="selected"{% endif %}>Admins</option>
+                    <option value="False" {% if not admin %}selected="selected"{% endif %}>Basic users</option>
+                    <option value="None" {% if admin == None %}selected="selected"{% endif %}>All</option>
+                </select>
+            </div>
+            <div class="form-group col-xs-6 col-sm-1">
+                <select name="active" class="form-control">
+                    <option value="True" {% if active %}selected="selected"{% endif %}>Active</option>
+                    <option value="False" {% if not active %}selected="selected"{% endif %}>Inactive</option>
+                    <option value="None" {% if active == None %}selected="selected"{% endif %}>All</option>
+                </select>
+            </div>
+            <div class="form-group col-xs-6 col-sm-1">
+                <button type="submit" class="btn btn-default" class="form-control">
+                    Filter
+                </button>
+            </div>
+        </form>
+    </div>
+
+</div>
+
+
+<table id="user_list" class="table">
+    <tr>
+        <th>User Id</th>
+        <th>Username</th>
+        <th>E-mail</th>
+        <th>Admin</th>
+        <th>Active</th>
+        <th></th>
+        <th></th>
+    </tr>
+    {% for user in users %}
+    <tr>
+        <td>{{ user.id }}</td>
+        <td>{{ user.username }}</td>
+        <td>{{ user.email }}</td>
+        <td>{{ user.is_admin }}</td>
+        <td>{{ user.is_active }}</td>
+        <td>
+            {% if user.is_admin %}
+            <form method="POST" action="{{ url_for('anitya_ui.set_user_admin_state',
+                user_id=user.id, state=False) }}">
+                <button type="submit" class="btn btn-danger btn-sm pull-right inline"
+                        id="user_btn">
+                    Revoke admin
+                </button>
+                {% else %}
+                <form method="POST" action="{{ url_for('anitya_ui.set_user_admin_state',
+                user_id=user.id, state=True) }}">
+                    <button type="submit" class="btn btn-success btn-sm pull-right inline"
+                            id="user_btn">
+                        Promote admin
+                    </button>
+                    {% endif %}
+                    {{ form.csrf_token }}
+                </form>
+
+        </td>
+        <td>
+            {% if user.is_active %}
+            <form method="POST" action="{{ url_for('anitya_ui.set_user_active_state',
+                user_id=user.id, state=False) }}">
+                <button type="submit" class="btn btn-danger btn-sm pull-right inline"
+                        id="user_btn">
+                    Ban
+                </button>
+                {% else %}
+                <form method="POST" action="{{ url_for('anitya_ui.set_user_active_state',
+                user_id=user.id, state=True) }}">
+                    <button type="submit" class="btn btn-success btn-sm pull-right inline"
+                            id="user_btn">
+                        Remove ban
+                    </button>
+                    {% endif %}
+                    {{ form.csrf_token }}
+                </form>
+
+        </td>
+    </tr>
+    {% endfor %}
+</table>
+
+{% endblock %}

--- a/anitya/templates/users.html
+++ b/anitya/templates/users.html
@@ -100,18 +100,18 @@
                 user_id=user.id, state=False) }}">
                 <button type="submit" class="btn btn-danger btn-sm pull-right inline"
                         id="user_btn">
-                    Revoke admin
+                    Revoke admin permissions
                 </button>
-                {% else %}
-                <form method="POST" action="{{ url_for('anitya_ui.set_user_admin_state',
-                user_id=user.id, state=True) }}">
-                    <button type="submit" class="btn btn-success btn-sm pull-right inline"
-                            id="user_btn">
-                        Promote admin
-                    </button>
-                    {% endif %}
-                    {{ form.csrf_token }}
-                </form>
+            {% else %}
+            <form method="POST" action="{{ url_for('anitya_ui.set_user_admin_state',
+            user_id=user.id, state=True) }}">
+                <button type="submit" class="btn btn-success btn-sm pull-right inline"
+                        id="user_btn">
+                    Give admin permissions
+                </button>
+                {% endif %}
+                {{ form.csrf_token }}
+            </form>
 
         </td>
         <td>
@@ -122,16 +122,16 @@
                         id="user_btn">
                     Ban
                 </button>
-                {% else %}
-                <form method="POST" action="{{ url_for('anitya_ui.set_user_active_state',
-                user_id=user.id, state=True) }}">
-                    <button type="submit" class="btn btn-success btn-sm pull-right inline"
-                            id="user_btn">
-                        Remove ban
-                    </button>
-                    {% endif %}
-                    {{ form.csrf_token }}
-                </form>
+            {% else %}
+            <form method="POST" action="{{ url_for('anitya_ui.set_user_active_state',
+            user_id=user.id, state=True) }}">
+                <button type="submit" class="btn btn-success btn-sm pull-right inline"
+                        id="user_btn">
+                    Remove ban
+                </button>
+                {% endif %}
+                {{ form.csrf_token }}
+            </form>
 
         </td>
     </tr>

--- a/anitya/tests/test_flask_admin.py
+++ b/anitya/tests/test_flask_admin.py
@@ -1130,7 +1130,7 @@ class SetUserAdminStateTests(DatabaseTestCase):
             ))
             self.assertEqual(404, output.status_code)
 
-    def test_missing(self):
+    def test_missing_user(self):
         """Assert trying to set the state of a non-existent user results in HTTP 404."""
         with login_user(self.flask_app, self.admin):
             output = self.client.post('/users/42/admin/true')
@@ -1291,7 +1291,7 @@ class SetUserActiveStateTests(DatabaseTestCase):
             ))
             self.assertEqual(404, output.status_code)
 
-    def test_missing(self):
+    def test_missing_user(self):
         """Assert trying to set the state of a non-existent user results in HTTP 404."""
         with login_user(self.flask_app, self.admin):
             output = self.client.post('/users/42/active/true')

--- a/news/621.feature
+++ b/news/621.feature
@@ -1,0 +1,1 @@
+Basic user management UI for admins


### PR DESCRIPTION
Changes:
* Adds new page `/users` which is similar to `/flags` page.
  This user management will help promote new admins or ban users.
![screenshot from 2018-11-16 11-22-40](https://user-images.githubusercontent.com/6943409/48616107-ec138780-e992-11e8-8dc1-0d2a4be54f34.png)
* Add `admin` flag to `User` model.
* User property `admin` is renamed to `is_admin`.
* Admin flag for preconfigured users is set on `is_admin` call.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>