### PR TITLE
Fix ansible issues

### DIFF
--- a/ansible/roles/anitya-dev/tasks/librariesio.yml
+++ b/ansible/roles/anitya-dev/tasks/librariesio.yml
@@ -3,7 +3,7 @@
 - name: Install sseclient
   dnf:
     name: [
-            python-sseclient
+            python3-sseclient
           ]
     state: present
 

--- a/ansible/roles/anitya-dev/tasks/rabbitmq.yml
+++ b/ansible/roles/anitya-dev/tasks/rabbitmq.yml
@@ -21,6 +21,14 @@
 - name: Enables the rabbitmq management and SSL authentication plugins
   rabbitmq_plugin:
     names: rabbitmq_management,rabbitmq_auth_mechanism_ssl
+  notify:
+    - reload rabbitmq
+
+- name: Ensure that .erlang.cookie has correct owner
+  file:
+    path: /var/lib/rabbitmq/.erlang.cookie
+    owner: rabbitmq
+    group: rabbitmq
 
 - name: start rabbitmq
   service: name=rabbitmq-server state=started enabled=yes

--- a/news/804.dev
+++ b/news/804.dev
@@ -1,0 +1,1 @@
+Fix rabbitmq-server in dev environment


### PR DESCRIPTION
* Rabbitmq server couldn't start because of bad ownership of one file.
* Changed name of python-sseclient to python3-sseclient - reason: not
found.

Fixes #804

Signed-off-by: Michal Konečný <mkonecny@redhat.com>