### PR TITLE
Print exception when thread crashes

### DIFF
--- a/news/PR824.bug
+++ b/news/PR824.bug
@@ -1,0 +1,1 @@
+No error was shown when check_service thread crashed


### PR DESCRIPTION
When thread crashes in ThreadPoolExecutor it doesn't print anything, but
the result is stored in Future object. This commit will check this
Future object and log exception if Thread crashed.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>