### PR TITLE
Add Dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,10 @@
+version: 1
+update_configs:
+  - package_manager: "python"
+    directory: "/"
+    update_schedule: "weekly"
+    default_labels:
+      - "dependencies"
+    default_reviewers:
+      - "jeremycline"
+      - "Zlopez"

--- a/news/PR844.dev
+++ b/news/PR844.dev
@@ -1,0 +1,1 @@
+Add Dependabot configuration file


### PR DESCRIPTION
Adds a [Dependabot](https://dependabot.com) config to help us keep our Python dependencies up to date. ✨

I have validated the config via [Dependabot's validation tool](https://dependabot.com/docs/config-file/validator/).
<img width="1012" alt="Screen Shot 2019-10-04 at 07 55 57" src="https://user-images.githubusercontent.com/1557529/66169856-c8296500-e67c-11e9-8a0e-709f0d320311.png">