### PR TITLE
Fix: Comparing by dates created version duplicates

### DIFF
--- a/anitya/lib/versions/base.py
+++ b/anitya/lib/versions/base.py
@@ -74,8 +74,11 @@ class Version(object):
             version = self.version[len(self.prefix):]
 
         # Many projects prefix their tags with 'v', so strip it if it's present
-        if v_prefix.match(version):
-            version = version[1:]
+        try:
+            if v_prefix.match(version):
+                version = version[1:]
+        except TypeError:
+            raise InvalidVersion(version)
 
         return version
 

--- a/anitya/lib/versions/date.py
+++ b/anitya/lib/versions/date.py
@@ -35,15 +35,6 @@ class DateVersion(Version):
 
     name = u'Date'
 
-    def __eq__(self, other):
-        """
-        Compare two versions for equality by date created.
-
-        Returns:
-            bool: True if the ```created_on``` attributes are equal.
-        """
-        return self.created_on == other.created_on
-
     def __lt__(self, other):
         """
         Compare two versions by date created.

--- a/anitya/tests/lib/versions/test_base.py
+++ b/anitya/tests/lib/versions/test_base.py
@@ -50,6 +50,14 @@ class VersionTests(unittest.TestCase):
         version.parse = mock.Mock(side_effect=exceptions.InvalidVersion('boop'))
         self.assertEqual('v1.0.0', str(version))
 
+    def test_str_parse_error_none(self):
+        """Assert __str__ calls parse throws InvalidVersion when version is None"""
+        version = base.Version(version=None)
+        self.assertRaises(
+            exceptions.InvalidVersion,
+            version.parse,
+        )
+
     def test_parse_no_v(self):
         """Assert parsing a version sans leading 'v' works."""
         version = base.Version(version='1.0.0')

--- a/anitya/tests/lib/versions/test_date.py
+++ b/anitya/tests/lib/versions/test_date.py
@@ -38,18 +38,18 @@ class DateVersionTests(unittest.TestCase):
         self.assertEqual('Date', date.DateVersion.name)
 
     def test_eq_no_equal(self):
-        version_old = date.DateVersion(created_on=datetime.now())
-        version_new = date.DateVersion(created_on=datetime.now())
+        version_old = date.DateVersion(version="1.0.0")
+        version_new = date.DateVersion(version="1.0.1")
 
         self.assertFalse(version_old == version_new)
 
     def test_eq_equal(self):
-        version_date = date.DateVersion(created_on=datetime.now())
+        version_date = date.DateVersion(version="1.0.0")
 
         self.assertTrue(version_date == version_date)
 
     def test_eq_value_missing(self):
-        version_date = date.DateVersion(created_on=datetime.now())
+        version_date = date.DateVersion(version="1.0.0")
         version_no_date = date.DateVersion()
 
         self.assertFalse(version_date == version_no_date)
@@ -79,8 +79,8 @@ class DateVersionTests(unittest.TestCase):
         self.assertFalse(version_date < version_no_date)
 
     def test_le(self):
-        version_old = date.DateVersion(created_on=datetime.now())
-        version_new = date.DateVersion(created_on=datetime.now())
+        version_old = date.DateVersion(version="1.0.0", created_on=datetime.now())
+        version_new = date.DateVersion(version="1.0.1", created_on=datetime.now())
 
         self.assertTrue(version_old <= version_new)
         self.assertTrue(version_old <= version_old)

--- a/news/702.bug
+++ b/news/702.bug
@@ -1,0 +1,1 @@
+Comparing versions for equality by date is creating duplicities


### PR DESCRIPTION
Date version scheme compared for equality only by dates, this caused
creation of duplicities, which led to crash when commiting changes.
This commit changes the way how the date version scheme is comparing for
equality. Now it is calling `__eq__` method in Version class. Versions are
now considered equal if they are same after prefix is stripped.

Fixes #702 

Signed-off-by: Michal Konečný <mkonecny@redhat.com>