### PR TITLE
Add timeout to check service

### DIFF
--- a/anitya/config.py
+++ b/anitya/config.py
@@ -88,6 +88,8 @@ DEFAULTS = dict(
     GITHUB_ACCESS_TOKEN=None,
     LEGACY_MESSAGING=False,  # If True, publish with fedmsg instead of fedora_messaging
     SSE_FEED="http://firehose.libraries.io/events",
+    CRON_POOL=10,  # Number of workers for check service
+    CHECK_TIMEOUT=600,  # Timeout for check service
 )
 
 # Start with a basic logging configuration, which will be replaced by any user-

--- a/anitya/tests/test_config.py
+++ b/anitya/tests/test_config.py
@@ -172,6 +172,8 @@ class LoadTests(unittest.TestCase):
             "GITHUB_ACCESS_TOKEN": "foobar",
             "LEGACY_MESSAGING": True,
             "SSE_FEED": "http://firehose.libraries.io/events",
+            "CRON_POOL": 10,
+            "CHECK_TIMEOUT": 600,
         }
         config = anitya_config.load()
         self.assertEqual(sorted(expected_config.keys()), sorted(config.keys()))

--- a/files/anitya.toml.sample
+++ b/files/anitya.toml.sample
@@ -62,6 +62,12 @@ default_regex = """\
 # This is used by GitHub API for github backend
 github_access_token = "foobar"
 
+# Check service configuration
+# Number of workers
+CRON_POOL = 10
+# Worker timeout in seconds
+CHECK_TIMEOUT = 600
+
 # The logging configuration, in Python dictConfig format.
 [anitya_log_config]
     version = 1

--- a/news/843.feature
+++ b/news/843.feature
@@ -1,0 +1,1 @@
+Add timeout option for check service


### PR DESCRIPTION
This will prevent thread from getting stuck when check for new release
takes too long.

This new value is configurable using CHECK_TIMEOUT parameter in
configuration.

Fixes #843

Signed-off-by: Michal Konečný <mkonecny@redhat.com>