### PR TITLE
Add If-Modified-Since field to call URL header

### DIFF
--- a/anitya/db/models.py
+++ b/anitya/db/models.py
@@ -284,6 +284,36 @@ class Project(Base):
         sorted_versions = self.get_sorted_version_objects()
         return [str(v) for v in sorted_versions]
 
+    def get_last_created_version(self):
+        """
+        Returns last obtained release by date.
+
+        Returns:
+            (`ProjectVersion`): Version object or None, if project doesn't have any version yet.
+        """
+        if self.versions_obj:
+            sorted_versions = sorted(
+                self.versions_obj, key=lambda x: x.created_on, reverse=True
+            )
+            return sorted_versions[0]
+
+        return None
+
+    def get_time_last_created_version(self):
+        """
+        Returns creation time of latest version sorted by time of creation.
+
+        Returns:
+            (`arrow.Arrow`): Time of the latest created version or None,
+                if project doesn't have any version yet.
+        """
+        version = self.get_last_created_version()
+
+        if version and version.created_on:
+            return arrow.get(version.created_on)
+
+        return None
+
     def create_version_objects(self, versions):
         """
         Creates sorted list of version objects defined by `self.version_class` from versions list.

--- a/anitya/lib/backends/cran.py
+++ b/anitya/lib/backends/cran.py
@@ -71,12 +71,16 @@ class CranBackend(BaseBackend):
         """
         url = "https://crandb.r-pkg.org/{name}".format(name=project.name)
 
+        last_change = project.get_time_last_created_version()
         try:
-            response = cls.call_url(url)
+            response = cls.call_url(url, last_change=last_change)
         except requests.RequestException as e:  # pragma: no cover
             raise AnityaPluginException("Could not contact {}: {}".format(url, str(e)))
 
         if response.status_code != 200:
+            # Not modified
+            if response.status_code == 304:
+                return None
             raise AnityaPluginException(
                 "Failed to download from {}: {} {}".format(
                     url, response.status_code, response.reason
@@ -126,13 +130,17 @@ class CranBackend(BaseBackend):
 
         """
         url = cls.get_version_url(project)
+        last_change = project.get_time_last_created_version()
 
         try:
-            response = cls.call_url(url)
+            response = cls.call_url(url, last_change=last_change)
         except requests.RequestException as e:  # pragma: no cover
             raise AnityaPluginException("Could not contact {}: {}".format(url, str(e)))
 
         if response.status_code != 200:
+            # Not modified
+            if response.status_code == 304:
+                return []
             raise AnityaPluginException(
                 "Failed to download from {}: {} {}".format(
                     url, response.status_code, response.reason

--- a/anitya/lib/backends/crates.py
+++ b/anitya/lib/backends/crates.py
@@ -145,8 +145,9 @@ class CratesBackend(BaseBackend):
                 was in an unexpected format.
         """
         url = cls.get_version_url(project)
+        last_change = project.get_time_last_created_version()
         try:
-            req = cls.call_url(url)
+            req = cls.call_url(url, last_change=last_change)
             req.raise_for_status()
             data = req.json()
         except requests.RequestException as e:

--- a/anitya/lib/backends/folder.py
+++ b/anitya/lib/backends/folder.py
@@ -74,16 +74,22 @@ class FolderBackend(BaseBackend):
 
         """
         url = cls.get_version_url(project)
+        last_change = project.get_time_last_created_version()
 
         try:
-            req = cls.call_url(url, insecure=project.insecure)
+            req = cls.call_url(url, last_change=last_change, insecure=project.insecure)
         except Exception as err:
             raise AnityaPluginException(
                 'Could not call : "%s" of "%s", with error: %s'
                 % (url, project.name, str(err))
             )
 
-        versions = None
+        versions = []
+
+        # Not modified
+        if req.status_code == 304:
+            return versions
+
         if not isinstance(req, six.string_types):
             req = req.text
 

--- a/anitya/lib/backends/gitlab.py
+++ b/anitya/lib/backends/gitlab.py
@@ -112,11 +112,15 @@ class GitlabBackend(BaseBackend):
                 "Project %s was incorrectly set-up" % project.name
             )
 
-        resp = cls.call_url(url)
+        last_change = project.get_time_last_created_version()
+        resp = cls.call_url(url, last_change=last_change)
 
-        if resp.ok:
+        if resp.status_code == 200:
             json = resp.json()
         else:
+            # Not modified
+            if resp.status_code == 304:
+                return []
             raise AnityaPluginException(
                 '%s: Server responded with status "%s": "%s"'
                 % (project.name, resp.status_code, resp.reason)

--- a/anitya/lib/backends/gnu.py
+++ b/anitya/lib/backends/gnu.py
@@ -73,15 +73,20 @@ class GnuBackend(BaseBackend):
 
         """
         url = cls.get_version_url(project)
+        last_change = project.get_time_last_created_version()
 
         try:
-            req = cls.call_url(url)
+            req = cls.call_url(url, last_change=last_change)
         except Exception:  # pragma: no cover
             raise AnityaPluginException(
                 'Could not call : "%s" of "%s"' % (url, project.name)
             )
 
-        versions = None
+        versions = []
+        # Not modified
+        if req.status_code == 304:
+            return versions
+
         try:
             regex = REGEX % {"name": project.name}
             versions = get_versions_by_regex_for_text(req.text, url, regex, project)

--- a/anitya/lib/backends/npmjs.py
+++ b/anitya/lib/backends/npmjs.py
@@ -41,11 +41,16 @@ class NpmjsBackend(BaseBackend):
 
         """
         url = cls.get_version_url(project)
+        last_change = project.get_time_last_created_version()
 
         try:
-            req = cls.call_url(url)
+            req = cls.call_url(url, last_change=last_change)
         except Exception:  # pragma: no cover
             raise AnityaPluginException("Could not contact %s" % url)
+
+        # Not modified
+        if req.status_code == 304:
+            return None
 
         try:
             data = req.json()
@@ -91,11 +96,16 @@ class NpmjsBackend(BaseBackend):
 
         """
         url = cls.get_version_url(project)
+        last_change = project.get_time_last_created_version()
 
         try:
-            req = cls.call_url(url)
+            req = cls.call_url(url, last_change=last_change)
         except Exception:  # pragma: no cover
             raise AnityaPluginException("Could not contact %s" % url)
+
+        # Not modified
+        if req.status_code == 304:
+            return []
 
         try:
             data = req.json()

--- a/anitya/lib/backends/packagist.py
+++ b/anitya/lib/backends/packagist.py
@@ -84,10 +84,15 @@ class PackagistBackend(BaseBackend):
                 "Project {} is not correctly set-up.".format(project.name)
             )
 
+        last_change = project.get_time_last_created_version()
         try:
-            req = cls.call_url(url)
+            req = cls.call_url(url, last_change=last_change)
         except Exception:  # pragma: no cover
             raise AnityaPluginException("Could not contact %s" % url)
+
+        # Not modified
+        if req.status_code == 304:
+            return []
 
         try:
             data = req.json()

--- a/anitya/lib/backends/pagure.py
+++ b/anitya/lib/backends/pagure.py
@@ -70,10 +70,15 @@ class PagureBackend(BaseBackend):
 
         """
         url = cls.get_version_url(project)
+        last_change = project.get_time_last_created_version()
         try:
-            req = cls.call_url(url)
+            req = cls.call_url(url, last_change=last_change)
         except Exception as err:  # pragma: no cover
             raise AnityaPluginException("Could not contact %s: %s" % (url, str(err)))
+
+        # Not modified
+        if req.status_code == 304:
+            return []
 
         try:
             data = req.json()

--- a/anitya/lib/backends/pypi.py
+++ b/anitya/lib/backends/pypi.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 
 """
- (c) 2014-2016 - Copyright Red Hat Inc
+ (c) 2014-2019 - Copyright Red Hat Inc
 
  Authors:
    Pierre-Yves Chibon <pingou@pingoured.fr>
    Ralph Bean <rbean@redhat.com>
+   Michal Konecny <mkonecny@redhat.com>
 
 """
 
@@ -39,10 +40,15 @@ class PypiBackend(BaseBackend):
 
         """
         url = cls.get_version_url(project)
+        last_change = project.get_time_last_created_version()
         try:
-            req = cls.call_url(url)
+            req = cls.call_url(url, last_change=last_change)
         except Exception:  # pragma: no cover
             raise AnityaPluginException("Could not contact %s" % url)
+
+        # Not modified
+        if req.status_code == 304:
+            return None
 
         try:
             data = req.json()
@@ -83,10 +89,15 @@ class PypiBackend(BaseBackend):
 
         """
         url = cls.get_version_url(project)
+        last_change = project.get_time_last_created_version()
         try:
-            req = cls.call_url(url)
+            req = cls.call_url(url, last_change=last_change)
         except Exception:  # pragma: no cover
             raise AnityaPluginException("Could not contact %s" % url)
+
+        # Not modified
+        if req.status_code == 304:
+            return []
 
         try:
             data = req.json()

--- a/anitya/lib/backends/rubygems.py
+++ b/anitya/lib/backends/rubygems.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 
 """
- (c) 2014-2016 - Copyright Red Hat Inc
+ (c) 2014-2019 - Copyright Red Hat Inc
 
  Authors:
    Pierre-Yves Chibon <pingou@pingoured.fr>
    Ralph Bean <rbean@redhat.com>
+   Michal Konecny <mkonecny@redhat.com>
 
 """
 
@@ -73,10 +74,15 @@ class RubygemsBackend(BaseBackend):
         """
         url = cls.get_version_url(project)
 
+        last_change = project.get_time_last_created_version()
         try:
-            req = cls.call_url(url)
+            req = cls.call_url(url, last_change=last_change)
         except Exception:  # pragma: no cover
             raise AnityaPluginException("Could not contact %s" % url)
+
+        # Not modified
+        if req.status_code == 304:
+            return []
 
         try:
             data = req.json()

--- a/anitya/tests/lib/backends/test_folder.py
+++ b/anitya/tests/lib/backends/test_folder.py
@@ -119,7 +119,23 @@ class FolderBackendtests(DatabaseTestCase):
             self.assertRaises(
                 AnityaPluginException, backend.FolderBackend.get_versions, project
             )
-            m_call.assert_called_with(project.version_url, insecure=True)
+            m_call.assert_called_with(
+                project.version_url, last_change=None, insecure=True
+            )
+
+    def test_folder_get_versions_not_modified(self):
+        """Assert that not modified response is handled correctly"""
+        pid = 2
+        project = models.Project.get(self.session, pid)
+
+        with mock.patch("anitya.lib.backends.BaseBackend.call_url") as m_call:
+            m_call.return_value = mock.Mock(status_code=304)
+            versions = backend.FolderBackend.get_versions(project)
+
+            m_call.assert_called_with(
+                project.version_url, last_change=None, insecure=True
+            )
+            self.assertEqual(versions, [])
 
     def test_folder_get_versions(self):
         """ Test the get_versions function of the folder backend. """

--- a/anitya/tests/lib/backends/test_gitlab.py
+++ b/anitya/tests/lib/backends/test_gitlab.py
@@ -24,6 +24,7 @@ Anitya tests for the GitLab backend.
 """
 
 import unittest
+import mock
 
 import anitya.lib.backends.gitlab as backend
 from anitya.db import models
@@ -205,6 +206,22 @@ class GitlabBackendtests(DatabaseTestCase):
         self.assertRaises(
             AnityaPluginException, backend.GitlabBackend.get_versions, project
         )
+
+    def test_get_versions_not_modified(self):
+        """Assert that not modified response is handled correctly"""
+        pid = 1
+        project = models.Project.get(self.session, pid)
+        exp_url = (
+            "https://gitlab.gnome.org/api/v4/projects/GNOME%2Fgnome-video-arcade/"
+            "repository/tags"
+        )
+
+        with mock.patch("anitya.lib.backends.BaseBackend.call_url") as m_call:
+            m_call.return_value = mock.Mock(status_code=304)
+            versions = backend.GitlabBackend.get_versions(project)
+
+            m_call.assert_called_with(exp_url, last_change=None)
+            self.assertEqual(versions, [])
 
 
 if __name__ == "__main__":

--- a/anitya/tests/lib/backends/test_gnu.py
+++ b/anitya/tests/lib/backends/test_gnu.py
@@ -24,6 +24,7 @@ anitya tests for the custom backend.
 """
 
 import unittest
+import mock
 
 import anitya.lib.backends.gnu as backend
 from anitya.db import models
@@ -136,6 +137,19 @@ class GnuBackendtests(DatabaseTestCase):
         self.assertRaises(
             AnityaPluginException, backend.GnuBackend.get_version, project
         )
+
+    def test_get_versions_not_modified(self):
+        """Assert that not modified response is handled correctly"""
+        pid = 1
+        project = models.Project.get(self.session, pid)
+        exp_url = "https://ftp.gnu.org/gnu/gnash/"
+
+        with mock.patch("anitya.lib.backends.BaseBackend.call_url") as m_call:
+            m_call.return_value = mock.Mock(status_code=304)
+            versions = backend.GnuBackend.get_versions(project)
+
+            m_call.assert_called_with(exp_url, last_change=None)
+            self.assertEqual(versions, [])
 
 
 if __name__ == "__main__":

--- a/anitya/tests/lib/backends/test_npmjs.py
+++ b/anitya/tests/lib/backends/test_npmjs.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2014  Red Hat, Inc.
+# Copyright © 2014-2019  Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions
@@ -24,6 +24,7 @@ anitya tests for the custom backend.
 """
 
 import unittest
+import mock
 
 import anitya.lib.backends.npmjs as backend
 from anitya.db import models
@@ -102,6 +103,19 @@ class NpmjsBackendtests(DatabaseTestCase):
         obs = backend.NpmjsBackend.get_version_url(project)
 
         self.assertEqual(obs, exp)
+
+    def test_get_version_not_modified(self):
+        """Assert that not modified response is handled correctly"""
+        pid = 1
+        project = models.Project.get(self.session, pid)
+        exp_url = "https://registry.npmjs.org/request"
+
+        with mock.patch("anitya.lib.backends.BaseBackend.call_url") as m_call:
+            m_call.return_value = mock.Mock(status_code=304)
+            versions = backend.NpmjsBackend.get_version(project)
+
+            m_call.assert_called_with(exp_url, last_change=None)
+            self.assertEqual(versions, None)
 
     def test_get_versions(self):
         """ Test the get_versions function of the npmjs backend. """
@@ -260,6 +274,19 @@ class NpmjsBackendtests(DatabaseTestCase):
         ]
         obs = backend.NpmjsBackend.get_ordered_versions(project)
         self.assertEqual(obs, exp)
+
+    def test_get_versions_not_modified(self):
+        """Assert that not modified response is handled correctly"""
+        pid = 1
+        project = models.Project.get(self.session, pid)
+        exp_url = "https://registry.npmjs.org/request"
+
+        with mock.patch("anitya.lib.backends.BaseBackend.call_url") as m_call:
+            m_call.return_value = mock.Mock(status_code=304)
+            versions = backend.NpmjsBackend.get_versions(project)
+
+            m_call.assert_called_with(exp_url, last_change=None)
+            self.assertEqual(versions, [])
 
     def test_npmjs_check_feed(self):
         """ Test the check_feed method of the npmjs backend. """

--- a/anitya/tests/lib/backends/test_packagist.py
+++ b/anitya/tests/lib/backends/test_packagist.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2014  Red Hat, Inc.
+# Copyright © 2014-2019  Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions
@@ -24,6 +24,7 @@ anitya tests for the packagist backend.
 """
 
 import unittest
+import mock
 
 import anitya.lib.backends.packagist as backend
 from anitya.db import models
@@ -194,6 +195,19 @@ class PackagistBackendtests(DatabaseTestCase):
         self.assertRaises(
             AnityaPluginException, backend.PackagistBackend.get_versions, project
         )
+
+    def test_packagist_get_versions_not_modified(self):
+        """Assert that not modified response is handled correctly"""
+        pid = 1
+        project = models.Project.get(self.session, pid)
+        exp_url = "https://packagist.org/packages/phpunit/php-code-coverage.json"
+
+        with mock.patch("anitya.lib.backends.BaseBackend.call_url") as m_call:
+            m_call.return_value = mock.Mock(status_code=304)
+            versions = backend.PackagistBackend.get_versions(project)
+
+            m_call.assert_called_with(exp_url, last_change=None)
+            self.assertEqual(versions, [])
 
 
 if __name__ == "__main__":

--- a/anitya/tests/lib/backends/test_pypi.py
+++ b/anitya/tests/lib/backends/test_pypi.py
@@ -23,6 +23,8 @@
 anitya tests for the pypi backend.
 """
 
+import mock
+
 import anitya.lib.backends.pypi as backend
 from anitya.db import models
 from anitya.lib.exceptions import AnityaPluginException
@@ -66,6 +68,24 @@ class PypiBackendtests(DatabaseTestCase):
         obs = backend.PypiBackend.get_version(project)
         self.assertEqual(obs, "1.1.2")
 
+    def test_pypi_get_version_not_modified(self):
+        """Assert that not modified response is handled correctly"""
+        project = models.Project(
+            name="repo_manager",
+            homepage="https://pypi.org/project/repo_manager/",
+            backend=BACKEND,
+        )
+        self.session.add(project)
+        self.session.commit()
+        exp_url = "https://pypi.org/pypi/repo_manager/json"
+
+        with mock.patch("anitya.lib.backends.BaseBackend.call_url") as m_call:
+            m_call.return_value = mock.Mock(status_code=304)
+            versions = backend.PypiBackend.get_version(project)
+
+            m_call.assert_called_with(exp_url, last_change=None)
+            self.assertEqual(versions, None)
+
     def test_get_version_url(self):
         """
         Assert that correct url is returned.
@@ -92,6 +112,24 @@ class PypiBackendtests(DatabaseTestCase):
 
         obs = backend.PypiBackend.get_versions(project)
         self.assertEqual(obs, exp)
+
+    def test_pypi_get_versions_not_modified(self):
+        """Assert that not modified response is handled correctly"""
+        project = models.Project(
+            name="repo_manager",
+            homepage="https://pypi.org/project/repo_manager/",
+            backend=BACKEND,
+        )
+        self.session.add(project)
+        self.session.commit()
+        exp_url = "https://pypi.org/pypi/repo_manager/json"
+
+        with mock.patch("anitya.lib.backends.BaseBackend.call_url") as m_call:
+            m_call.return_value = mock.Mock(status_code=304)
+            versions = backend.PypiBackend.get_versions(project)
+
+            m_call.assert_called_with(exp_url, last_change=None)
+            self.assertEqual(versions, [])
 
     def test_pypi_check_feed(self):
         """ Test the check_feed method of the pypi backend. """

--- a/anitya/tests/lib/backends/test_rubygems.py
+++ b/anitya/tests/lib/backends/test_rubygems.py
@@ -24,6 +24,7 @@ anitya tests for the custom backend.
 """
 
 import unittest
+import mock
 
 import anitya.lib.backends.rubygems as backend
 from anitya.db import models
@@ -100,6 +101,19 @@ class RubygemsBackendtests(DatabaseTestCase):
         self.assertRaises(
             AnityaPluginException, backend.RubygemsBackend.get_version, project
         )
+
+    def test_rubygems_get_versions_not_modified(self):
+        """Assert that not modified response is handled correctly"""
+        pid = 1
+        project = models.Project.get(self.session, pid)
+        exp_url = "https://rubygems.org/api/v1/versions/bio/latest.json"
+
+        with mock.patch("anitya.lib.backends.BaseBackend.call_url") as m_call:
+            m_call.return_value = mock.Mock(status_code=304)
+            versions = backend.RubygemsBackend.get_versions(project)
+
+            m_call.assert_called_with(exp_url, last_change=None)
+            self.assertEqual(versions, [])
 
     def test_rubygems_check_feed(self):
         """ Test the check_feed method of the rubygems backend. """

--- a/anitya/tests/request-data/anitya.tests.lib.backends.test_init.BaseBackendTests.test_call_url_last_change
+++ b/anitya/tests/request-data/anitya.tests.lib.backends.test_init.BaseBackendTests.test_call_url_last_change
@@ -1,0 +1,44 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      From:
+      - admin@fedoraproject.org
+      If-modified-since:
+      - Tue, 07 May 2019 12:36:59 GMT
+      User-Agent:
+      - Anitya 0.15.1 at release-monitoring.org
+    method: GET
+    uri: https://www.example.com/
+  response:
+    body:
+      string: ''
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - max-age=604800
+      Date:
+      - Tue, 07 May 2019 12:37:00 GMT
+      Etag:
+      - '"1541025663+ident"'
+      Expires:
+      - Tue, 14 May 2019 12:37:00 GMT
+      Last-Modified:
+      - Fri, 09 Aug 2013 23:54:35 GMT
+      Server:
+      - ECS (dcb/7F18)
+      Vary:
+      - Accept-Encoding
+      X-Cache:
+      - HIT
+    status:
+      code: 304
+      message: Not Modified
+version: 1

--- a/news/730.feature
+++ b/news/730.feature
@@ -1,0 +1,1 @@
+Check for new versions only when there is any change on the URL till last version was retrieved


### PR DESCRIPTION
This prevents downloading the page each time check is performed
on project. Instead use the time when latest version was obtained as
reference in If-Modified-Since field in HTML header.

Closes #730 

Signed-off-by: Michal Konečný <mkonecny@redhat.com>