### PR TITLE
Link to commit of latest version if known

### DIFF
--- a/anitya/db/migrations/versions/16aa7da2764c_add_projectversion_commit_url.py
+++ b/anitya/db/migrations/versions/16aa7da2764c_add_projectversion_commit_url.py
@@ -1,0 +1,26 @@
+"""add ProjectVersion.commit_url
+
+Revision ID: 16aa7da2764c
+Revises: 314651690dc7
+Create Date: 2019-12-19 14:54:56.036040
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "16aa7da2764c"
+down_revision = "314651690dc7"
+
+
+def upgrade():
+    op.add_column(
+        "projects_versions",
+        sa.Column("commit_url", sa.String(length=200), nullable=True),
+    )
+
+
+def downgrade():
+    with op.batch_alter_table("projects_versions") as batch_op:
+        batch_op.drop_column("commit_url")

--- a/anitya/db/models.py
+++ b/anitya/db/models.py
@@ -353,6 +353,11 @@ class Project(Base):
                         if isinstance(version, dict) and "cursor" in version
                         else None
                     ),
+                    commit_url=(
+                        version["commit_url"]
+                        if isinstance(version, dict) and "commit_url" in version
+                        else None
+                    ),
                 )
                 for version in versions
             ]
@@ -385,11 +390,19 @@ class Project(Base):
                 prefix=self.version_prefix,
                 created_on=v_obj.created_on,
                 pattern=self.version_pattern,
+                commit_url=v_obj.commit_url,
             )
             for v_obj in self.versions_obj
         ]
         sorted_versions = list(reversed(sorted(versions)))
         return sorted_versions
+
+    @property
+    def latest_version_object(self):
+        sorted_versions = self.get_sorted_version_objects()
+        if sorted_versions:
+            return sorted_versions[0]
+        return None
 
     def get_version_class(self):
         """
@@ -633,6 +646,7 @@ class ProjectVersion(Base):
     )
     version = sa.Column(sa.String(50), primary_key=True)
     created_on = sa.Column(sa.DateTime, default=datetime.datetime.utcnow)
+    commit_url = sa.Column(sa.String(200), nullable=True)
 
     project = sa.orm.relationship(
         "Project", backref=sa.orm.backref("versions_obj", cascade="all, delete-orphan")

--- a/anitya/lib/utilities.py
+++ b/anitya/lib/utilities.py
@@ -131,7 +131,9 @@ def check_project_release(project, session, test=False):
             if len(version.version) < version_column_len:
                 project.versions_obj.append(
                     models.ProjectVersion(
-                        project_id=project.id, version=version.version
+                        project_id=project.id,
+                        version=version.version,
+                        commit_url=version.commit_url,
                     )
                 )
             else:

--- a/anitya/lib/versions/base.py
+++ b/anitya/lib/versions/base.py
@@ -46,6 +46,7 @@ class Version(object):
         created_on: Optional[datetime] = None,
         pattern: Optional[str] = None,
         cursor: Optional[str] = None,
+        commit_url: Optional[str] = None,
     ):
         """
         Constructor of Version class.
@@ -57,6 +58,7 @@ class Version(object):
             pattern: Calendar version pattern.
                 See `Calendar version scheme_` for more information.
             cursor: An opaque, backend-specific cursor pointing to the version.
+            commit_url: A URL pointing to the commit tagged as the version.
 
         .. _Calendar version scheme:
            https://calver.org/#scheme
@@ -79,6 +81,7 @@ class Version(object):
         else:
             self.pattern = None
         self.cursor = cursor
+        self.commit_url = commit_url
 
     def __str__(self):
         """

--- a/anitya/templates/project.html
+++ b/anitya/templates/project.html
@@ -40,7 +40,11 @@
                 <h4 class="list-group-item-heading">Latest version</h4>
                 <div class="list-group-item-text">
                   {% if project.versions %}
-                    <div property="doap:release" typeof="doap:Version">{{ project.latest_version }}</div>
+                    {% if project.latest_version_object and project.latest_version_object.commit_url %}
+                      <div property="doap:release" typeof="doap:Version">{{ project.latest_version }} (<a href="{{ project.latest_version_object.commit_url }}">commit</a>)</div>
+                    {% else %}
+                      <div property="doap:release" typeof="doap:Version">{{ project.latest_version }}</div>
+                    {% endif %}
                   {% else %}
                     <p id="version_info">No version available for this package</p>
                   {% endif %}

--- a/anitya/tests/db/test_models.py
+++ b/anitya/tests/db/test_models.py
@@ -278,6 +278,40 @@ class ProjectTests(DatabaseTestCase):
         self.assertEqual(versions[0].version, version_second.version)
         self.assertEqual(versions[1].version, version_first.version)
 
+    def test_latest_version_object_with_versions(self):
+        """Test the latest_version_object property with versions."""
+        project = models.Project(
+            name="test",
+            homepage="https://example.com",
+            backend="custom",
+            ecosystem_name="pypi",
+            version_scheme="RPM",
+        )
+        self.session.add(project)
+        self.session.flush()
+
+        version_first = models.ProjectVersion(project_id=project.id, version="0.8")
+        version_second = models.ProjectVersion(project_id=project.id, version="1.0")
+        self.session.add(version_first)
+        self.session.add(version_second)
+        self.session.flush()
+
+        self.assertEqual(project.latest_version_object.version, version_second.version)
+
+    def test_latest_version_object_without_versions(self):
+        """Test the latest_version_object property without versions."""
+        project = models.Project(
+            name="test",
+            homepage="https://example.com",
+            backend="custom",
+            ecosystem_name="pypi",
+            version_scheme="RPM",
+        )
+        self.session.add(project)
+        self.session.flush()
+
+        self.assertIsNone(project.latest_version_object)
+
     def test_get_version_class(self):
         project = models.Project(
             name="test",

--- a/anitya/tests/lib/backends/test_github.py
+++ b/anitya/tests/lib/backends/test_github.py
@@ -553,13 +553,29 @@ class JsonTests(unittest.TestCase):
                 "repository": {
                     "refs": {
                         "totalCount": 1,
-                        "edges": [{"cursor": "cUrSoR", "node": {"name": "1.0"}}],
+                        "edges": [
+                            {
+                                "cursor": "cUrSoR",
+                                "node": {
+                                    "name": "1.0",
+                                    "target": {
+                                        "commitUrl": "https://foobar.com/foo/bar/commits/12345678"
+                                    },
+                                },
+                            }
+                        ],
                     },
                 },
                 "rateLimit": {"limit": 5000, "remaining": 5000, "resetAt": "dummy"},
             }
         }
-        exp = [{"cursor": "cUrSoR", "version": "1.0"}]
+        exp = [
+            {
+                "cursor": "cUrSoR",
+                "version": "1.0",
+                "commit_url": "https://foobar.com/foo/bar/commits/12345678",
+            }
+        ]
         obs = backend.parse_json(json, self.project)
         self.assertEqual(exp, obs)
 

--- a/news/PR874.feature
+++ b/news/PR874.feature
@@ -1,0 +1,1 @@
+Link to commit of latest version if known


### PR DESCRIPTION
This only links the commit from the latest version field, where we can make it explicit that it's a commit, not a release page or anything:

![Screenshot from 2019-12-20 23-18-55](https://user-images.githubusercontent.com/820624/71296272-485b8e80-237f-11ea-9eaa-d0aa4ca739d5.png)
