### PR TITLE
Remove python2-dnf from Vagrantfile

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -32,7 +32,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  config.vm.provision "shell", inline: "sudo dnf upgrade -y"
 
  # bootstrap and run with ansible
- config.vm.provision "shell", inline: "sudo dnf -y install python2-dnf libselinux-python"
+ config.vm.provision "shell", inline: "sudo dnf -y install libselinux-python"
  config.vm.provision "ansible" do |ansible|
      ansible.playbook = "ansible/vagrant-playbook.yml"
  end


### PR DESCRIPTION
Fedora 29 comes with python3-dnf preinstalled

    anitya:   python3-dnf-4.0.9-2.fc29.noarch