### PR TITLE
Fix releases_only not changed on edit

### DIFF
--- a/anitya/lib/utilities.py
+++ b/anitya/lib/utilities.py
@@ -344,8 +344,8 @@ def edit_project(
         changes["insecure"] = {"old": old, "new": project.insecure}
     if releases_only != project.releases_only:
         old = project.releases_only
-        project.insecure = insecure
-        changes["insecure"] = {"old": old, "new": project.insecure}
+        project.releases_only = releases_only
+        changes["releases_only"] = {"old": old, "new": project.releases_only}
 
     try:
         if changes:

--- a/anitya/tests/lib/test_utilities.py
+++ b/anitya/tests/lib/test_utilities.py
@@ -108,6 +108,7 @@ class EditProjectTests(DatabaseTestCase):
         self.assertEqual(project_objs[0].homepage, "https://www.geany.org/")
         self.assertEqual(project_objs[1].name, "R2spec")
         self.assertEqual(project_objs[2].name, "subsurface")
+        self.assertFalse(project_objs[0].releases_only)
 
         with fml_testing.mock_sends(anitya_schema.ProjectEdited):
             utilities.edit_project(
@@ -131,6 +132,7 @@ class EditProjectTests(DatabaseTestCase):
         self.assertEqual(project_objs[0].name, "geany")
         self.assertEqual(project_objs[0].homepage, "https://www.geany.org")
         self.assertEqual(project_objs[0].backend, "PyPI")
+        self.assertTrue(project_objs[0].releases_only)
 
     def test_edit_project_creating_duplicate(self):
         """

--- a/news/855.bug
+++ b/news/855.bug
@@ -1,0 +1,1 @@
+Can't disable "Check releases instead of tags" checkbox when editing project


### PR DESCRIPTION
Project field releases_only was not changed when edit was done, this
commit is fixing this issue.

Fixes #855.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>