### PR TITLE
Add error counter for project checking

### DIFF
--- a/anitya/db/migrations/versions/314651690dc7_add_error_counter_to_project.py
+++ b/anitya/db/migrations/versions/314651690dc7_add_error_counter_to_project.py
@@ -1,0 +1,33 @@
+"""Add error counter to project
+
+Revision ID: 314651690dc7
+Revises: 136d119ab015
+Create Date: 2019-12-17 11:55:12.472854
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "314651690dc7"
+down_revision = "136d119ab015"
+
+
+def upgrade():
+    """ Add error_counter column to project. """
+    op.add_column(
+        "projects",
+        sa.Column(
+            "error_counter", sa.Integer(), default=0, server_default=sa.text("0")
+        ),
+    )
+    op.create_index(
+        op.f("ix_projects_error_counter"), "projects", ["error_counter"], unique=False
+    )
+
+
+def downgrade():
+    """ Remove error_counter column from project. """
+    op.drop_column("projects", "error_counter")
+    op.drop_index(op.f("ix_projects_error_counter"), table_name="projects")

--- a/anitya/lib/utilities.py
+++ b/anitya/lib/utilities.py
@@ -106,6 +106,7 @@ def check_project_release(project, session, test=False):
         if not test:
             project.logs = str(err)
             project.check_successful = False
+            project.error_counter += 1
             session.add(project)
             session.commit()
         raise
@@ -120,6 +121,7 @@ def check_project_release(project, session, test=False):
     # otherwise this backend raises exception
     project.logs = "Version retrieved correctly"
     project.check_successful = True
+    project.error_counter = 0
 
     p_versions = project.get_sorted_version_objects()
     old_version = project.latest_version or ""

--- a/anitya/templates/project.html
+++ b/anitya/templates/project.html
@@ -213,6 +213,9 @@
         <table class="table table-condensed">
           <tr>
             <th>Status</th>
+            {% if project.check_successful is not none and project.check_successful == false %}
+            <th>Checks failed</th>
+            {% endif %}
             <th>Updated</th>
             <th>Description</th>
           </tr>
@@ -221,6 +224,7 @@
             <td>Not updated</td>
             {% elif not project.check_successful %}
             <td style="color:red;">Fail</td>
+            <td>{{ project.error_counter }}</td>
             {% else %}
             <td style="color:green;">OK</td>
             {% endif %}

--- a/anitya/templates/updates.html
+++ b/anitya/templates/updates.html
@@ -72,6 +72,11 @@
     <span class="list-group-item">
       <h4 class="list-group-item-heading">
         <table class="table table-condensed">
+            <th>Project name</th>
+            <th>Log content</th>
+            {% if status == 'failed' %}
+            <th>Checks failed</th>
+            {% endif %}
         {% for project in projects %}
             <tr>
               <td>
@@ -82,6 +87,9 @@
               <td>
                 {{ project.logs }}
               </td>
+              {% if status == 'failed' %}
+              <td>{{ project.error_counter }}</td>
+              {% endif %}
             </tr>
           {% endfor %}
           </table>

--- a/anitya/tests/db/test_models.py
+++ b/anitya/tests/db/test_models.py
@@ -460,13 +460,17 @@ class ProjectTests(DatabaseTestCase):
         set to 'failed'.
         """
         create_project(self.session)
+        error_counter = 0
         for project in self.session.query(models.Project).all():
-            project.logs = "No upstream version found"
+            project.check_successful = False
+            project.error_counter = error_counter
+            error_counter += 1
         self.session.commit()
 
         projects = models.Project.updated(self.session, status="failed")
-        self.assertEqual(len(projects), 3)
-        self.assertEqual(projects[0].logs, "No upstream version found")
+        self.assertEqual(len(projects), 2)
+        self.assertEqual(projects[0].error_counter, 2)
+        self.assertEqual(projects[1].error_counter, 1)
 
     def test_project_updated_odd(self):
         """

--- a/anitya/tests/lib/test_utilities.py
+++ b/anitya/tests/lib/test_utilities.py
@@ -246,6 +246,7 @@ class CheckProjectReleaseTests(DatabaseTestCase):
             project,
             self.session,
         )
+        self.assertEqual(project.error_counter, 1)
 
     @mock.patch(
         "anitya.lib.backends.npmjs.NpmjsBackend.get_versions", return_value=["1.0.0"]
@@ -442,6 +443,27 @@ class CheckProjectReleaseTests(DatabaseTestCase):
             "remove-circular-dependency-7bbe4a64-3514-4f6e-9c03-9dc8bcf4def7"
             in versions
         )
+
+    @mock.patch(
+        "anitya.lib.backends.npmjs.NpmjsBackend.get_versions", return_value=["1.0.0"]
+    )
+    def test_check_project_release_error_counter_reset(self, mock_method):
+        """ Test if error_counter reset to 0, when successful check is done. """
+        with fml_testing.mock_sends(anitya_schema.ProjectCreated):
+            project = utilities.create_project(
+                self.session,
+                name="pypi_and_npm",
+                homepage="https://example.com/not-a-real-npmjs-project",
+                backend="npmjs",
+                user_id="noreply@fedoraproject.org",
+            )
+        project.error_counter = 30
+        self.session.add(project)
+        self.session.commit()
+
+        utilities.check_project_release(project, self.session)
+
+        self.assertEqual(project.error_counter, 0)
 
 
 class MapProjectTests(DatabaseTestCase):

--- a/news/829.feature
+++ b/news/829.feature
@@ -1,0 +1,1 @@
+Add error counter to project


### PR DESCRIPTION
This adds error counter to project, which is incremented each time an
error happens when checking for new version. Error counter is reset to
0, when successful check is done.

This also introduces GUI changes that allows users to see the error
counter on each project and option to find the projects, which are
failing most.

This will help identify problematic projects.

Implements part of #829

Signed-off-by: Michal Konečný <mkonecny@redhat.com>