### PR TITLE
Mock the Fedora Messaging calls in the unit tests

### DIFF
--- a/anitya/tests/db/test_models.py
+++ b/anitya/tests/db/test_models.py
@@ -29,6 +29,7 @@ import time
 import mock
 import datetime
 
+from fedora_messaging import testing as fml_testing
 from sqlalchemy.dialects import postgresql, sqlite
 from sqlalchemy.types import CHAR
 from sqlalchemy.exc import IntegrityError
@@ -46,6 +47,7 @@ from anitya.tests.base import (
     create_flagged_project,
 )
 from anitya.lib import utilities
+import anitya_schema
 
 
 class ProjectTests(DatabaseTestCase):
@@ -743,13 +745,14 @@ class ProjectFlagTestCase(DatabaseTestCase):
         if project name is provided.
         """
         flag = create_flagged_project(self.session)
-        flag_add = utilities.flag_project(
-            self.session,
-            flag.project,
-            "This is a duplicate.",
-            "cthulhu@redhat.com",
-            "user_openid_id",
-        )
+        with fml_testing.mock_sends(anitya_schema.ProjectFlag):
+            flag_add = utilities.flag_project(
+                self.session,
+                flag.project,
+                "This is a duplicate.",
+                "cthulhu@redhat.com",
+                "user_openid_id",
+            )
         flag_add.state = "closed"
 
         self.session.add(flag_add)
@@ -776,13 +779,14 @@ class ProjectFlagTestCase(DatabaseTestCase):
         if from date is provided.
         """
         flag = create_flagged_project(self.session)
-        flag_add = utilities.flag_project(
-            self.session,
-            flag.project,
-            "This is a duplicate.",
-            "cthulhu@redhat.com",
-            "user_openid_id",
-        )
+        with fml_testing.mock_sends(anitya_schema.ProjectFlag):
+            flag_add = utilities.flag_project(
+                self.session,
+                flag.project,
+                "This is a duplicate.",
+                "cthulhu@redhat.com",
+                "user_openid_id",
+            )
         flag_add.state = "closed"
         self.session.add(flag_add)
         self.session.commit()
@@ -797,13 +801,14 @@ class ProjectFlagTestCase(DatabaseTestCase):
         if state is provided.
         """
         flag = create_flagged_project(self.session)
-        flag_add = utilities.flag_project(
-            self.session,
-            flag.project,
-            "This is a duplicate.",
-            "cthulhu@redhat.com",
-            "user_openid_id",
-        )
+        with fml_testing.mock_sends(anitya_schema.ProjectFlag):
+            flag_add = utilities.flag_project(
+                self.session,
+                flag.project,
+                "This is a duplicate.",
+                "cthulhu@redhat.com",
+                "user_openid_id",
+            )
         flag_add.state = "closed"
         self.session.add(flag_add)
         self.session.commit()
@@ -817,13 +822,14 @@ class ProjectFlagTestCase(DatabaseTestCase):
         if offset is set.
         """
         flag = create_flagged_project(self.session)
-        flag_add = utilities.flag_project(
-            self.session,
-            flag.project,
-            "This is a duplicate.",
-            "cthulhu@redhat.com",
-            "user_openid_id",
-        )
+        with fml_testing.mock_sends(anitya_schema.ProjectFlag):
+            flag_add = utilities.flag_project(
+                self.session,
+                flag.project,
+                "This is a duplicate.",
+                "cthulhu@redhat.com",
+                "user_openid_id",
+            )
         flag_add.state = "closed"
         self.session.add(flag_add)
         self.session.commit()
@@ -837,13 +843,14 @@ class ProjectFlagTestCase(DatabaseTestCase):
         if limit is set.
         """
         flag = create_flagged_project(self.session)
-        flag_add = utilities.flag_project(
-            self.session,
-            flag.project,
-            "This is a duplicate.",
-            "cthulhu@redhat.com",
-            "user_openid_id",
-        )
+        with fml_testing.mock_sends(anitya_schema.ProjectFlag):
+            flag_add = utilities.flag_project(
+                self.session,
+                flag.project,
+                "This is a duplicate.",
+                "cthulhu@redhat.com",
+                "user_openid_id",
+            )
         flag_add.state = "closed"
         self.session.add(flag_add)
         self.session.commit()
@@ -857,13 +864,14 @@ class ProjectFlagTestCase(DatabaseTestCase):
         if count is set.
         """
         flag = create_flagged_project(self.session)
-        flag_add = utilities.flag_project(
-            self.session,
-            flag.project,
-            "This is a duplicate.",
-            "cthulhu@redhat.com",
-            "user_openid_id",
-        )
+        with fml_testing.mock_sends(anitya_schema.ProjectFlag):
+            flag_add = utilities.flag_project(
+                self.session,
+                flag.project,
+                "This is a duplicate.",
+                "cthulhu@redhat.com",
+                "user_openid_id",
+            )
         flag_add.state = "closed"
         self.session.add(flag_add)
         self.session.commit()

--- a/anitya/tests/test_flask_api.py
+++ b/anitya/tests/test_flask_api.py
@@ -26,6 +26,8 @@ anitya tests for the flask API.
 import json
 import unittest
 
+from fedora_messaging import testing as fml_testing
+
 from anitya.db import models
 from anitya.lib.backends import REGEX
 from anitya.tests.base import (
@@ -35,6 +37,7 @@ from anitya.tests.base import (
     create_package,
     create_ecosystem_projects,
 )
+import anitya_schema
 
 
 # Py3 compatibility: UTF-8 decoding and JSON decoding may be separate steps
@@ -238,7 +241,8 @@ class AnityaWebAPItests(DatabaseTestCase):
         """ Test the api_get_version function of the API. """
         create_distro(self.session)
 
-        output = self.app.post("/api/version/get")
+        with fml_testing.mock_sends():
+            output = self.app.post("/api/version/get")
         self.assertEqual(output.status_code, 400)
         data = _read_json(output)
 
@@ -249,7 +253,8 @@ class AnityaWebAPItests(DatabaseTestCase):
         create_package(self.session)
 
         data = {"id": 10}
-        output = self.app.post("/api/version/get", data=data)
+        with fml_testing.mock_sends():
+            output = self.app.post("/api/version/get", data=data)
         self.assertEqual(output.status_code, 404)
         data = _read_json(output)
 
@@ -263,7 +268,8 @@ class AnityaWebAPItests(DatabaseTestCase):
         self.session.commit()
 
         data = {"id": 1}
-        output = self.app.post("/api/version/get", data=data)
+        with fml_testing.mock_sends():
+            output = self.app.post("/api/version/get", data=data)
         self.assertEqual(output.status_code, 400)
         data = _read_json(output)
 
@@ -284,7 +290,8 @@ class AnityaWebAPItests(DatabaseTestCase):
         self.session.commit()
 
         data = {"id": 1}
-        output = self.app.post("/api/version/get", data=data)
+        with fml_testing.mock_sends(anitya_schema.ProjectVersionUpdated):
+            output = self.app.post("/api/version/get", data=data)
         self.assertEqual(output.status_code, 200)
         data = _read_json(output)
         del data["created_on"]

--- a/anitya/tests/test_flask_api_v2.py
+++ b/anitya/tests/test_flask_api_v2.py
@@ -26,10 +26,12 @@ from __future__ import unicode_literals
 from unittest import mock
 
 import json
+from fedora_messaging import testing as fml_testing
 from social_flask_sqlalchemy import models as social_models
 
 from anitya.db import Session, models
 from anitya.lib import exceptions
+import anitya_schema
 from .base import DatabaseTestCase, create_project
 
 
@@ -511,15 +513,17 @@ class PackagesResourcePostTests(DatabaseTestCase):
             "distribution": "Fedora",
         }
 
-        output = self.app.post(
-            "/api/v2/packages/", headers=self.auth, data=request_data
-        )
+        with fml_testing.mock_sends(anitya_schema.ProjectMapCreated):
+            output = self.app.post(
+                "/api/v2/packages/", headers=self.auth, data=request_data
+            )
         self.assertEqual(output.status_code, 201)
 
         request_data["distribution"] = "Debian"
-        output = self.app.post(
-            "/api/v2/packages/", headers=self.auth, data=request_data
-        )
+        with fml_testing.mock_sends(anitya_schema.ProjectMapCreated):
+            output = self.app.post(
+                "/api/v2/packages/", headers=self.auth, data=request_data
+            )
         self.assertEqual(output.status_code, 201)
 
     def test_conflicting_request(self):
@@ -531,13 +535,15 @@ class PackagesResourcePostTests(DatabaseTestCase):
             "distribution": "Fedora",
         }
 
-        output = self.app.post(
-            "/api/v2/packages/", headers=self.auth, data=request_data
-        )
+        with fml_testing.mock_sends(anitya_schema.ProjectMapCreated):
+            output = self.app.post(
+                "/api/v2/packages/", headers=self.auth, data=request_data
+            )
         self.assertEqual(output.status_code, 201)
-        output = self.app.post(
-            "/api/v2/packages/", headers=self.auth, data=request_data
-        )
+        with fml_testing.mock_sends():
+            output = self.app.post(
+                "/api/v2/packages/", headers=self.auth, data=request_data
+            )
         self.assertEqual(output.status_code, 409)
         # Error details should report conflicting fields.
         data = _read_json(output)
@@ -1038,13 +1044,15 @@ class ProjectsResourcePostTests(DatabaseTestCase):
             "name": "requests",
         }
 
-        output = self.app.post(
-            "/api/v2/projects/", headers=self.auth, data=request_data
-        )
+        with fml_testing.mock_sends(anitya_schema.ProjectCreated):
+            output = self.app.post(
+                "/api/v2/projects/", headers=self.auth, data=request_data
+            )
         self.assertEqual(output.status_code, 201)
-        output = self.app.post(
-            "/api/v2/projects/", headers=self.auth, data=request_data
-        )
+        with fml_testing.mock_sends():
+            output = self.app.post(
+                "/api/v2/projects/", headers=self.auth, data=request_data
+            )
         self.assertEqual(output.status_code, 409)
         # Error details should report conflicting fields.
         data = _read_json(output)
@@ -1062,9 +1070,10 @@ class ProjectsResourcePostTests(DatabaseTestCase):
             "name": "requests",
         }
 
-        output = self.app.post(
-            "/api/v2/projects/", headers=self.auth, data=request_data
-        )
+        with fml_testing.mock_sends(anitya_schema.ProjectCreated):
+            output = self.app.post(
+                "/api/v2/projects/", headers=self.auth, data=request_data
+            )
 
         data = _read_json(output)
         self.assertEqual(output.status_code, 201)
@@ -1088,9 +1097,10 @@ class ProjectsResourcePostTests(DatabaseTestCase):
             "check_release": "True",
         }
 
-        output = self.app.post(
-            "/api/v2/projects/", headers=self.auth, data=request_data
-        )
+        with fml_testing.mock_sends(anitya_schema.ProjectCreated):
+            output = self.app.post(
+                "/api/v2/projects/", headers=self.auth, data=request_data
+            )
 
         mock_check.assert_called_once_with(mock.ANY, mock.ANY)
         self.assertEqual(output.status_code, 201)
@@ -1109,9 +1119,10 @@ class ProjectsResourcePostTests(DatabaseTestCase):
             "check_release": "True",
         }
 
-        output = self.app.post(
-            "/api/v2/projects/", headers=self.auth, data=request_data
-        )
+        with fml_testing.mock_sends(anitya_schema.ProjectCreated):
+            output = self.app.post(
+                "/api/v2/projects/", headers=self.auth, data=request_data
+            )
 
         mock_check.assert_called_once_with(mock.ANY, mock.ANY)
         self.assertEqual(output.status_code, 201)

--- a/news/PR860.dev
+++ b/news/PR860.dev
@@ -1,0 +1,1 @@
+Mock the Fedora Messaging calls in the unit tests


### PR DESCRIPTION
This should make the tests much faster since they won't wait for the publish timeout anymore.