### PR TITLE
Ratelimit enhancement

### DIFF
--- a/anitya/lib/utilities.py
+++ b/anitya/lib/utilities.py
@@ -75,18 +75,18 @@ def check_project_release(project, session, test=False):
 
     try:
         versions_prefix = backend.get_versions(project)
-    except exceptions.AnityaPluginException as err:
-        _log.exception("AnityaError catched:")
-        if not test:
-            project.logs = str(err)
-            session.add(project)
-            session.commit()
-        raise
     except exceptions.RateLimitException as err:
         _log.exception("AnityaError catched:")
         if not test:
             project.logs = str(err)
             project.next_check = err.reset_time.to('utc').datetime
+            session.add(project)
+            session.commit()
+        raise
+    except exceptions.AnityaPluginException as err:
+        _log.exception("AnityaError catched:")
+        if not test:
+            project.logs = str(err)
             session.add(project)
             session.commit()
         raise

--- a/anitya/tests/lib/backends/test_github.py
+++ b/anitya/tests/lib/backends/test_github.py
@@ -353,6 +353,7 @@ class JsonTests(unittest.TestCase):
                     }
                 },
                 "rateLimit": {
+                    "limit": 5000,
                     "remaining": 0,
                     "resetAt": "2008-09-03T20:56:35.450686"
                 }
@@ -380,6 +381,7 @@ class JsonTests(unittest.TestCase):
                     }
                 },
                 "rateLimit": {
+                    "limit": 5000,
                     "remaining": 5000,
                     "resetAt": "dummy"
                 }
@@ -388,6 +390,38 @@ class JsonTests(unittest.TestCase):
         exp = [u'1.0']
         obs = backend.parse_json(json, project)
         self.assertEqual(exp, obs)
+
+    def test_parse_json_threshold_reach(self):
+        """
+        Assert that exception is thrown when
+        rate limit threshold is reached.
+        """
+        project = models.Project(
+            name='foobar',
+            homepage='https://foobar.com',
+            version_url='foo/bar',
+            backend=BACKEND,
+        )
+        json = {
+            "data": {
+                "repository": {
+                    "refs": {
+                        "totalCount": 0
+                    }
+                },
+                "rateLimit": {
+                    "limit": 5000,
+                    "remaining": 500,
+                    "resetAt": "2008-09-03T20:56:35.450686"
+                }
+            }
+        }
+        self.assertRaises(
+            RateLimitException,
+            backend.parse_json,
+            json,
+            project
+        )
 
 
 if __name__ == '__main__':

--- a/news/665.feature
+++ b/news/665.feature
@@ -1,0 +1,1 @@
+Rate limit enhancements


### PR DESCRIPTION
To prevent reaching the rate limit, blacklist is introduced to cron script. This marks backend as blacklisted when threshold is reached. Projects with blacklisted backend are no longer checked and automatically rescheduled to rate limit reset time.

This is now used only for Github, because it's only backend raising `RateLimitException`.

Fixes https://github.com/release-monitoring/anitya/issues/665