### PR TITLE
Fix first login issue

### DIFF
--- a/anitya/db/events.py
+++ b/anitya/db/events.py
@@ -17,11 +17,10 @@
 import logging
 
 from sqlalchemy import event
-from sqlalchemy.exc import IntegrityError
 
 from anitya.lib import plugins
 from .meta import Session
-from .models import Project, User
+from .models import Project
 
 
 _log = logging.getLogger(__name__)
@@ -58,23 +57,3 @@ def set_ecosystem(session, flush_context, instances):
                 if new_obj.ecosystem_name not in valid_names:
                     raise ValueError('Invalid ecosystem_name "{}", must be one of {}'.format(
                         new_obj.ecosystem_name, valid_names))
-
-
-@event.listens_for(Session, 'before_flush')
-def check_user(session, flush_context, instances):
-    """
-    An SQLAlchemy event listener that checks if the user has social_auth table.
-
-    Args:
-        session (sqlalchemy.orm.session.Session): The session that is about to be committed.
-        flush_context (sqlalchemy.orm.session.UOWTransaction): Unused.
-        instances (object): deprecated and unused
-
-    Raises:
-        ValueError: If the social_auth table is not associated with this user.
-    """
-    for new_obj in session.new:
-        if isinstance(new_obj, User):
-            if new_obj.social_auth.count() == 0:
-                raise IntegrityError('Missing social_auth table', {
-                    'social_auth': None, 'email': new_obj.email}, None)

--- a/anitya/tests/db/test_events.py
+++ b/anitya/tests/db/test_events.py
@@ -22,8 +22,6 @@
 
 from anitya.db import models, Session
 from anitya.tests.base import DatabaseTestCase
-from sqlalchemy.exc import IntegrityError
-from social_flask_sqlalchemy import models as social_models
 
 
 class SetEcosystemTests(DatabaseTestCase):
@@ -68,36 +66,3 @@ class SetEcosystemTests(DatabaseTestCase):
 
         Session.add(project)
         self.assertRaises(ValueError, Session.commit)
-
-
-class CheckUserTests(DatabaseTestCase):
-    """ Tests for `anitya.db.events.check_user` functioni. """
-
-    def test_check_user_no_social_auth(self):
-        """ Assert `sqlalchemy.exc.IntegrityError` is raised when social_auth is missing. """
-        user = models.User(
-            email='user@fedoraproject.org',
-            username='user',
-        )
-
-        self.session.add(user)
-        self.assertRaises(IntegrityError, self.session.commit)
-
-    def test_check_user_with_social_auth(self):
-        """ Assert user is created. """
-        user = models.User(
-            email='user@fedoraproject.org',
-            username='user',
-        )
-        user_social_auth = social_models.UserSocialAuth(
-            user_id=user.id,
-            user=user
-        )
-
-        self.session.add(user)
-        self.session.add(user_social_auth)
-        self.session.commit()
-
-        user = self.session.query(models.User).one()
-
-        self.assertTrue(len(user.social_auth.all()), 1)

--- a/anitya/tests/test_app.py
+++ b/anitya/tests/test_app.py
@@ -81,10 +81,8 @@ class IntegrityErrorHandlerTests(base.DatabaseTestCase):
     def setUp(self):
         super(IntegrityErrorHandlerTests, self).setUp()
         session = Session()
-        user = models.User(email='user@example.com', username='user')
-        social_auth_user = social_models.UserSocialAuth(provider='Demo Provider', user=user)
-        session.add(social_auth_user)
-        session.add(user)
+        self.user = models.User(email='user@example.com', username='user')
+        session.add(self.user)
         session.commit()
 
     def test_not_email(self):
@@ -99,6 +97,11 @@ class IntegrityErrorHandlerTests(base.DatabaseTestCase):
     def test_email(self):
         """Assert an HTTP 400 is generated from an email IntegrityError."""
 
+        social_auth_user = social_models.UserSocialAuth(
+            provider='Demo Provider', user=self.user)
+        self.session.add(social_auth_user)
+        self.session.commit()
+
         err = IntegrityError('SQL Statement', {'email': 'user@example.com'}, None)
         expected_msg = ("Error: There's already an account associated with your email, "
                         "authenticate with Demo Provider.")
@@ -109,13 +112,13 @@ class IntegrityErrorHandlerTests(base.DatabaseTestCase):
         self.assertEqual(expected_msg, msg)
 
     def test_no_social_auth(self):
-        """Assert an HTTP 400 is generated from an social_auth IntegrityError."""
+        """Assert an HTTP 500 is generated from an social_auth IntegrityError."""
 
         err = IntegrityError('SQL Statement', {
-            'social_auth': 'user',
             'email': 'user@example.com'}, None)
-        expected_msg = ("Error: Authentication with authentication provider failed. "
-                        "Please try again later...")
+        expected_msg = ("Error: There was already an existing account with missing provider. "
+                        "So we removed it. "
+                        "Please try to log in again.")
 
         msg, errno = app.integrity_error_handler(err)
 
@@ -138,3 +141,39 @@ class AuthExceptionHandlerTests(base.DatabaseTestCase):
 
         self.assertEqual(400, errno)
         self.assertEqual(exp_msg, msg)
+
+
+class WhenUserLogInTests(base.DatabaseTestCase):
+    """ Tests for `anitya.app.when_user_log_in` function. """
+
+    def test_without_error(self):
+        """Assert that nothing happens if social_auth info is available."""
+        user = models.User(
+            email='user@example.com',
+            username='user'
+            )
+        social_auth_user = social_models.UserSocialAuth(
+            provider='Demo Provider',
+            user=user)
+        self.session.add(social_auth_user)
+        self.session.add(user)
+        self.session.commit()
+
+        # If the method doesn't throw exception the test is ok
+        app.when_user_log_in(app, user)
+
+    def test_social_auth_missing(self):
+        """Assert that exception is thrown when social_auth info is missing."""
+        user = models.User(
+            email='user@example.com',
+            username='user'
+        )
+        self.session.add(user)
+        self.session.commit()
+
+        self.assertRaises(
+            IntegrityError,
+            app.when_user_log_in,
+            app,
+            user
+        )


### PR DESCRIPTION
This is fixing the issue that was accidentally added by social_auth check (https://github.com/release-monitoring/anitya/pull/615) in events.
It turned out that the user table entry and social_auth entry are created in separate transactions.
This caused issue when you tried to login when user didn't exists.
This fix is checking the social_auth entry when user logs in and deletes the user when no entry is actually created.

Fixes #689 

Signed-off-by: Michal Konečný <mkonecny@redhat.com>