### PR TITLE
Add option to check releases instead tags on GitHub

### DIFF
--- a/anitya/db/migrations/versions/5e209766aead_add_release_check_to_project.py
+++ b/anitya/db/migrations/versions/5e209766aead_add_release_check_to_project.py
@@ -1,0 +1,33 @@
+"""Add release check to project
+
+Revision ID: 5e209766aead
+Revises: e34988f3e2f4
+Create Date: 2019-06-06 14:53:06.236820
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "5e209766aead"
+down_revision = "e34988f3e2f4"
+
+
+def upgrade():
+    """ Add releases_only column to the projects table. """
+    op.add_column(
+        "projects",
+        sa.Column(
+            "releases_only",
+            sa.Boolean(),
+            default=False,
+            server_default="FALSE",
+            nullable=False,
+        ),
+    )
+
+
+def downgrade():
+    """ Drop releases_only column to the projects table. """
+    op.drop_column("projects", "releases_only")

--- a/anitya/db/models.py
+++ b/anitya/db/models.py
@@ -211,6 +211,8 @@ class Project(Base):
             to the HTML from ``version_url`` to find versions.
         insecure (sa.Boolean): Whether or not to validate the x509 certificate
             offered by the server at ``version_url``. Defaults to ``False``.
+        releases_only (sa.Boolean): Whether or not to check releases instead of tags.
+            This is now only used by GitHub backend.
         latest_version (sa.Boolean): The latest version for the project, as determined
             by the version sorting algorithm.
         logs (sa.Text): The result of the last update.
@@ -238,6 +240,7 @@ class Project(Base):
     regex = sa.Column(sa.String(200), nullable=True)
     version_prefix = sa.Column(sa.String(200), nullable=True)
     insecure = sa.Column(sa.Boolean, nullable=False, default=False)
+    releases_only = sa.Column(sa.Boolean, nullable=False, default=False)
     version_scheme = sa.Column(sa.String(50), nullable=True)
 
     latest_version = sa.Column(sa.String(50))

--- a/anitya/forms.py
+++ b/anitya/forms.py
@@ -39,6 +39,9 @@ class ProjectForm(FlaskForm):
     check_release = BooleanField(
         "Check latest release on submit", [validators.optional()]
     )
+    releases_only = BooleanField(
+        "Check releases instead of tags", [validators.optional()]
+    )
 
     def __init__(self, *args, **kwargs):
         """ Calls the default constructor with the normal argument but

--- a/anitya/lib/utilities.py
+++ b/anitya/lib/utilities.py
@@ -295,6 +295,7 @@ def create_project(
     regex=None,
     check_release=False,
     insecure=False,
+    releases_only=False,
 ):
     """ Create the project in the database.
 
@@ -308,6 +309,7 @@ def create_project(
         regex=regex,
         version_prefix=version_prefix,
         insecure=insecure,
+        releases_only=releases_only,
     )
 
     session.add(project)
@@ -345,6 +347,7 @@ def edit_project(
     version_prefix,
     regex,
     insecure,
+    releases_only,
     user_id,
     check_release=False,
 ):
@@ -385,6 +388,10 @@ def edit_project(
             changes["regex"] = {"old": old, "new": project.regex}
     if insecure != project.insecure:
         old = project.insecure
+        project.insecure = insecure
+        changes["insecure"] = {"old": old, "new": project.insecure}
+    if releases_only != project.releases_only:
+        old = project.releases_only
         project.insecure = insecure
         changes["insecure"] = {"old": old, "new": project.insecure}
 

--- a/anitya/templates/project_new.html
+++ b/anitya/templates/project_new.html
@@ -49,20 +49,23 @@
               <td><label>Examples:</label></td>
               <td id="example_urls"></td>
             </tr>
+            <tr id="releases_only_row">
+              {{ render_field_in_row(form.releases_only, tabindex=8) }}
+            </tr>
             <tr id="insecure_row">
-              {{ render_field_in_row(form.insecure, tabindex=7) }}
+              {{ render_field_in_row(form.insecure, tabindex=9) }}
             </tr>
             <tr id="check_release_row">
-              {{ render_field_in_row(form.check_release, tabindex=8) }}
+              {{ render_field_in_row(form.check_release, tabindex=10) }}
             </tr>
 
             {%- if context == 'Add' -%}
             <tr>
-              {{ render_field_in_row(form.distro, tabindex=9) }}
+              {{ render_field_in_row(form.distro, tabindex=11) }}
               <td></td>
             </tr>
             <tr>
-              {{ render_field_in_row(form.package_name, tabindex=10) }}
+              {{ render_field_in_row(form.package_name, tabindex=12) }}
               <td></td>
             </tr>
             {%- endif -%}
@@ -147,6 +150,9 @@
         "For example regex '(\d)_(\d)_(\d)' applied to '1_2_3' " +
         "will convert version to '1.2.3'.");
     $("#regex").tooltip();
+    $("#releases_only").prop('title', "Check releases instead of tags " +
+        "when checking for new releases");
+    $("#releases_only").tooltip();
     $("#insecure").prop('title', "This should only be set when the version URL " +
         "is HTTPS and the host does not have a trusted certificate");
     $("#insecure").tooltip();
@@ -173,6 +179,7 @@
     $('#default_regex_row').hide();
     $('#version_url_row').hide();
     $('#insecure_row').hide();
+    $('#releases_only_row').hide();
     $('#regex').attr('placeholder', '');
 
     $("label[for='version_url']").text('Version URL');
@@ -188,6 +195,7 @@
       $("#version_url").prop('title', "Owner/project from GitHub. " +
         "For example if the project URL is 'https://github.com/fedora-infra/fedocal' " +
         "this field should contain 'fedora-infra/fedocal'.");
+      $('#releases_only_row').show();
     };
     if (str == 'GitLab'){
       $("label[for='version_url']").text('GitLab project url');

--- a/anitya/tests/lib/test_utilities.py
+++ b/anitya/tests/lib/test_utilities.py
@@ -117,6 +117,7 @@ class EditProjectTests(DatabaseTestCase):
             regex=None,
             insecure=False,
             user_id="noreply@fedoraproject.org",
+            releases_only=True,
         )
 
         project_objs = models.Project.all(self.session)
@@ -153,6 +154,7 @@ class EditProjectTests(DatabaseTestCase):
             regex=project_objs[2].regex,
             insecure=False,
             user_id="noreply@fedoraproject.org",
+            releases_only=False,
         )
 
     def test_edit_project_insecure(self):
@@ -176,6 +178,7 @@ class EditProjectTests(DatabaseTestCase):
             regex=project_objs[0].regex,
             insecure=True,
             user_id="noreply@fedoraproject.org",
+            releases_only=False,
         )
 
         project_objs = models.Project.all(self.session)

--- a/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_get_versions_releases_only
+++ b/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_get_versions_releases_only
@@ -1,0 +1,96 @@
+interactions:
+- request:
+    body: '{"query": "\n{\n    repository(owner: \"fedora-infra\", name: \"the-new-hotness\")
+      {\n        releases (orderBy: {field: CREATED_AT, direction: DESC}, first: 50)
+      {\n            totalCount\n            edges {\n                cursor\n                node
+      {\n                    name\n                    tag { target { commitUrl }
+      }\n                }\n            }\n        }\n    }\n    rateLimit {\n        limit\n        remaining\n        resetAt\n    }\n}"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - bearer foobar
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '464'
+      Content-Type:
+      - application/json
+      From:
+      - admin@fedoraproject.org
+      User-Agent:
+      - Anitya 0.15.1 at release-monitoring.org
+    method: POST
+    uri: https://api.github.com/graphql
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7WWW2+jVhSF/0rFcxyf+8Vvuciq1AJjOZNqWvXhXBMiB1IgBRz1v3cfZ6R6+oQf
+        sGQZc7h9rL3XXh+ZN73JNh9ZG96aruqbdvr8dwimC13a7pveHO6a97rPNphcZcE/pYU/PjL33nZN
+        m22yb/RxckRPZf1tKt9+4fnLzVju0VDs0VRud1P+0Iz5fTMUd92QvzRDnrPb+/0WZVdZ3fiQ7lKb
+        V/jN+uewqsOwem76OnTdT3+ja4yvNRzYm6fT05j2KcCTwN2b19eq/9oe4LTnvn/rNuv1U9U/v9tr
+        WFrH4JvWrKo6tmb9v8uuP89dM8QZp8RS4RkxVBgTifJaW2Ix00Fyw6TzRmf/wOdqPvBYAHD50KCi
+        OgP+Qr7OBVYLAWsUheZBY2cMiZp5LIhw0RsshdDSKqI0c1ZcDJwfmyMoeyz358A7PhdYLgQcgozM
+        KKkCczoqG4MSISruQowxRB4cYTIafjkwqHsq6ekMuPzry1xgsRCwi5EjGiIUsUeGOqGsj5xIpJHU
+        KljqFI9R0MuB7xsEJT3l5z1c/jbMBU6lsEQPCxIVxcRzLrG2gXiAT5oyryMKhimHSBBWXgo8JFjo
+        4+MPplXwVKmzTIstBGyUxdJH6bXDDDvGMDUMXgL2mAWvtJTUM+Mu6+FiuxuL+wZDH+P8vKRv6/e5
+        wHQhYIS8MmBbYMneKYU0V0hZ6r2mghOulOKeYc5mK5xPaMzxLil8TMAnl344jaUb/Ui3c4HJQsCC
+        QBVHiSMjUnmBmIuWRcwNZSAzhX72hjOrLgEeYA6PxUszlaDyD8C3x7u5wHghYKqEk4jioA0i2PgI
+        49hpTQNVISJHYH/kXPj5wBUai8eTwjgFjpNLf1dY2sef5wKnhLKEaTHoYOOoYpI6KWHqAqIwVmkv
+        NMxoTTzxgpn5PZzv0QgKD0ld+I4nl/4OzNH2bR4whK3FgLGWlGOYxxCqKLg1p44KBS/BOnA07jnF
+        mqBZChepf+/QkB92KWWl4IHz/4LHzcjKl7nASynsoW4DxCosDE+lHLnlFsYvtDUylllwMIWVJyfg
+        PyFdZq3pw68VRNoUbg+fGxwhBCvh1VR1VUMAZlrrtKML/Q0cmBGE9QqJFZIPGG0w2yD6e7rkv17L
+        SETZCwAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Cache-Control:
+      - no-cache
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 07 Jun 2019 09:14:04 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Accepted-OAuth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v4; format=json
+      X-GitHub-Request-Id:
+      - BE56:78E8:180B0F6:2EEE4A2:5CFA2ADB
+      X-OAuth-Scopes:
+      - repo:status
+      X-RateLimit-Limit:
+      - '5000'
+      X-RateLimit-Remaining:
+      - '4999'
+      X-RateLimit-Reset:
+      - '1559902443'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -488,6 +488,7 @@ def new_project():
                 regex=form.regex.data.strip() or None,
                 user_id=flask.g.user.username,
                 check_release=form.check_release.data,
+                releases_only=form.releases_only.data,
             )
             Session.commit()
 
@@ -562,6 +563,7 @@ def edit_project(project_id):
                 insecure=form.insecure.data,
                 user_id=flask.g.user.username,
                 check_release=form.check_release.data,
+                releases_only=form.releases_only.data,
             )
             if changes:
                 flask.flash("Project edited")

--- a/news/733.feature
+++ b/news/733.feature
@@ -1,0 +1,1 @@
+Allow fetching releases on Github backend


### PR DESCRIPTION
Add new `releases_only` check on project and new call for GitHub API v4
which is checking releases instead of tags.

Fixes #733

Fixes #734

Signed-off-by: Michal Konečný <mkonecny@redhat.com>