### PR TITLE
Fix vagrant up

### DIFF
--- a/ansible/roles/anitya-dev/tasks/main.yml
+++ b/ansible/roles/anitya-dev/tasks/main.yml
@@ -45,7 +45,7 @@
   become_user: "{{ ansible_env.SUDO_USER }}"
   shell: >
       source ~/.bashrc && mkvirtualenv anitya -a ~/devel/ &&
-      virtualenv --python=/usr/bin/python3 --system-site-packages ~/.virtualenvs/anitya/
+      virtualenv-3 --python=/usr/bin/python3 --system-site-packages ~/.virtualenvs/anitya/
   args:
     creates: /home/{{ ansible_env.SUDO_USER }}/.virtualenvs/anitya
 


### PR DESCRIPTION
virtualenv is not in the vagrant box. Be explicit and use virtualenv-3.

Signed-off-by: Jeremy Cline <jcline@redhat.com>