### PR TITLE
Fix alembic migrations

### DIFF
--- a/anitya/db/migrations/versions/5e209766aead_add_release_check_to_project.py
+++ b/anitya/db/migrations/versions/5e209766aead_add_release_check_to_project.py
@@ -1,7 +1,7 @@
 """Add release check to project
 
 Revision ID: 5e209766aead
-Revises: e34988f3e2f4
+Revises: 708f6f26b4b6
 Create Date: 2019-06-06 14:53:06.236820
 """
 
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "5e209766aead"
-down_revision = "e34988f3e2f4"
+down_revision = "708f6f26b4b6"
 
 
 def upgrade():

--- a/anitya/db/migrations/versions/708f6f26b4b6_add_version_pattern.py
+++ b/anitya/db/migrations/versions/708f6f26b4b6_add_version_pattern.py
@@ -1,7 +1,7 @@
 """Add version pattern
 
 Revision ID: 708f6f26b4b6
-Revises: 1ab95561edae
+Revises: e34988f3e2f4
 Create Date: 2019-04-25 16:51:03.302314
 """
 
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "708f6f26b4b6"
-down_revision = "1ab95561edae"
+down_revision = "e34988f3e2f4"
 
 
 def upgrade():

--- a/anitya/db/migrations/versions/e34988f3e2f4_add_statistics_to_run.py
+++ b/anitya/db/migrations/versions/e34988f3e2f4_add_statistics_to_run.py
@@ -1,7 +1,7 @@
 """Add statistics to run
 
 Revision ID: e34988f3e2f4
-Revises: 708f6f26b4b6
+Revises: 1ab95561edae
 Create Date: 2019-03-14 15:41:11.614870
 """
 
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "e34988f3e2f4"
-down_revision = "708f6f26b4b6"
+down_revision = "1ab95561edae"
 
 
 def upgrade():

--- a/ansible/roles/anitya-dev/tasks/db.yml
+++ b/ansible/roles/anitya-dev/tasks/db.yml
@@ -50,8 +50,8 @@
 - name: Create /home/vagrant/alembic.ini
   replace:
     dest: /home/vagrant/alembic.ini
-    regexp: "^script_location = alembic*$"
-    replace: "script_location = devel/alembic"
+    regexp: "^script_location = anitya.*$"
+    replace: "script_location = devel/anitya/db/migrations"
 
 - name: Switch the database connection to postgres
   replace:

--- a/news/819.bug
+++ b/news/819.bug
@@ -1,0 +1,1 @@
+One revision is skipped when doing `alembic upgrade head`


### PR DESCRIPTION
* When using production database one revision was skipped. This was caused
by bad order of the revisions.

* Thanks to recent changes to alembic.ini one issue was found in ansible
script that tried to replace non-existing line in alembic.ini.

Fixes #819.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>