### PR TITLE
Createdb.py fixes

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -2,7 +2,7 @@
 
 [alembic]
 # path to migration scripts
-script_location = anitya:db/migrations
+script_location = anitya/db/migrations
 
 # template used to generate migration files
 # file_template = %%(rev)s_%%(slug)s

--- a/anitya/lib/utilities.py
+++ b/anitya/lib/utilities.py
@@ -234,55 +234,6 @@ def log(session, project=None, distro=None, topic=None, message=None):
     return final_msg
 
 
-def init(db_url, alembic_ini=None, debug=False, create=False):  # pragma: no cover
-    """ Create the tables in the database using the information from the
-    url obtained.
-
-    :deprecated: This function is deprecated as of Anitya 0.12. Use the
-                 scoped session in :mod:`anitya.db`
-
-    :arg db_url, URL used to connect to the database. The URL contains
-        information with regards to the database engine, the host to
-        connect to, the user and password and the database name.
-          ie: <engine>://<user>:<password>@<host>/<dbname>
-    :kwarg alembic_ini, path to the alembic ini file. This is necessary
-        to be able to use alembic correctly, but not for the unit-tests.
-    :kwarg debug, a boolean specifying wether we should have the verbose
-        output of sqlalchemy or not.
-    :return a session that can be used to query the database.
-
-    """
-    engine = create_engine(db_url, echo=debug)
-
-    if create:
-        Base.metadata.create_all(engine)
-
-    # Source: https://docs.sqlalchemy.org/en/latest/dialects/sqlite.html
-    # see section 'sqlite-foreign-keys'
-    if db_url.startswith("sqlite:"):
-
-        def _fk_pragma_on_connect(dbapi_con, con_record):
-            dbapi_con.execute("PRAGMA foreign_keys=ON")
-
-        sa.event.listen(engine, "connect", _fk_pragma_on_connect)
-
-    if alembic_ini is not None:  # pragma: no cover
-        # then, load the Alembic configuration and generate the
-        # version table, "stamping" it with the most recent rev:
-        from alembic.config import Config
-        from alembic import command
-
-        alembic_cfg = Config(alembic_ini)
-        command.stamp(alembic_cfg, "head")
-
-    scopedsession = scoped_session(sessionmaker(bind=engine))
-
-    if create:
-        plugins.load_plugins(scopedsession)
-
-    return scopedsession
-
-
 def create_project(
     session,
     name,

--- a/anitya/lib/utilities.py
+++ b/anitya/lib/utilities.py
@@ -21,19 +21,15 @@
 
 import logging
 
-import sqlalchemy as sa
-from fedora_messaging import api, message, exceptions as fm_exceptions
-from sqlalchemy import create_engine
-from sqlalchemy.exc import SQLAlchemyError, IntegrityError
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.orm import scoped_session
-from sqlalchemy.orm.exc import NoResultFound
 import arrow
+from fedora_messaging import api, message, exceptions as fm_exceptions
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.orm.exc import NoResultFound
 
-from . import plugins, exceptions
 from anitya import config
-from anitya.db import models, Base
+from anitya.db import models
 
+from . import exceptions, plugins
 
 _log = logging.getLogger(__name__)
 

--- a/createdb.py
+++ b/createdb.py
@@ -1,7 +1,60 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from anitya.config import config
-from anitya.lib import utilities
+import os
+from argparse import ArgumentParser
+from pathlib import Path
 
-utilities.init(config["DB_URL"], None, debug=True, create=True)
+from alembic import command
+from alembic.config import Config
+from social_flask_sqlalchemy import models as social_models
+
+from anitya.app import create
+from anitya.config import load
+from anitya.db import Base, Session
+
+parser = ArgumentParser()
+
+script_dir = Path(__file__).parent.absolute()
+
+parser.add_argument("--debug", action="store_true", default=False, dest="verbose")
+parser.add_argument("--alembic-config", default=None)
+parser.add_argument(
+    "--db-uri",
+    default=None,
+    help="This will override the URLs specified in alembic and anitya",
+)
+
+args = parser.parse_args()
+
+alembic_config = args.alembic_config
+anitya_config = load()
+
+anitya_config["SQL_DEBUG"] = args.verbose
+
+if args.db_uri:
+    anitya_config["DB_URL"] = args.db_uri
+
+# An app object is required for social_auth tables to be created properly
+anitya_app = create(config=anitya_config)
+engine = Session.get_bind()
+
+Base.metadata.create_all(engine)
+
+# This call depends on app.create calling init_social which defines
+# necessary column information in the social_auth_usersocialauth table
+social_models.PSABase.metadata.create_all(engine)
+
+# Set the alembic_version based on the current migrations available.
+# This presupposes the models haven't changed outside of a migration.
+#
+# Default to the side-by-side alembic.ini.
+if alembic_config is None:
+    alembic_config = os.path.join(script_dir, "alembic.ini")
+    if args.verbose and os.path.isfile(alembic_config):
+        print("No alembic config specified, defaulting to: {}".format(alembic_config))
+
+if alembic_config and os.path.isfile(alembic_config):
+    alembic_cfg = Config(alembic_config)
+    alembic_cfg.set_main_option("sqlalchemy.url", anitya_config["DB_URL"])
+    command.stamp(alembic_cfg, "head")

--- a/news/PR817.bug
+++ b/news/PR817.bug
@@ -1,0 +1,1 @@
+Fix createdb.py to now create all tables properly


### PR DESCRIPTION
Fix createdb.py so that it creates the proper tables, including the social_auth tables. Stamp the alembic revision head if a config is provided.

Drop the old DB init code as it's stale.