### PR TITLE
Add support for multiple prefixes

### DIFF
--- a/anitya/lib/versions/base.py
+++ b/anitya/lib/versions/base.py
@@ -60,7 +60,17 @@ class Version(object):
            https://calver.org/#scheme
         """
         self.version = version
-        self.prefix = prefix
+        if prefix:
+            self.prefixes = prefix.split(";")
+            # Sort from shorter to longest, this will prevent stripping
+            # shorter prefix instead of larger.
+            # For example:
+            # version = release_db-1.2.3
+            # prefixes = release_db-;release
+            # would return db-1.2.3 instead of 1.2.3 if the sort is not done
+            self.prefixes.sort(key=len)
+        else:
+            self.prefixes = []
         self.created_on = created_on
         if pattern:
             self.pattern = pattern.upper()
@@ -95,8 +105,9 @@ class Version(object):
         """
         # If there's a prefix set on the project, strip it if it's present
         version = self.version
-        if self.prefix and self.version.startswith(self.prefix):
-            version = self.version[len(self.prefix) :]
+        for prefix in self.prefixes:
+            if prefix and self.version.startswith(prefix):
+                version = self.version[len(prefix) :]
 
         # Many projects prefix their tags with 'v', so strip it if it's present
         if v_prefix.match(version):

--- a/anitya/templates/project_new.html
+++ b/anitya/templates/project_new.html
@@ -150,7 +150,9 @@
     $("#version_url").tooltip();
     $("#version_prefix").prop('title', "Prefix filled here will be removed " +
         "from retrieved version. For example version prefix " +
-        "'v' will convert 'v1.2.3' to '1.2.3'.");
+        "'v' will convert 'v1.2.3' to '1.2.3'. " +
+        "It's possible to specify multiple prefixes split by ';' like this " +
+        "'v;release'.");
     $("#version_prefix").tooltip();
     $("#regex").prop('title', "Python regex to use for version retrieval. " +
         "Matched groups will be concatenated by '.'. " +

--- a/anitya/tests/lib/versions/test_base.py
+++ b/anitya/tests/lib/versions/test_base.py
@@ -78,6 +78,19 @@ class VersionTests(unittest.TestCase):
         version = base.Version(version="release-v1.0.0", prefix="release-")
         self.assertEqual("1.0.0", version.parse())
 
+    def test_parse_with_multiple_prefixes(self):
+        """ Assert parsing is working when multiple prefixes are provided. """
+        version = base.Version(version="release_db-1.2.3", prefix="release_db-;release")
+        self.assertEqual("1.2.3", version.parse())
+
+    def test_parse_with_multiple_prefixes_one_empty(self):
+        """
+        Assert parsing is working when multiple prefixes are provided and one
+        is empty string.
+        """
+        version = base.Version(version="release_db-1.2.3", prefix="release_db-; ")
+        self.assertEqual("1.2.3", version.parse())
+
     def test_prerelease(self):
         """Assert prerelease is defined and returns False"""
         version = base.Version(version="v1.0.0")

--- a/news/655.feature
+++ b/news/655.feature
@@ -1,0 +1,1 @@
+Support multiple version prefixes

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ sqlalchemy >= 0.9
 straight.plugin
 ordered-set
 psycopg2
-pyasn1 >= 0.4.1
+pyasn1 <0.5.0,>=0.4.1
 pytoml
 wtforms
 arrow


### PR DESCRIPTION
Fixes #655 

This PR add support for multiple prefixes. See screenshots bellow.

# Project before
![Screenshot from 2019-04-08 13-12-02](https://user-images.githubusercontent.com/6943409/55733836-cb6dcc00-5a1e-11e9-802b-19582d0cbc00.png)

# Example prefixes
![Screenshot from 2019-04-08 13-15-24](https://user-images.githubusercontent.com/6943409/55733833-cad53580-5a1e-11e9-8b92-1140e20d381b.png)

# Project after
![Screenshot from 2019-04-08 13-13-58](https://user-images.githubusercontent.com/6943409/55733834-cb6dcc00-5a1e-11e9-86f7-db2888b48777.png)



Signed-off-by: Michal Konečný <mkonecny@redhat.com>