### PR TITLE
Use mapping as another condition for deletion

### DIFF
--- a/anitya/check_service.py
+++ b/anitya/check_service.py
@@ -128,8 +128,9 @@ class Checker:
     def is_delete_candidate(self, project: db.Project) -> bool:
         """
         Check if this project is a candidate for deletion. Project is a candidate for
-        deletion, if error_counter already reached configured threshold and no version
-        was retrieved yet.
+        deletion, if error_counter already reached configured threshold and project
+        has no mapping. If mapping exists, but project doesn't have any versions it's
+        still a candidate for deletion.
 
         Args:
             project: Project to check
@@ -139,8 +140,12 @@ class Checker:
         """
         if project.error_counter < config.get("CHECK_ERROR_THRESHOLD"):
             return False
-        if project.versions:
-            return False
+        packages = db.Packages.query.filter(db.Packages.project_id == project.id).all()
+        if packages:
+            if not project.versions:
+                return True
+            else:
+                return False
 
         return True
 


### PR DESCRIPTION
Recently there was a flood of junk projects from PyPi received through
libraries.io consumers. These projects doesn't exist anymore on PyPi,
but at least one version was retrieved, so current solution of delete
candidate recognition doesn't recognize this project as candidate
for deletion, but if the project doesn't have mapping it could be
in most cases safely deleted.

Still if there is mapping and no versionis retrieved it will be deleted.
The prime condition is still the error threshold.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>