### PR TITLE
Show raw version on project page

### DIFF
--- a/anitya/templates/project.html
+++ b/anitya/templates/project.html
@@ -217,6 +217,7 @@
             <th>Version</th>
             <th>Retrieved on (UTC)</th>
             {% if is_admin %}
+            <th>Raw version</th>
             <th>Delete</th>
             {% endif %}
           </tr>
@@ -229,6 +230,7 @@
             <td>Date information unavailable</td>
             {% endif %}
             {% if is_admin %}
+            <td>{{ version.version }}</td>
             <td>
               <a href="{{ url_for('anitya_ui.delete_project_version',
                           project_id=project.id,

--- a/news/PR696.feature
+++ b/news/PR696.feature
@@ -1,0 +1,1 @@
+Show raw version on project page for admins


### PR DESCRIPTION
This will allow admins to recognize versions with and without prefix
when removing versions from project.

![screenshot from 2019-01-08 09-39-43](https://user-images.githubusercontent.com/6943409/50819640-f31f9c00-132a-11e9-9e3e-872d0de7c236.png)

Signed-off-by: Michal Konečný <mkonecny@redhat.com>