### PR TITLE
Versions are now shown correctly on project page

### DIFF
--- a/anitya/templates/project.html
+++ b/anitya/templates/project.html
@@ -222,7 +222,7 @@
           </tr>
           {% for version in project.get_sorted_version_objects() %}
           <tr property="doap:release" typeof="doap:Version">
-            <td property="doap:revision">{{ version.version }}</td>
+            <td property="doap:revision">{{ version.parse() }}</td>
             {% if version.created_on %}
             <td>{{ version.created_on.strftime('%Y-%m-%d %H:%M') }}</td>
             {% else %}


### PR DESCRIPTION
With introduction of new version prefix handling (https://github.com/release-monitoring/anitya/pull/652) a new issue was created. With the new prefix handling we actually don't remove the prefix, but instead we let this on `Version` class.
Previously the `project.html` template used version.version to show version on the project page, but now it is changed to `version.parse()` which returns the correct string stripped of any prefix.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>