### PR TITLE
python3-libselinux is automatically installed on F29 box

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -32,9 +32,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  config.vm.provision "shell", inline: "sudo dnf upgrade -y"
 
  # bootstrap and run with ansible
- config.vm.provision "shell", inline: "sudo dnf -y install libselinux-python"
  config.vm.provision "ansible" do |ansible|
      ansible.playbook = "ansible/vagrant-playbook.yml"
+     ansible.raw_arguments = ["-e", "ansible_python_interpreter=/usr/bin/python3"]
  end
 
 


### PR DESCRIPTION
This removes Python 2 dependency, and now Ansible needs to be told to use python3 explicitly, because there is no `python` binary on the box anymore.