### PR TITLE
Fix topic_prefix in libraries.io consumer

### DIFF
--- a/anitya/librariesio_consumer.py
+++ b/anitya/librariesio_consumer.py
@@ -117,6 +117,7 @@ class LibrariesioConsumer(FedmsgConsumer):
         initialize(config.config)
 
         super(LibrariesioConsumer, self).__init__(hub)
+        hub.config['topic_prefix'] = "org.release-monitoring"
 
     def consume(self, message):
         """

--- a/anitya/tests/test_librariesio_consumer.py
+++ b/anitya/tests/test_librariesio_consumer.py
@@ -93,6 +93,14 @@ class LibrariesioConsumerTests(DatabaseTestCase):
 
         self.assertEqual([u'anitya.prod.sse2fedmsg.librariesio'], consumer.topic)
 
+    def test_prefix_setup(self):
+        """Assert that topic_prefix is changed after initialization."""
+        mock_hub = mock.Mock(config={'environment': 'dev', 'topic_prefix': 'anitya'})
+        self.assertEqual(mock_hub.config['topic_prefix'], 'anitya')
+        LibrariesioConsumer(mock_hub)
+
+        self.assertEqual(mock_hub.config['topic_prefix'], 'org.release-monitoring')
+
     @mock.patch('anitya.librariesio_consumer._log')
     def test_no_ecosystem(self, mock_log):
         """Assert that messages about platforms we don't support are handled gracefully"""

--- a/news/PR704.bug
+++ b/news/PR704.bug
@@ -1,0 +1,1 @@
+Libraries.io consumer is replacing topic_prefix for Anitya


### PR DESCRIPTION
The topic prefix in libraries.io consumer shouldn't replace anitya's
topic_prefix. Unfortunatelly this isn't possible in fedmsg. So we need
this little hack to be able to receive and send messages with different
prefixes.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>