### PR TITLE
Fix search for projects by distro

### DIFF
--- a/anitya/db/models.py
+++ b/anitya/db/models.py
@@ -610,7 +610,10 @@ class Project(Base):
 
         if distro is not None:
             query1 = query1.filter(Project.id == Packages.project_id).filter(
-                sa.func.lower(Packages.distro) == sa.func.lower(distro)
+                sa.func.lower(Packages.distro_name) == sa.func.lower(distro)
+            )
+            query2 = query2.filter(
+                sa.func.lower(Packages.distro_name) == sa.func.lower(distro)
             )
 
         query = query1.distinct().union(query2.distinct()).order_by(cls.name)

--- a/anitya/tests/db/test_models.py
+++ b/anitya/tests/db/test_models.py
@@ -344,6 +344,11 @@ class ProjectTests(DatabaseTestCase):
         """
         create_project(self.session)
         create_package(self.session)
+        # Create mapping for another distro to be sure that only Fedora mappings
+        # are taken into account
+        package = models.Packages(distro_name="Debian", project_id=3)
+        self.session.add(package)
+        self.session.commit()
 
         projects = models.Project.search(self.session, "*", distro="Fedora")
         self.assertEqual(len(projects), 2)

--- a/news/876.bug
+++ b/news/876.bug
@@ -1,0 +1,1 @@
+Distro search is broken


### PR DESCRIPTION
Use distro_name instead of distro relationship on package, because the
later caused error 500.
Limit project search by mapping to distro if available. Otherwise we
will end up with projects from another distros.

Fixes #876

Signed-off-by: Michal Konečný <mkonecny@redhat.com>