### PR TITLE
Fix: Counters saved to database are always 0

### DIFF
--- a/news/795.bug
+++ b/news/795.bug
@@ -1,0 +1,1 @@
+Check service: Counters saved to database are always 0


### PR DESCRIPTION
Statistics were saved to database before the actual check was finished.
This commit is adding wait for every thread executed in the pool.

Fixes #795

Signed-off-by: Michal Konečný <mkonecny@redhat.com>