### PR TITLE
Fix URL to fedmsg website on index.html

### DIFF
--- a/anitya/templates/index.html
+++ b/anitya/templates/index.html
@@ -20,7 +20,7 @@
     <div class="col-md-4 col-md-offset-2">
       <h2><span class="glyphicon glyphicon-bullhorn"></span> Announce</h2>
       <p>We monitor upstream releases and broadcast them on
-      <a href="http://fedmsg.com">fedmsg</a>, the FEDerated MeSsaGe bus. </p>
+      <a href="https://fedmsg.readthedocs.io/en/stable/">fedmsg</a>, the FEDerated MeSsaGe bus. </p>
       <p>Use <a href="https://apps.fedoraproject.org/notifications">fedmsg
       notifications (FMN)</a>, to set up your own, <em>personalized</em>,
       alerts.</p>

--- a/anitya/tests/test_flask.py
+++ b/anitya/tests/test_flask.py
@@ -403,7 +403,7 @@ class FlaskTest(DatabaseTestCase):
         expected = b"""
       <h2><span class="glyphicon glyphicon-bullhorn"></span> Announce</h2>
       <p>We monitor upstream releases and broadcast them on
-      <a href="http://fedmsg.com">fedmsg</a>, the FEDerated MeSsaGe bus. </p>
+      <a href="https://fedmsg.readthedocs.io/en/stable/">fedmsg</a>, the FEDerated MeSsaGe bus. </p>
       <p>Use <a href="https://apps.fedoraproject.org/notifications">fedmsg
       notifications (FMN)</a>, to set up your own, <em>personalized</em>,
       alerts.</p>"""

--- a/news/PR722.other
+++ b/news/PR722.other
@@ -1,0 +1,1 @@
+Fix URL to fedmsg website on index.html to use the correct website URL


### PR DESCRIPTION
The domain fedmsg.com is not owned by the Fedora Project and points
to some kind of spam site. The page on readthedocs.io appears to be
the correct project website, so we should point to that.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>