### PR TITLE
Bump Vagrant box to Fedora 31

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
- config.vm.box = "fedora/30-cloud-base"
+ config.vm.box = "fedora/31-cloud-base"
 
  # Forward traffic on the host to the development server on the guest
  config.vm.network "forwarded_port", guest: 5000, host: 5000

--- a/news/PR858.dev
+++ b/news/PR858.dev
@@ -1,0 +1,1 @@
+Bump Vagrant box to Fedora 31


### PR DESCRIPTION
This PR just bumps the `config.vm.box` value. The Vagrant box provisions well on top of F31 without changes to the Ansible files. I've skimmed them and only found one thing where I'm not sure if I should change it, namely in `ansible/roles/anitya-dev/files/bashrc`, there's this line...:

````
source /usr/bin/virtualenvwrapper-3.sh
````

...which is a symlink to `virtualenvwrapper.sh`. If you want, I can change that one, too, just to be prepared if the symlink ever gets dropped.