### PR TITLE
Restore missing closing """ in sample configuration

### DIFF
--- a/files/anitya.toml.sample
+++ b/files/anitya.toml.sample
@@ -55,6 +55,8 @@ librariesio_platform_whitelist = []
 default_regex = """\
                 (?i)%(name)s(?:[-_]?(?:minsrc|src|source))?[-_]([^-/_\\s]+?)(?:[-_]\
                 (?:minsrc|src|source|asc|release))?\\.(?:tar|t[bglx]z|tbz2|zip)\
+                """
+
 # Github access token
 # This is used by GitHub API for github backend
 github_access_token = "foobar"

--- a/news/PR797.bug
+++ b/news/PR797.bug
@@ -1,0 +1,1 @@
+Restore missing closing """ in sample configuration


### PR DESCRIPTION
A previous commit has removed the closing """ from the default_regex
string. This commits adds it back.