### PR TITLE
Fix accessing projects in GitLab subgroups

### DIFF
--- a/anitya/lib/backends/gitlab.py
+++ b/anitya/lib/backends/gitlab.py
@@ -82,11 +82,11 @@ class GitlabBackend(BaseBackend):
         elif project.homepage:
             tokens = project.homepage.split("/")
 
-        if len(tokens) == 5:
+        if len(tokens) >= 5:
             url = url_template % {
                 "hostname": tokens[0] + "//" + tokens[2],
                 "owner": tokens[3],
-                "repo": tokens[4],
+                "repo": "%2F".join(tokens[4:]),  # any subgroups & repo
             }
 
         return url

--- a/anitya/tests/lib/backends/test_gitlab.py
+++ b/anitya/tests/lib/backends/test_gitlab.py
@@ -129,6 +129,45 @@ class GitlabBackendtests(DatabaseTestCase):
 
         self.assertEqual(obs, exp)
 
+    def test_get_version_url_project_version_url_subgroup(self):
+        """
+        Assert that the correct URL is returned when
+        a project version url is specified for a
+        subgrouped project.
+        """
+        project = models.Project(
+            name="test",
+            homepage="http://example.org",
+            version_url="https://gitlab.com/group/subgroup/test",
+            backend=BACKEND,
+        )
+        exp = (
+            "https://gitlab.com/api/v4/projects/group%2Fsubgroup%2Ftest/repository/tags"
+        )
+
+        obs = backend.GitlabBackend.get_version_url(project)
+
+        self.assertEqual(obs, exp)
+
+    def test_get_version_url_project_homepage_only_subgroup(self):
+        """
+        Assert that the correct url is returned when
+        only a project homepage is specified for a
+        subgrouped project.
+        """
+        project = models.Project(
+            name="test",
+            homepage="https://gitlab.com/group/subgroup/test",
+            backend=BACKEND,
+        )
+        exp = (
+            "https://gitlab.com/api/v4/projects/group%2Fsubgroup%2Ftest/repository/tags"
+        )
+
+        obs = backend.GitlabBackend.get_version_url(project)
+
+        self.assertEqual(obs, exp)
+
     def test_get_version_url_project_wrong_homepage(self):
         """
         Assert that empty url is returned when

--- a/news/PR884.bug
+++ b/news/PR884.bug
@@ -1,0 +1,1 @@
+Fix accessing projects in GitLab subgroups


### PR DESCRIPTION
In GitLab API endpoints, subgroups are separated from parent
(sub-)groups with URL-encoded slashes, i.e. %2F.

Fixes: #763

Signed-off-by: Nils Philippsen <nils@redhat.com>