### PR TITLE
Change ecosystem when homepage or backend is changed

### DIFF
--- a/anitya/db/__init__.py
+++ b/anitya/db/__init__.py
@@ -32,4 +32,7 @@ from .models import (  # noqa: F401
     User,
     ApiToken,
 )
-from .events import set_ecosystem  # noqa: F401
+
+# You need to import the events to register them with application
+# If they are not imported, there wouldn't be triggered
+from . import events  # noqa: F401

--- a/anitya/tests/db/test_models.py
+++ b/anitya/tests/db/test_models.py
@@ -81,21 +81,6 @@ class ProjectTests(DatabaseTestCase):
             backend="Nope",
         )
 
-    def test_default_ecosystem_is_homepage(self):
-        project = models.Project(
-            name="test",
-            homepage="https://example.com",
-            backend="custom",
-            ecosystem_name=None,
-        )
-        self.session.add(project)
-        self.session.commit()
-        self.assertEqual(1, self.session.query(models.Project).count())
-        self.assertEqual(
-            "https://example.com",
-            self.session.query(models.Project).one().ecosystem_name,
-        )
-
     def test_validate_ecosystem_good(self):
         project = models.Project(
             name="test",

--- a/news/764.bug
+++ b/news/764.bug
@@ -1,0 +1,1 @@
+If URL is changed, update ecosystem value as well


### PR DESCRIPTION
Till now ecosystem was only set once, when project was created. With
this commit ecosystem is changed when homepage or backend change is
emitted. The ecosystem value is set as follows:
 - Ecosystem is set using backend if backend is associated with ecosystem
 - Ecosystem is set to homepage

Fixes #764

Signed-off-by: Michal Konečný <mkonecny@redhat.com>