### PR TITLE
Do not duplicate project search form

### DIFF
--- a/anitya/templates/search.html
+++ b/anitya/templates/search.html
@@ -39,17 +39,14 @@
 
   <div class="col-sm-6">
     {% if distroname %}
-    <form action="{{ url_for('anitya_ui.distro_projects_search', distroname=distroname)
-     }}" role="form">
-    {% else %}
-    <form action="{{ url_for('anitya_ui.projects_search') }}" role="form" class="form-inline">
-    {% endif %}
+    <form action="{{ url_for('anitya_ui.distro_projects_search', distroname=distroname) }}">
       <div class="form-group">
         <input type="text" name="pattern" placeholder="Project name"
             class="form-control input-sm" value="{{ pattern }}"/>
         <button type="submit" class="btn btn-sm btn-default">Search</button>
       </div>
     </form>
+    {% endif %}
   </div>
 </div>
 
@@ -58,7 +55,7 @@
     <p>{{ projects_count }} projects found</p>
     <div class="list-group">
     {% if projects %}
-      <span class="list-group-item">
+      <div class="list-group-item">
         <p class="list-group-item-text">
           <dl class="dl-horizontal">
             <table class="table table-condensed">
@@ -88,7 +85,7 @@
           </dl>
         </p>
         <div class="clearfix"></div>
-      </span>
+      </div>
     {% else %}
     <blockquote>
         Oups this is embarrassing, it seems that no projects are being

--- a/anitya/tests/test_flask.py
+++ b/anitya/tests/test_flask.py
@@ -611,11 +611,9 @@ class FlaskTest(DatabaseTestCase):
         monitored currently.
         <p><a href="/project/new?name=gua">Click Here</a> to add this project instead. </p>
     </blockquote>"""
-        self.assertTrue(expected in output.data)
-        self.assertTrue(
-            b'form action="/distro/Fedora/search/" role="form">' in output.data
-        )
-        self.assertTrue(b"<h1>Search projects in Fedora</h1>" in output.data)
+        self.assertIn(expected, output.data)
+        self.assertIn(b'form action="/distro/Fedora/search/">', output.data)
+        self.assertIn(b"<h1>Search projects in Fedora</h1>", output.data)
 
     def test_distro_projects_search_pattern(self):
         """

--- a/news/PR877.bug
+++ b/news/PR877.bug
@@ -1,0 +1,1 @@
+Removed duplicate search form from project search result page


### PR DESCRIPTION
Currently search form for projects present both in page header and in results table header. This PR leaves search form in table header only when searching inside distros.