### PR TITLE
Return odd_change parameter

### DIFF
--- a/anitya/lib/utilities.py
+++ b/anitya/lib/utilities.py
@@ -140,6 +140,7 @@ def check_project_release(project, session, test=False):
                 versions=project.versions,
                 ecosystem=project.ecosystem_name,
                 agent='anitya',
+                odd_change=False
             ),
         )
 


### PR DESCRIPTION
After discussing this with @jeremycline in https://github.com/release-monitoring/anitya/pull/570 I decided to return the odd_change parameter. Just in case some consumer could need this.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>